### PR TITLE
Fix gallery image/label clipping on Android 15+ edge-to-edge displays

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/ImageGalleryActivity.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/ImageGalleryActivity.kt
@@ -11,6 +11,7 @@ import com.google.android.stardroid.R
 import com.google.android.stardroid.activities.dialogs.ObjectInfoDialogFragment
 import com.google.android.stardroid.activities.util.ActivityLightLevelChanger
 import com.google.android.stardroid.activities.util.ActivityLightLevelManager
+import com.google.android.stardroid.activities.util.EdgeToEdgeFixer
 import com.google.android.stardroid.activities.util.NightModeHelper
 import com.google.android.stardroid.education.ObjectInfo
 import com.google.android.stardroid.education.ObjectInfoRegistry
@@ -37,6 +38,7 @@ class ImageGalleryActivity : FragmentActivity(),
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_image_gallery)
+        EdgeToEdgeFixer.applyEdgeToEdgeFixForActionBarActivity(this)
 
         val items = registry.getAllWithImages()
         val recyclerView = findViewById<RecyclerView>(R.id.gallery_grid)
@@ -48,6 +50,11 @@ class ImageGalleryActivity : FragmentActivity(),
             }
         }
         recyclerView.adapter = galleryAdapter
+    }
+
+    override fun onStart() {
+        super.onStart()
+        EdgeToEdgeFixer.applyTopPaddingForActionBar(this, findViewById(android.R.id.content))
     }
 
     override fun onResume() {

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/ImageGalleryActivity.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/ImageGalleryActivity.kt
@@ -54,7 +54,7 @@ class ImageGalleryActivity : FragmentActivity(),
 
     override fun onStart() {
         super.onStart()
-        EdgeToEdgeFixer.applyTopPaddingForActionBar(this, findViewById(android.R.id.content))
+        EdgeToEdgeFixer.applyTopPaddingForActionBar(this, findViewById(R.id.gallery_grid))
     }
 
     override fun onResume() {


### PR DESCRIPTION
Apply EdgeToEdgeFixer to ImageGalleryActivity so the action bar and navigation bar no longer overlap the RecyclerView content.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
