### PR TITLE
fix #227 : replace deprecated gallery by recycler view

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:1.10.19'
     testImplementation 'org.robolectric:robolectric:3.0'
+    implementation 'com.android.support:recyclerview-v7:26.1.0'
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.easymock:easymock:2.5.2'
 }

--- a/app/src/main/res/layout/imagedisplaypanel.xml
+++ b/app/src/main/res/layout/imagedisplaypanel.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="fill_parent"
-    android:orientation="vertical">
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:id="@+id/galleryItemLayout"
+    android:orientation="horizontal">
   <ImageView
       android:id="@+id/image_gallery_image"
-      android:layout_height="200dip"
-      android:layout_width="wrap_content"
-      android:adjustViewBounds="true"
-      android:scaleType="fitCenter"/>
+      android:layout_height="200dp"
+      android:layout_width="200dp"
+      android:adjustViewBounds="true" />
   <TextView
       android:text="Image title placeholder"
       android:id="@+id/image_gallery_title"
       android:layout_width="wrap_content"
+      android:layout_marginStart="10dp"
+      android:textSize="15sp"
       android:layout_height="wrap_content"
       android:textColor="#ffffff"
-      android:layout_gravity="center"/>
+      android:layout_gravity="center"
+      android:layout_marginLeft="10dp" />
 </LinearLayout>

--- a/app/src/main/res/layout/imagegallery.xml
+++ b/app/src/main/res/layout/imagegallery.xml
@@ -13,10 +13,11 @@
       android:layout_height="wrap_content"
       android:text="@string/hubble_image_gallery_title"
       android:gravity="center_horizontal"/>
-  <Gallery
-      android:id="@+id/image_gallery"
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:unselectedAlpha = "0.4"
-      android:spacing = "10px"/>
+    <android.support.v7.widget.RecyclerView
+        android:layout_width="match_parent"
+        android:id="@+id/gallery_list"
+        android:layout_margin="10dp"
+        android:scrollbars="vertical"
+        android:layout_height="wrap_content">
+    </android.support.v7.widget.RecyclerView>
 </LinearLayout>


### PR DESCRIPTION
Fix #227 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradlew app:connectedGmsDebugAndroidTest` to make sure you didn't break anything (with an emulator running or phone connected)

- [x] If you have multiple commits please combine them into one commit by squashing them.


Replaces deprecated Gallery by RecyclerVIew .

- Improved performance
- Better UI
- Less empty screen


![IMG_20190426_050225](https://user-images.githubusercontent.com/38163725/56774501-987a5500-67e0-11e9-8527-007f0247b78a.jpg)
