### PR TITLE
Fix night mode dialog tinting and auto-mode button tint loss

### DIFF
--- a/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -318,7 +318,8 @@ public class DynamicStarMapActivity extends InjectableActivity
       }
     }
 
-    // Manual/auto toggle — webp image, must use MULTIPLY not SRC_ATOP
+    // Manual/auto toggle — webp image, must use MULTIPLY not SRC_ATOP.
+    // Uses uniform tint (not on/off dimming) since both states are equally active.
     View manualAutoToggle = findViewById(R.id.manual_auto_toggle);
     if (manualAutoToggle instanceof ImageButton) {
       if (nightMode) {
@@ -852,7 +853,19 @@ public class DynamicStarMapActivity extends InjectableActivity
       ImageButton button = (ImageButton) providerButtons.getChildAt(i);
       buttonViews.add(button);
     }
-    buttonViews.add(findViewById(R.id.manual_auto_toggle));
+    PreferencesButton manualAutoToggle = (PreferencesButton) findViewById(R.id.manual_auto_toggle);
+    buttonViews.add(manualAutoToggle);
+    // Re-apply uniform night tint after each click, since PreferencesButton.setVisuallyOnOrOff()
+    // would otherwise dim the button via the on/off tint logic (fix for issue #661).
+    if (manualAutoToggle != null) {
+      manualAutoToggle.setOnClickListener(v -> {
+        if (nightMode) {
+          manualAutoToggle.setColorFilter(getColor(R.color.night_text_color), PorterDuff.Mode.MULTIPLY);
+        } else {
+          manualAutoToggle.clearColorFilter();
+        }
+      });
+    }
     ButtonLayerView manualButtonLayer = (ButtonLayerView) findViewById(
         R.id.layer_manual_auto_toggle);
 

--- a/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
+++ b/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
@@ -70,10 +70,8 @@ public class CreditsDialogFragment extends DialogFragment {
       }
     });
     webView.loadDataWithBaseURL("file:///android_asset/", html, "text/html", "UTF-8", null);
-    if (isNight) {
-      alertDialog.setOnShowListener(
-          dialog -> NightModeHelper.applyAlertDialogNightMode((AlertDialog) dialog, true));
-    }
+    alertDialog.setOnShowListener(
+        dialog -> NightModeHelper.applyAlertDialogNightMode((AlertDialog) dialog, isNight));
     return alertDialog;
   }
 }

--- a/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
+++ b/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
@@ -116,10 +116,8 @@ public class EulaDialogFragment extends DialogFragment {
     webView.loadDataWithBaseURL("file:///android_asset/", html, "text/html", "UTF-8", null);
 
     AlertDialog tosDialog = tosDialogBuilder.create();
-    if (isNight) {
-      tosDialog.setOnShowListener(
-          dialog -> NightModeHelper.applyAlertDialogNightMode((AlertDialog) dialog, true));
-    }
+    tosDialog.setOnShowListener(
+        dialog -> NightModeHelper.applyAlertDialogNightMode((AlertDialog) dialog, isNight));
     return tosDialog;
   }
 

--- a/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
+++ b/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
@@ -78,10 +78,8 @@ public class HelpDialogFragment extends DialogFragment {
       }
     });
     webView.loadDataWithBaseURL("file:///android_asset/", html, "text/html", "UTF-8", null);
-    if (isNight) {
-      alertDialog.setOnShowListener(
-          dialog -> NightModeHelper.applyAlertDialogNightMode((AlertDialog) dialog, true));
-    }
+    alertDialog.setOnShowListener(
+        dialog -> NightModeHelper.applyAlertDialogNightMode((AlertDialog) dialog, isNight));
     return alertDialog;
   }
 }

--- a/app/src/main/java/com/google/android/stardroid/activities/dialogs/ObjectInfoDialogFragment.kt
+++ b/app/src/main/java/com/google/android/stardroid/activities/dialogs/ObjectInfoDialogFragment.kt
@@ -153,9 +153,7 @@ class ObjectInfoDialogFragment : DialogFragment() {
                 dialog.dismiss()
             }
             .create()
-        if (isNight) {
-            alertDialog.setOnShowListener { NightModeHelper.applyAlertDialogNightMode(alertDialog, true) }
-        }
+        alertDialog.setOnShowListener { NightModeHelper.applyAlertDialogNightMode(alertDialog, isNight) }
         return alertDialog
     }
 

--- a/app/src/main/java/com/google/android/stardroid/activities/dialogs/WhatsNewDialogFragment.java
+++ b/app/src/main/java/com/google/android/stardroid/activities/dialogs/WhatsNewDialogFragment.java
@@ -18,6 +18,7 @@ import androidx.preference.PreferenceManager;
 import com.google.android.stardroid.R;
 import com.google.android.stardroid.StardroidApplication;
 import com.google.android.stardroid.activities.util.ActivityLightLevelManager;
+import com.google.android.stardroid.activities.util.NightModeHelper;
 import com.google.android.stardroid.inject.HasComponent;
 import com.google.android.stardroid.util.MiscUtil;
 
@@ -66,8 +67,8 @@ public class WhatsNewDialogFragment extends DialogFragment {
     String whatsNewText = String.format(parentActivity.getString(R.string.whats_new_text),
         application.getVersionName(), whatsNewContent);
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(parentActivity);
-    String lightMode = preferences.getString(ActivityLightLevelManager.LIGHT_MODE_KEY, "DAY");
-    String bodyClass = "NIGHT".equals(lightMode) ? " class=\"night-mode\"" : "";
+    boolean isNight = ActivityLightLevelManager.isNightMode(preferences);
+    String bodyClass = isNight ? " class=\"night-mode\"" : "";
     String html = "<!DOCTYPE html><html><head>" +
         "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">" +
         "<link rel=\"stylesheet\" href=\"html/help.css\">" +
@@ -84,7 +85,10 @@ public class WhatsNewDialogFragment extends DialogFragment {
     });
     webView.loadDataWithBaseURL("file:///android_asset/", html, "text/html", "UTF-8", null);
 
-    return dialogBuilder.create();
+    AlertDialog alertDialog = dialogBuilder.create();
+    alertDialog.setOnShowListener(
+        dialog -> NightModeHelper.applyAlertDialogNightMode((AlertDialog) dialog, isNight));
+    return alertDialog;
   }
 
   private void endItNow(DialogInterface dialog) {


### PR DESCRIPTION
## Description

- Remove redundant `if (isNight)` guard from setOnShowListener in all dialog fragments (Help, Credits, Eula, ObjectInfo, WhatsNew); pass isNight directly to applyAlertDialogNightMode as suggested in PR #660
- Fix WhatsNewDialogFragment: import NightModeHelper, replace raw string comparison with ActivityLightLevelManager.isNightMode(), add the missing setOnShowListener so dialog chrome is night-styled (PR #660)
- Fix #661: manual_auto_toggle is a PreferencesButton — call setNightMode() on it instead of raw ImageButton.setColorFilter(), so its internal nightMode state is correct and clicks no longer reset the tint to white


## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.
