### PR TITLE
TimeTravel dialog Display crash fix#277

### DIFF
--- a/app/src/main/java/com/google/android/stardroid/activities/dialogs/TimeTravelDialog.java
+++ b/app/src/main/java/com/google/android/stardroid/activities/dialogs/TimeTravelDialog.java
@@ -185,8 +185,8 @@ public class TimeTravelDialog extends Dialog {
 
   private void updateDisplay() {
     Date date = calendar.getTime();
-    dateTimeReadout.setText(String.format(parentActivity.getString(R.string.now_visiting,
-                                                                   dateFormat.format(date))));
+    dateTimeReadout.setText(String.format(parentActivity.getString(R.string.now_visiting)+
+                                                                   dateFormat.format(date)));
   }
 
   private void setToNextSunRiseOrSet(Planet.RiseSetIndicator indicator) {


### PR DESCRIPTION

Fixes #277 

- [x] Run the unit tests with `gradlew app:connectedGmsDebugAndroidTest` to make sure you didn't break anything (with an emulator running or phone connected)

- [x] If you have multiple commits please combine them into one commit by squashing them.
