### PR TITLE
Add OK button to ToS dialog when opened from menu

### DIFF
--- a/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
+++ b/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
@@ -74,6 +74,13 @@ public class EulaDialogFragment extends DialogFragment {
                   rejectEula(dialog);
                 }
               });
+    } else {
+      tosDialogBuilder.setNeutralButton(android.R.string.ok,
+          new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+              dialog.dismiss();
+            }
+          });
     }
 
     // Build the HTML content
@@ -130,6 +137,8 @@ public class EulaDialogFragment extends DialogFragment {
 
   @Override
   public void onCancel(DialogInterface dialog) {
-    rejectEula(dialog);
+    if (resultListener != null) {
+      rejectEula(dialog);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- When the Terms of Service dialog is opened from the menu, it had no buttons — the user was stuck with no way to close it. This adds a neutral **OK** button for that case.
- Guards `onCancel` so that back-dismissing the menu dialog does not incorrectly fire a `TOS_REJECTED_EVENT` analytics event.

## Test plan

- [ ] Open Terms of Service from the main menu — verify an OK button appears and dismisses the dialog
- [ ] Back-press to dismiss the menu ToS dialog — verify no rejection event is logged
- [ ] First-launch EULA flow still shows Accept/Decline buttons and works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)