### PR TITLE
Improve the android.yml

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        api-level: [ 29 ]
+        api-level: [ 34, 36 ] # Keep 34 as it pre-dates edge to edge.
         target: [ default ]
 
     steps:
@@ -86,6 +86,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
+          profile: Nexus 6
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run connected tests
@@ -101,9 +102,6 @@ jobs:
           profile: Nexus 6
           script: |
             adb wait-for-device
-            adb shell settings put global window_animation_scale 0
-            adb shell settings put global transition_animation_scale 0
-            adb shell settings put global animator_duration_scale 0
             ./gradlew connectedGmsDebugAndroidTest -x lint --stacktrace
 
       - name: Upload connected test results


### PR DESCRIPTION
The CI config hasn't changed in a long time and there are probably improvements that can be made.  It's pretty unreliable as is.



  1. No Gradle caching

  This is the biggest reliability and speed issue. Every run downloads all dependencies from scratch, which is slow and vulnerable to transient network failures. Add caching after the Java setup step in both jobs:

  - uses: actions/cache@v4 with: path: | ~/.gradle/caches ~/.gradle/wrapper key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }} restore-keys: | ${{ runner.os }}-gradle-

  2. build + testGmsDebugUnitTest is redundant (line 24)

  ./gradlew build already runs test, lint, and assemble for all variants. Then testGmsDebugUnitTest re-runs the GMS debug tests. You're doing double work. Change to one of:

  - ./gradlew assembleGmsDebug testGmsDebugUnitTest — build + test just the GMS debug variant
  - ./gradlew build — if you actually want all variants built and tested

  3. No AVD caching for emulator tests

  The emulator image is downloaded fresh every run, which is slow and can fail. The android-emulator-runner action supports AVD caching:

  - name: AVD cache uses: actions/cache@v4 id: avd-cache with: path: | ~/.android/avd/* ~/.android/adb* key: avd-${{ matrix.api-level }}-${{ matrix.target }}

  - name: Create AVD and generate snapshot if: steps.avd-cache.outputs.cache-hit != 'true' uses: reactivecircus/android-emulator-runner@v2 with: api-level: ${{ matrix.api-level }} target: ${{ matrix.target }} arch: x86_64 force-avd-creation: false emulator-options: -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim -memory 3072 disable-animations: true profile: Nexus 6 script: echo "Generated AVD snapshot for caching."

  - name: Run tests uses: reactivecircus/android-emulator-runner@v2 with: api-level: ${{ matrix.api-level }} target: ${{ matrix.target }} arch: x86_64 force-avd-creation: false emulator-options: -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim -memory 3072 disable-animations: true profile: Nexus 6 script: ./gradlew connectedGmsDebugAndroidTest -x lint --stacktrace

  4. Connected tests should depend on the build job (line 28)

  If there's a compilation error, the connected test job still spins up an emulator (slow) before failing. Add:

  connected_test:
    needs: build_and_unit_test
    runs-on: ubuntu-latest

  5. No job timeouts

  If the emulator hangs, it runs until GitHub's 6-hour default. Add explicit timeouts:

  build_and_unit_test:
    runs-on: ubuntu-latest
    timeout-minutes: 15

  connected_test:
    timeout-minutes: 30

  6. No test artifact upload

  When tests fail, you can't inspect detailed results. Add after the test steps:

  - name: Upload test results if: always() uses: actions/upload-artifact@v4 with: name: test-results path: | **/build/reports/tests/ **/build/reports/androidTests/

  7. No concurrency control

  Multiple pushes can queue up redundant runs. Add at the top level:

  concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true

  8. Single-entry matrix is unnecessary (lines 31-33)

  The strategy.matrix with only one API level adds complexity without benefit. Either remove the matrix and hardcode api-level: 29 directly, or add more API levels if you want broader coverage.

  9. Emulator runner version (line 50)

  reactivecircus/android-emulator-runner@v2 is fairly old. Consider pinning to a specific recent release tag for stability (check their releases page for the latest).

  ---
  Summary of priority

  The changes most likely to improve reliability, in order of impact:

  1. Gradle dependency caching — reduces network failures and speeds up builds significantly
  2. needs: build_and_unit_test on connected tests — avoids wasting time booting emulators when compilation fails
  3. AVD caching — avoids re-downloading emulator images
  4. Job timeouts — prevents hung runs from consuming your CI minutes
  5. Concurrency control — cancels stale runs on new pushes

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Translation (new or updated)
- [ ] Documentation
- [x] Refactoring / code cleanup
- [ ] Dependency upgrade

## Checklist

- [ ] I've read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one
- [ ] Added an entry to `[Unreleased]` in CHANGELOG.md (if applicable)

## Notes for Reviewers

<!-- Anything reviewers should know? -->

*Note:* The Cirrus CI system may show failures on your PR. It's pretty flaky right now so don't be alarmed.
