### PR TITLE
Enable app-specific languages.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
         versionCode 1618
         versionName "1.12.2:Earth"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        resourceConfigurations += ['en', 'b+en+GB', 'es', 'de', 'it', 'fr', 'pt', 'pl', 'ru', 'b+zh+Hans', 'b+zh+Hant', 'ja', 'ko', 'ar', 'hi', 'tr', 'th', 'id', 'fa', 'uk', 'ca', 'cs', 'da', 'nl', 'hu', 'nb', 'sk', 'sv', 'el', 'cy']
+        resourceConfigurations += ['en', 'b+en+GB', 'ar', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'es', 'fa', 'fr', 'hi', 'hu', 'id', 'it', 'ja', 'ko', 'ms', 'nb', 'nl', 'pl', 'pt', 'ru', 'sk', 'sl', 'sv', 'th', 'tr', 'uk', 'b+zh+Hans', 'b+zh+Hant']
     }
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
         android:name=".StardroidApplication"
         android:icon="@mipmap/skymap_logo_new"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:theme="@style/AppTheme">
         <activity
             android:name=".activities.SplashScreenActivity"

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="en-GB"/>
+    <locale android:name="ar"/>
+    <locale android:name="ca"/>
+    <locale android:name="cs"/>
+    <locale android:name="cy"/>
+    <locale android:name="da"/>
+    <locale android:name="de"/>
+    <locale android:name="el"/>
+    <locale android:name="es"/>
+    <locale android:name="fa"/>
+    <locale android:name="fr"/>
+    <locale android:name="hi"/>
+    <locale android:name="hu"/>
+    <locale android:name="id"/>
+    <locale android:name="it"/>
+    <locale android:name="ja"/>
+    <locale android:name="ko"/>
+    <locale android:name="ms"/>
+    <locale android:name="nb"/>
+    <locale android:name="nl"/>
+    <locale android:name="pl"/>
+    <locale android:name="pt"/>
+    <locale android:name="ru"/>
+    <locale android:name="sk"/>
+    <locale android:name="sl"/>
+    <locale android:name="sv"/>
+    <locale android:name="th"/>
+    <locale android:name="tr"/>
+    <locale android:name="uk"/>
+    <locale android:name="zh-Hans"/>
+    <locale android:name="zh-Hant"/>
+</locale-config>


### PR DESCRIPTION
## Description

It could be that our new translations are rubbish. I can imagine a user who has their phone in Dutch, but wants to have Sky Map in English.  This change should enable that.

## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [x] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
