### PR TITLE
Update .gitignore - exclude entire /.idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,8 @@
 .gradle
 /local.properties
 # User-specific configurations
-.idea/libraries/
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/.name
-.idea/compiler.xml
-.idea/copyright/profiles_settings.xml
-.idea/encodings.xml
-.idea/misc.xml
-.idea/modules.xml
-.idea/scopes/scope_settings.xml
-.idea/vcs.xml
+.idea/
 *.iml
-/.idea/libraries
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
* Git is currently wants to check in changes to  /gradle.xml.  The entire `/.idea` directory should be ignored.
* The entire ``/.idea`` directory should really be deleted from the Git repo as well, although I didn't make that change here.