### PR TITLE
Change the way we deal with devices lacking a sensor.  

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.google.android.stardroid"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 1405
-        versionName "1.8.1"
+        versionCode 1407
+        versionName "1.8.2"
         buildConfigField 'String', 'GOOGLE_ANALYTICS_CODE', '""'
     }
     signingConfigs {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -409,15 +409,19 @@
     <string name="puppidvelids" translation_description="Meteor Shower">Puppid-Velids</string>
     <string name="ursids" translation_description="Meteor Shower">Ursids</string>
 
-    <string name="no_sensor_warning">Your device lacks orientation sensors - automode unavailable</string>
-    <string name="warning_dialog_title">Warning</string>
+    <string name="no_sensor_warning">Your device may lack orientation sensors - automode may not work</string>
+    <string name="warning_dialog_title">Bad news!</string>
     <string name="missing_sensor_dialog_text">\n
-        Unfortunately your device does not have one of the
+        Unfortunately your device might not have one of the
     sensors that Sky Map needs.\n\n
         To show you the sky in the direction your phone is pointing Sky Map
-    needs both a built-in compass and an accelerometer.\n\n
-        You can still use Sky Map on this device,
-    but only in manual mode where you drag, rotate and stretch the map manually with your fingers.
+    needs both a built-in compass and an accelerometer.  Your device reports that it is missing
+        one of them.  The good news is that some devices (for example some Moto E phones) falsely claim
+        not to have a compass but actually do.\n\n
+
+        If your device really is missing a sensor then auto-mode will not work.  However, you
+        can still use Sky Map on this device in manual mode where you drag, rotate and stretch the
+        map with your fingers.
     </string>
     <string name="do_not_show_again">Do not show this message again</string>
 </resources>


### PR DESCRIPTION
Instead of blocking the use of automode, we just warn the user that it might not work.  This is because some devices like the Moto E are falsely marketed as lacking a compass (and the SensorManager reports its absence)...but they actually do have one and Sky Map works on them just fine.  Yay marketing.

https://github.com/sky-map-team/stardroid/issues/68