### PR TITLE
Add analytics of sensor types …

### DIFF
--- a/app/src/main/java/com/google/android/stardroid/StardroidApplication.java
+++ b/app/src/main/java/com/google/android/stardroid/StardroidApplication.java
@@ -239,26 +239,29 @@ public class StardroidApplication extends Application {
     SensorManager sensorManager = (SensorManager)getSystemService(SENSOR_SERVICE);
     if (sensorManager == null) {
       Log.e(TAG, "No sensor manager");
-      analytics.trackEvent(Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "No Manager", 0);
+      analytics.trackEvent(
+          Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "No Sensor Manager", 0);
     }
     // Minimum requirements
     if (sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null) {
       if (sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD) != null) {
         Log.i(TAG, "Minimal sensors available");
-        analytics.trackEvent(Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "Yes", 1);
+        analytics.trackEvent(
+            Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "Minimal Sensors: Yes", 1);
       } else {
         Log.e(TAG, "No magnetic field sensor");
         analytics.trackEvent(
-            Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "No Mag Field", 0);
+            Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "No Mag Field Sensor", 0);
       }
     } else {
       if (sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD) != null) {
         Log.e(TAG, "No accelerometer");
-        analytics.trackEvent(Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "No Accel", 0);
+        analytics.trackEvent(
+            Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "No Accel Sensor", 0);
       } else {
         Log.e(TAG, "No magnetic field sensor or accelerometer");
         analytics.trackEvent(
-            Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "No Mag Field/Accel", 0);
+            Analytics.APP_CATEGORY, Analytics.SENSOR_AVAILABILITY, "No Mag Field/Accel Sensors", 0);
       }
     }
 
@@ -271,11 +274,11 @@ public class StardroidApplication extends Application {
       if (sensorManager.getDefaultSensor(sensorType) == null) {
         Log.i(TAG, "No sensor of type " + sensorType);
         analytics.trackEvent(
-            Analytics.APP_CATEGORY, Analytics.SENSOR_TYPE + sensorType, "None", 0);
+            Analytics.APP_CATEGORY, Analytics.SENSOR_TYPE + sensorType, "Sensor Absent", 0);
       } else {
         Log.i(TAG, "Sensor present of type " + sensorType);
         analytics.trackEvent(
-            Analytics.APP_CATEGORY, Analytics.SENSOR_TYPE + sensorType, "Present", 1);
+            Analytics.APP_CATEGORY, Analytics.SENSOR_TYPE + sensorType, "Sensor Present", 1);
       }
     }
 
@@ -297,9 +300,9 @@ public class StardroidApplication extends Application {
 
   private static String getSafeNameForSensor(Sensor sensor) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
-      return sensor.getStringType();
+      return "Sensor type: " + sensor.getStringType() + ": " + sensor.getType();
     } else {
-     return Integer.toString(sensor.getType());
+     return "Sensor type: " + sensor.getType();
     }
   }
 }

--- a/app/src/main/java/com/google/android/stardroid/StardroidApplication.java
+++ b/app/src/main/java/com/google/android/stardroid/StardroidApplication.java
@@ -23,6 +23,7 @@ import android.content.res.AssetManager;
 import android.content.res.Resources;
 import android.hardware.Sensor;
 import android.hardware.SensorManager;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -132,8 +133,8 @@ public class StardroidApplication extends Application {
 
     // It will be interesting to see *when* people use Sky Map.
     analytics.trackEvent(
-            Analytics.GENERAL_CATEGORY, Analytics.START_HOUR,
-            Integer.toString(Calendar.getInstance().get(Calendar.HOUR_OF_DAY)) + 'h', 0);
+        Analytics.GENERAL_CATEGORY, Analytics.START_HOUR,
+        Integer.toString(Calendar.getInstance().get(Calendar.HOUR_OF_DAY)) + 'h', 0);
 
     preferences.registerOnSharedPreferenceChangeListener(preferenceChangeAnalyticsTracker);
   }
@@ -284,13 +285,21 @@ public class StardroidApplication extends Application {
     Set<String> sensorTypes = new HashSet<>();
     for (Sensor sensor : allSensors) {
       Log.i(TAG, sensor.getName());
-      sensorTypes.add(sensor.getStringType());
+      sensorTypes.add(getSafeNameForSensor(sensor));
     }
     Log.d(TAG, "All sensors summary:");
     for (String sensorType : sensorTypes) {
       Log.i(TAG, sensorType);
       analytics.trackEvent(
           Analytics.APP_CATEGORY, Analytics.SENSOR_NAME, sensorType, 1);
+    }
+  }
+
+  private static String getSafeNameForSensor(Sensor sensor) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+      return sensor.getStringType();
+    } else {
+     return Integer.toString(sensor.getType());
     }
   }
 }

--- a/app/src/main/java/com/google/android/stardroid/util/Analytics.java
+++ b/app/src/main/java/com/google/android/stardroid/util/Analytics.java
@@ -82,6 +82,9 @@ public class Analytics {
   public static final String GENERAL_CATEGORY = "General";
   public static final String START_HOUR = "Start up hour";
   public static final String SESSION_LENGTH_BUCKET = "Session length bucket";
+  public static final String SENSOR_AVAILABILITY = "Minimal Sensor Availability";
+  public static final String SENSOR_TYPE = "Sensor Type -";
+  public static final String SENSOR_NAME = "Sensor Name";
   // TODO(johntaylor): use CustomVariable.VISITOR_SCOPE if it gets made public.
   private static final int VISITOR_SCOPE = 1;
 

--- a/app/src/main/java/com/google/android/stardroid/util/Analytics.java
+++ b/app/src/main/java/com/google/android/stardroid/util/Analytics.java
@@ -83,7 +83,7 @@ public class Analytics {
   public static final String START_HOUR = "Start up hour";
   public static final String SESSION_LENGTH_BUCKET = "Session length bucket";
   public static final String SENSOR_AVAILABILITY = "Minimal Sensor Availability";
-  public static final String SENSOR_TYPE = "Sensor Type -";
+  public static final String SENSOR_TYPE = "Sensor Type - ";
   public static final String SENSOR_NAME = "Sensor Name";
   // TODO(johntaylor): use CustomVariable.VISITOR_SCOPE if it gets made public.
   private static final int VISITOR_SCOPE = 1;


### PR DESCRIPTION
…so we can plan what to support in the future.

I had a user complain that the map didn't move.  Turns out her (new) phone had no compass.  Who knew that was possible?  We should warn the user when they run the app maybe, and force it into manual mode.  In the meantime gather stats on what sensors people have.  I'm hoping we can switch to using the rotation vector sensor (which will incorporate the gyroscope when present), but want to check it's near universal on modern devices.