### PR TITLE
Added an extra check on whether there's a rotation vector.

### DIFF
--- a/app/src/main/java/com/google/android/stardroid/StardroidApplication.java
+++ b/app/src/main/java/com/google/android/stardroid/StardroidApplication.java
@@ -19,6 +19,8 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.os.Build;
 import android.preference.PreferenceManager;
@@ -228,6 +230,7 @@ public class StardroidApplication extends Application {
             Analytics.SENSOR_CATEGORY, Analytics.ROT_SENSOR_AVAILABILITY, "OK - All", 1);
       } else if (hasDefaultSensor(Sensor.TYPE_ACCELEROMETER) && hasDefaultSensor(
           Sensor.TYPE_MAGNETIC_FIELD)) {
+        // Although the phone claims to have a gyro
         hasRotationSensor = true;
         analytics.trackEvent(
             Analytics.SENSOR_CATEGORY, Analytics.ROT_SENSOR_AVAILABILITY, "OK - No gyro", 1);
@@ -280,6 +283,30 @@ public class StardroidApplication extends Application {
   }
 
   private boolean hasDefaultSensor(int sensorType) {
-    return sensorManager != null && sensorManager.getDefaultSensor(sensorType) != null;
+    if (sensorManager == null) {
+      return false;
+    }
+    Sensor sensor = sensorManager.getDefaultSensor(sensorType);
+    if (sensor == null) {
+      return false;
+    }
+    SensorEventListener dummy = new SensorEventListener() {
+      @Override
+      public void onSensorChanged(SensorEvent event) {
+        // Nothing
+      }
+
+      @Override
+      public void onAccuracyChanged(Sensor sensor, int accuracy) {
+        // Nothing
+      }
+    };
+    boolean success = sensorManager.registerListener(
+        dummy, sensor, SensorManager.SENSOR_DELAY_UI);
+    analytics.trackEvent(
+        Analytics.SENSOR_CATEGORY, Analytics.SENSOR_LIAR, Analytics.getSafeNameForSensor(sensor),
+        1);
+    sensorManager.unregisterListener(dummy);
+    return success;
   }
 }

--- a/app/src/main/java/com/google/android/stardroid/StardroidApplication.java
+++ b/app/src/main/java/com/google/android/stardroid/StardroidApplication.java
@@ -230,7 +230,6 @@ public class StardroidApplication extends Application {
             Analytics.SENSOR_CATEGORY, Analytics.ROT_SENSOR_AVAILABILITY, "OK - All", 1);
       } else if (hasDefaultSensor(Sensor.TYPE_ACCELEROMETER) && hasDefaultSensor(
           Sensor.TYPE_MAGNETIC_FIELD)) {
-        // Although the phone claims to have a gyro
         hasRotationSensor = true;
         analytics.trackEvent(
             Analytics.SENSOR_CATEGORY, Analytics.ROT_SENSOR_AVAILABILITY, "OK - No gyro", 1);

--- a/app/src/main/java/com/google/android/stardroid/util/Analytics.java
+++ b/app/src/main/java/com/google/android/stardroid/util/Analytics.java
@@ -111,6 +111,8 @@ public class Analytics {
   public static final String SENSOR_NAME = "Sensor Name";
   public static final String HIGH_SENSOR_ACCURACY_ACHIEVED = "High Accuracy Achieved";
   public static final String SENSOR_ACCURACY_CHANGED = "Sensor Accuracy Changed";
+  // Phone claims to have a sensor, but then doesn't allow registration of a listener.
+  public static final String SENSOR_LIAR = "Sensor Liar";
 
   @Inject
   Analytics(StardroidApplication application) {


### PR DESCRIPTION
If we find a default sensor we try to register a dummy listener with it.
Log an analytics event if we find such a beast.