### PR TITLE
Add dynamic "Start from Now" / "Go!" button in Time Travel dialog

### DIFF
--- a/app/src/main/java/com/google/android/stardroid/activities/dialogs/TimeTravelDialog.java
+++ b/app/src/main/java/com/google/android/stardroid/activities/dialogs/TimeTravelDialog.java
@@ -73,6 +73,8 @@ public class TimeTravelDialog extends Dialog {
   private AstronomerModel model;
   private long lastClickTime = 0;
   private int currentSearchTargetRes = 0;  // 0 = no search target
+  private boolean userHasModifiedTime = false;
+  private Button goButton;
 
   public TimeTravelDialog(final DynamicStarMapActivity parentActivity,
                           final AstronomerModel model) {
@@ -113,7 +115,8 @@ public class TimeTravelDialog extends Dialog {
         }
       });
 
-    Button goButton = (Button) findViewById(R.id.timeTravelGo);
+    goButton = (Button) findViewById(R.id.timeTravelGo);
+    goButton.setText(R.string.start_from_now);
     goButton.setOnClickListener(new View.OnClickListener() {
         public void onClick(View v) {
           parentActivity.setTimeTravelMode(calendar.getTime(), currentSearchTargetRes);
@@ -147,6 +150,18 @@ public class TimeTravelDialog extends Dialog {
     // the first time the dialog is shown.  Thereafter it will remember the
     // last value set.
     calendar.setTime(new Date());
+    updateDisplay();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    // Reset state each time the dialog is shown.
+    userHasModifiedTime = false;
+    currentSearchTargetRes = 0;
+    popularDatesMenu.setSelection(0);
+    calendar.setTime(new Date());
+    updateGoButtonText();
     updateDisplay();
   }
 
@@ -221,6 +236,8 @@ public class TimeTravelDialog extends Dialog {
    */
   private void setDate(int year, int month, int day) {
     calendar.set(year, month, day);
+    userHasModifiedTime = true;
+    updateGoButtonText();
     updateDisplay();
   }
 
@@ -230,6 +247,8 @@ public class TimeTravelDialog extends Dialog {
   private void setTime(int hour, int minute) {
     calendar.set(Calendar.HOUR_OF_DAY, hour);
     calendar.set(Calendar.MINUTE, minute);
+    userHasModifiedTime = true;
+    updateGoButtonText();
     updateDisplay();
   }
 
@@ -245,6 +264,14 @@ public class TimeTravelDialog extends Dialog {
     Date date = calendar.getTime();
     dateTimeReadout.setText(parentActivity.getString(R.string.now_visiting,
                                                                    dateFormat.format(date)));
+  }
+
+  private void updateGoButtonText() {
+    if (userHasModifiedTime) {
+      goButton.setText(R.string.go);
+    } else {
+      goButton.setText(R.string.start_from_now);
+    }
   }
 
   private Universe universe = new Universe();
@@ -268,6 +295,8 @@ public class TimeTravelDialog extends Dialog {
     TimeTravelEvent event = TimeTravelEvents.ALL.get(index);
     Log.d(TAG, "Popular event " + index + ": " + getContext().getString(event.getDisplayNameRes()));
     currentSearchTargetRes = event.getSearchTargetRes();
+    userHasModifiedTime = true;
+    updateGoButtonText();
     switch (event.getType()) {
       case NOW:
         calendar.setTime(new Date());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="cancel">Cancel</string>
     <string name="set" translation_description="Button label. Set the date to the given value">Set</string>
     <string name="go">Go!</string>
+    <string name="start_from_now">Start from Now</string>
     <string name="other_prefs">Other</string>
     <string name="location_prefs">Location Settings</string>
     <string name="force_gps_pref">Always use GPS</string>


### PR DESCRIPTION
The button now shows "Start from Now" by default when the dialog opens, making it easy to enter time travel mode from the current time. When the user selects a popular event or modifies the date/time, the button changes to "Go!" to indicate they're traveling to a specific destination.

## Description

The previous overhaul of the time travel dialog removed the apparently superfluous "Now" option. However, this was actually the only way (if clunky) to fastforward or go backwards from the current time.  Made it a bit more obvious how to do this (though it's still clunky.)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade

## Checklist

- [ ] I've read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one
- [ ] Added an entry to `[Unreleased]` in CHANGELOG.md (if applicable)

## Notes for Reviewers

<!-- Anything reviewers should know? -->

*Note:* The Cirrus CI system may show failures on your PR. It's pretty flaky right now so don't be alarmed.
