### PR TITLE
getObjectNamesMatchingPrefix returns sorted set now (alphabetical default)

### DIFF
--- a/app/src/main/java/com/google/android/stardroid/layers/LayerManager.kt
+++ b/app/src/main/java/com/google/android/stardroid/layers/LayerManager.kt
@@ -87,7 +87,7 @@ class LayerManager(private val sharedPreferences: SharedPreferences) : OnSharedP
             }
         }
         Log.d(TAG, "Got " + all.size + " results in total for " + prefix)
-        return all.toSortedSet() // can pass in a different comparator later for different sorting criteria
+        return all.toSortedSet( compareBy { it.query }) // can pass in a different comparator later for different sorting criteria
     }
 
     private fun isLayerVisible(layer: Layer) = sharedPreferences.getBoolean(layer.preferenceId, true)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->
This PR changes the behavior of getObjectNamesMatchingPrefix to return the resulting hash set in an order (default alphabetical) using a SortedSet. It is needed because the method originally returned results in an arbitrary order, which was unhelpful. 

## Type of Change

- [X] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
