### PR TITLE
Add Github issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+**Summary:** 
+
+Summarize your issue in one sentence (what goes wrong, what did you expect to happen)
+
+**Steps to reproduce:** 
+
+How can we reproduce the issue?
+
+**Expected behavior:** 
+
+What did you expect the app to do?
+
+**Observed behavior:** 
+
+What did you see instead?  Describe your issue in detail here.
+
+**Device and Android version:** 
+
+What make and model device (e.g., Samsung Galaxy S7) did you encounter this on?  What Android version (e.g., Android 4.0 Ice Cream Sandwich) are you running?  Is it the stock version from the manufacturer or a custom ROM?  What version of Google Play Services is running on your device?
+
+**Screenshots:** 
+
+Can be created by pressing the Volume Down and Power Button at the same time on Android 4.0 and higher.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Please make sure these boxes are checked before submitting your pull request - thanks!
+
+- [ ] Run the unit tests with `gradlew app:connectedAndroidTest` to make sure you didn't break anything
+
+- [ ] If you have multiple commits please combine them into one commit by squashing them.


### PR DESCRIPTION
See https://github.com/blog/2111-issue-and-pull-request-templates for how these work with Github.  It's similar to how the AOSP issue tracker injects template text when you open a new issue.

I've found that these templates result in better formatted issues and pull requests from outside contributors in projects I've worked on, and also force me to better document bug reports/PRs myself as a maintainer - having the template to drop text into streamlines the process significantly.

Normally I've included a link to CLAs in the PR template as well, but I couldn't find an obvious one for stardroid.  So if there is one that I missed, if there is anything else here you don't want (e.g., squashing commits) or something missing, let me know and I'd be happy to update the PR.