### PR TITLE
Clarify compass calibration messaging

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,17 +238,9 @@
     <string name="compass_calibration_activity_warning">Your compass may need to be
         calibrated</string>
     <string name="compass_calib_what_to_do"
-        translation_description="Information for the user on how to calibrate the compass when the dialog auto-opens. Placeholder is the video URL">Your phone is reporting to Sky
-        Map that its internal compass is uncalibrated.
-    This is not a Sky Map issue but we can help you try to fix it. To calibrate the compass try moving your phone in a figure of eight
-        motion as demonstrated in this video %s until the accuracy reads \'high\'.</string>
+        translation_description="Information for the user on how to calibrate the compass when the dialog auto-opens. Placeholder is the video URL">Your phone is reporting that its internal compass needs calibration. This is a function of your phone\'s hardware, not a Sky Map software issue. To calibrate, move your phone in a figure-8 motion as demonstrated in this video: %s, until the accuracy reads \'high\'. Note: even after calibration, environmental factors like metal cases or nearby electronics can still affect accuracy. This is a physical limitation of mobile compasses.</string>
     <string name="compass_calib_what_to_do_user"
-        transation_description="Information for the user on how to calibrate the compass when they invoke the calibration dialog. Placeholder is the video URL">Your phone\'s
-        compass
-        accuracy is shown above.
-    If it is not \'high\' then the compass may need calibrating. This is not a Sky Map issue, but
-    a property of your phone. To calibrate the compass try moving your phone in a figure of eight
-        motion as demonstrated in this video %s.</string>
+        translation_description="Information for the user on how to calibrate the compass when they invoke the calibration dialog. Placeholder is the video URL">Your phone\'s compass accuracy is shown above. If it is not \'high\', the compass may need calibrating. This is a function of your phone\'s hardware, not a Sky Map software issue. To calibrate, move your phone in a figure-8 motion as demonstrated in this video: %s. Note: even when calibrated, local magnetic fields like car dashboards or magnets may cause a slight bias in direction. This is a physical limitation of mobile compasses.</string>
     <string name="sensor_reverse_preference_title">Reverse Magnetic Z</string>
     <string name="sensor_reverse_preference_summary">Fix for phones with incorrectly implemented sensors - requires restart</string>
     <string name="whats_new_dialog_title">What\'s new</string>


### PR DESCRIPTION
Fixes #632

Updates compass calibration dialog text to better distinguish between hardware limitations and Sky Map software functionality.

Users often blame the app when compass accuracy issues persist, but this is typically a hardware or environmental issue rather than a software problem. These changes improve user education by:

- Explicitly stating that compass calibration is a hardware function, not a Sky Map issue
- Explaining environmental factors that affect accuracy (metal cases, nearby electronics, magnetic fields)
- Maintaining clear calibration instructions while setting realistic expectations

This should reduce user frustration and support requests by clarifying what the app can and cannot control.