### PR TITLE
Moved the timetravel bar to near the bottom of the screen where it's

### DIFF
--- a/app/src/main/res/layout/time_player.xml
+++ b/app/src/main/res/layout/time_player.xml
@@ -10,6 +10,13 @@
     android:layout_height="wrap_content"
     android:background="#20990099">
 
+ <!-- Spacer -->
+ <View
+     android:layout_width="match_parent"
+     android:layout_height="match_parent"
+     android:layout_weight="1"
+     android:orientation="vertical"/>
+
  <!-- Top bar with icon, status message, time, and cancel button. -->
  <RelativeLayout
     android:orientation="vertical"
@@ -31,7 +38,7 @@
     android:layout_height="wrap_content"
     android:text="Time travel: Fill in label ..."
     android:layout_toRightOf="@id/time_travel_icon"
-    android.paddingLeft="10dip"
+    android:paddingLeft="10dip"
     android:textAppearance="?android:attr/textAppearanceMedium"
     android:layout_marginLeft="2dip"
     />
@@ -113,5 +120,9 @@
     />
 
  </LinearLayout>
-
+ <!-- Spacer -->
+ <View
+     android:layout_width="match_parent"
+     android:layout_height="50dp"
+     android:orientation="vertical"/>
 </LinearLayout>


### PR DESCRIPTION
less likely to be interfered with by the other UI elements near the top.

In some cases this interference can make it very hard to close.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradlew app:connectedGmsDebugAndroidTest` to make sure you didn't break anything (with an emulator running or phone connected)

- [ ] If you have multiple commits please combine them into one commit by squashing them.
