### PR TITLE
Fix French name for Monoceros constellation: Monocéros → Licorne

### DIFF
--- a/app/src/main/res/values-fr/celestial_objects.xml
+++ b/app/src/main/res/values-fr/celestial_objects.xml
@@ -80,7 +80,7 @@
     <!-- tm:omitted name="lynx" reason="identical_to_source" -->
     <string name="mensa" translation_description="Name of the Mensa constellation">Table</string>
     <string name="microscopium" translation_description="Name of the Microscopium constellation">Microscope</string>
-    <string name="monoceros" translation_description="Name of the Monoceros constellation">Monocéros</string>
+    <string name="monoceros" translation_description="Name of the Monoceros constellation">Licorne</string>
     <string name="musca" translation_description="Name of the Musca constellation">Mouche</string>
     <string name="norma" translation_description="Name of the Norma constellation">Règle</string>
     <string name="octans" translation_description="Name of the Octans constellation">Octant</string>


### PR DESCRIPTION
"Licorne" (unicorn) is the standard French astronomical name used in French star atlases and astronomy references, not the Latin transliteration.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
