### PR TITLE
Handling location permissions by creating an Alert Dialog 

### DIFF
--- a/app/src/main/java/com/google/android/stardroid/control/LocationController.java
+++ b/app/src/main/java/com/google/android/stardroid/control/LocationController.java
@@ -113,7 +113,18 @@ public class LocationController extends AbstractController implements LocationLi
         if (possiblelocationProvider == null) {
           Log.i(TAG, "No location provider is even available");
           // TODO(johntaylor): should we make this a dialog?
-          Toast.makeText(context, R.string.location_no_auto, Toast.LENGTH_LONG).show();
+//          Toast.makeText(context, R.string.location_no_auto, Toast.LENGTH_LONG).show();
+          AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context);
+          alertDialogBuilder
+                  .setTitle("Warning")
+                  .setMessage(R.string.location_no_auto)
+                  .setNegativeButton("Cancel", new OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                      dialogInterface.dismiss();
+                    }
+                  })
+                  .create();
           setLocationFromPrefs();
           return;
         }


### PR DESCRIPTION
Signed-off-by: Sashrika Kaur <sashrikakaur@yahoo.co.in>

Fixes #306

Adding Alert Dialog instead of toast to handle location permissions

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradlew app:connectedGmsDebugAndroidTest` to make sure you didn't break anything (with an emulator running or phone connected)

- [ ] If you have multiple commits please combine them into one commit by squashing them.
