### PR TITLE
Fix #143 - Tweak Travis script and build.gradle to fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 jdk: oraclejdk7
-# Don't use the Travis Container-Based Infrastructure - causes memory issues
-sudo: true
+# Use the Travis Container-Based Infrastructure
+sudo: false
 
 cache:
   directories:
@@ -11,16 +11,23 @@ cache:
 env:
   global:
     - ANDROID_API_LEVEL=23
+    - EMULATOR_API_LEVEL=21
     - ANDROID_BUILD_TOOLS_VERSION=23.0.3
     - ANDROID_ABI=armeabi-v7a
-    - ADB_INSTALL_TIMEOUT=10 # minutes (2 minutes by default)
+    - ANDROID_TAG=google_apis
+    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 android:
   components:
+    - tools # to get the new `repository-11.xml`
     - platform-tools
-    - tools
+    - tools # to install Android SDK tools 25.1.x
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION
     - android-$ANDROID_API_LEVEL
+    - android-$EMULATOR_API_LEVEL
+    # For Google APIs
+    - addon-google_apis-google-$ANDROID_API_LEVEL
+    - addon-google_apis-google-$EMULATOR_API_LEVEL
     # Google Play Services
     - extra-google-google_play_services
     # Support library
@@ -29,11 +36,12 @@ android:
     - extra-google-m2repository
     - extra-android-m2repository
     # Specify at least one system image
-    - sys-img-armeabi-v7a-android-$ANDROID_API_LEVEL
+    - sys-img-armeabi-v7a-google_apis-$ANDROID_API_LEVEL
+    - sys-img-armeabi-v7a-google_apis-$EMULATOR_API_LEVEL
 
 before_script:
   # Create and start emulator
-  - echo no | android create avd --force -n test -t android-$ANDROID_API_LEVEL --abi $ANDROID_ABI
+  - echo no | android create avd --force -n test -t "android-"$EMULATOR_API_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,12 @@ android {
         // TODO(jontayler): fix the missing translations.
         abortOnError false
     }
+
+    // This enables long timeouts required on slow environments, e.g. Travis
+    adbOptions {
+        timeOutInMs 10 * 60 * 1000  // 10 minutes
+        installOptions "-d", "-t"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
So it turns out there were a number of things that needed to change to make this work:

* Add separate ANDOID_TAG ABI tag variable
* Duplicate tools to get the new `repository-11.xml` and to install Android SDK tools 25.1.x
* Change system image names to match new Android SDK
* Change emulator start command to use new ABI tag variable to specify Google APIs
* Add adbOptions timeout in build.gradle

See https://github.com/travis-ci/travis-ci/issues/6122#issuecomment-239073557 for details.

I tested this patch and [it passes](https://travis-ci.org/barbeau/stardroid/builds/151978552) :).

A huuuuuge thanks to @ardock who shared his solution in the above Travis CI issue. :+1: :+1: