### PR TITLE
Fix build_skymap.sh to reliably propagate exit codes

### DIFF
--- a/build_skymap.sh
+++ b/build_skymap.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/bash
+set -euo pipefail
 QUICK=false
 FDROID=false
 


### PR DESCRIPTION
## Summary
- Replaces `#!/bin/sh -e` with `#!/bin/bash` + `set -euo pipefail`
- `sh -e` has POSIX edge cases where failures inside `if`/`else` branches may not trigger exit; `bash` with `set -euo pipefail` is unambiguous
- Callers (e.g. the translate-skymap workflow) can now rely on `$?` to detect build failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)