### PR TITLE
add changes in search control bar for cancel button overlap

### DIFF
--- a/app/src/main/res/layout/skyrenderer.xml
+++ b/app/src/main/res/layout/skyrenderer.xml
@@ -12,7 +12,7 @@
     android:id="@+id/main_sky_view"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:layout_weight="1">
+    android:layout_weight="1">+
     <android.opengl.GLSurfaceView
       android:layout_width="fill_parent"
       android:layout_height="fill_parent"
@@ -38,7 +38,6 @@
         android:layout_height="wrap_content"
         android:layout_width="fill_parent"
         android:visibility="gone" />
-
       <!-- Include a place for the search controls bar -->
       <RelativeLayout
         android:id="@+id/search_control_bar"
@@ -47,13 +46,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="#20990099"
-        android:visibility="gone">
+        android:visibility="gone"
+          android:layout_marginTop="?android:attr/actionBarSize">
         <ImageView
           android:id="@+id/search_icon"
           android:layout_width="34dip"
           android:layout_height="wrap_content"
           android:src="@drawable/search_lens_very_small"
-          android:paddingTop="10dip" />
+          android:paddingTop="10dip"/>
         <TextView
           android:id="@+id/search_status_label"
           android:layout_width="fill_parent"

--- a/app/src/main/res/layout/skyrenderer.xml
+++ b/app/src/main/res/layout/skyrenderer.xml
@@ -12,7 +12,7 @@
     android:id="@+id/main_sky_view"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:layout_weight="1">+
+    android:layout_weight="1">
     <android.opengl.GLSurfaceView
       android:layout_width="fill_parent"
       android:layout_height="fill_parent"

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@
 # org.gradle.parallel=true
 
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx2048M
+org.gradle.jvmargs=-Xmx4096M

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@
 # org.gradle.parallel=true
 
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx4096M
+org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
Signed-off-by: Sashrika Kaur <sashrikakaur@yahoo.co.in>

Fixes #252 

The cancel search button was overlapping with the sky map toolbar. Adding a margin prevents the overlap and allows easy access of the menu in skymap toolbar and search button in the search control bar.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/43554558/55266084-31c95080-52a1-11e9-9876-7f4a36a464c5.gif)
