### PR TITLE
Fix flaky SplashScreenActivityTest

### DIFF
--- a/app/src/androidTest/java/com/google/android/stardroid/test/SplashScreenActivityTest.java
+++ b/app/src/androidTest/java/com/google/android/stardroid/test/SplashScreenActivityTest.java
@@ -63,11 +63,12 @@ public class SplashScreenActivityTest {
     Thread.sleep(2000);
     onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click());
     // TODO: figure out how to dispense with crap like hand-tuned waiting times.
-    Thread.sleep(2000);
+    // The fadeout animation takes 3000ms, so we need to wait longer than that.
+    Thread.sleep(4000);
     // Can't detect this since the UI is still changing.
     // TODO: figure out how we could.
     //onView(withId(R.id.splash)).check(matches(isDisplayed()));
-    onView(withId(R.id.whatsnew_webview)).check(matches(isDisplayed()));
+    onView(withId(R.id.whatsnew_webview)).inRoot(isDialog()).check(matches(isDisplayed()));
   }
 
   @Test


### PR DESCRIPTION
  Description:                                                                                                        
  ## Summary                                                                                                          
  - Increased wait time from 2000ms to 4000ms (fadeout animation takes 3000ms)                                        
  - Added `.inRoot(isDialog())` to find WebView in the dialog's window root                                           
                                                                                                                      
  ## Problem                                                                                                          
  The test was failing intermittently in CI because:                                                                  
  1. The wait was shorter than the fadeout animation                                                                  
  2. Espresso couldn't find the WebView without specifying the dialog root                                            
                                                                                                                      
  ## Test plan                                                                                                        
  - [x] Verified test passes locally with `./gradlew app:connectedAndroidTest`