### PR TITLE
Update search overlay text when target is centered on screen

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -197,7 +197,7 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
   @Inject AstronomerModel model;
   private RendererController rendererController;
   private boolean nightMode = false;
-  private boolean searchMode = false;
+  private volatile boolean searchMode = false;
   private volatile boolean lastSearchFocusState = false;
   private Vector3 searchTarget = CoordinateManipulationsKt.getGeocentricCoords(0, 0);
 
@@ -1041,13 +1041,10 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
     TextView statusLabel = findViewById(R.id.search_status_label);
     TextView promptText = findViewById(R.id.search_prompt);
     if (found) {
-      statusLabel.setText(
-          String.format("%s %s", getString(R.string.search_target_found_message), searchTargetName));
+      statusLabel.setText(getString(R.string.search_target_found_message, searchTargetName));
       promptText.setVisibility(View.GONE);
     } else {
-      statusLabel.setText(
-          String.format("%s %s", getString(R.string.search_target_looking_message),
-              searchTargetName));
+      statusLabel.setText(getString(R.string.search_target_looking_message, searchTargetName));
       promptText.setVisibility(View.VISIBLE);
     }
   }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -15,6 +15,7 @@
 package com.google.android.stardroid.activities;
 
 import android.app.SearchManager;
+import java.lang.ref.WeakReference;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
@@ -187,6 +188,8 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
   private static final String TAG = MiscUtil.getTag(DynamicStarMapActivity.class);
 
   private ImageButton cancelSearchButton;
+  private TextView searchStatusLabel;
+  private TextView searchPromptText;
   @Inject ControllerGroup controller;
   private GestureDetector gestureDetector;
   @Inject
@@ -891,15 +894,18 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
     // The renderer will now call back every frame to get model updates.
     rendererController.addUpdateClosure(
         new RendererModelUpdateClosure(model, rendererController, sharedPreferences));
+    WeakReference<DynamicStarMapActivity> weakThis = new WeakReference<>(this);
     rendererController.addUpdateClosure(() -> {
-      if (!searchMode) {
-        lastSearchFocusState = false;
+      DynamicStarMapActivity activity = weakThis.get();
+      if (activity == null) return;
+      if (!activity.searchMode) {
+        activity.lastSearchFocusState = false;
         return;
       }
       boolean inFocus = rendererController.isSearchTargetInFocus();
-      if (inFocus == lastSearchFocusState) return;
-      lastSearchFocusState = inFocus;
-      runOnUiThread(() -> updateSearchPrompt(inFocus));
+      if (inFocus == activity.lastSearchFocusState) return;
+      activity.lastSearchFocusState = inFocus;
+      activity.runOnUiThread(() -> activity.updateSearchPrompt(inFocus));
     });
 
     Log.i(TAG, "Setting layers @ " + System.currentTimeMillis());
@@ -925,6 +931,8 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
   private void wireUpScreenControls() {
     cancelSearchButton = findViewById(R.id.cancel_search_button);
     cancelSearchButton.setOnClickListener(v -> cancelSearch());
+    searchStatusLabel = findViewById(R.id.search_status_label);
+    searchPromptText = findViewById(R.id.search_prompt);
 
     // Push the search control bar below the status bar and any display cutout
     // so it doesn't overlap with camera notches on modern phones.
@@ -1038,14 +1046,13 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
   }
 
   private void updateSearchPrompt(boolean found) {
-    TextView statusLabel = findViewById(R.id.search_status_label);
-    TextView promptText = findViewById(R.id.search_prompt);
     if (found) {
-      statusLabel.setText(getString(R.string.search_target_found_message, searchTargetName));
-      promptText.setVisibility(View.GONE);
+      searchStatusLabel.setText(getString(R.string.search_target_found_message, searchTargetName));
+      searchPromptText.setVisibility(View.GONE);
     } else {
-      statusLabel.setText(getString(R.string.search_target_looking_message, searchTargetName));
-      promptText.setVisibility(View.VISIBLE);
+      searchStatusLabel.setText(
+          getString(R.string.search_target_looking_message, searchTargetName));
+      searchPromptText.setVisibility(View.VISIBLE);
     }
   }
 

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -198,6 +198,7 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
   private RendererController rendererController;
   private boolean nightMode = false;
   private boolean searchMode = false;
+  private volatile boolean lastSearchFocusState = false;
   private Vector3 searchTarget = CoordinateManipulationsKt.getGeocentricCoords(0, 0);
 
   @Inject SharedPreferences sharedPreferences;
@@ -890,6 +891,16 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
     // The renderer will now call back every frame to get model updates.
     rendererController.addUpdateClosure(
         new RendererModelUpdateClosure(model, rendererController, sharedPreferences));
+    rendererController.addUpdateClosure(() -> {
+      if (!searchMode) {
+        lastSearchFocusState = false;
+        return;
+      }
+      boolean inFocus = rendererController.isSearchTargetInFocus();
+      if (inFocus == lastSearchFocusState) return;
+      lastSearchFocusState = inFocus;
+      runOnUiThread(() -> updateSearchPrompt(inFocus));
+    });
 
     Log.i(TAG, "Setting layers @ " + System.currentTimeMillis());
     layerManager.registerWithRenderer(rendererController);
@@ -1026,6 +1037,21 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
     searchMode = false;
   }
 
+  private void updateSearchPrompt(boolean found) {
+    TextView statusLabel = findViewById(R.id.search_status_label);
+    TextView promptText = findViewById(R.id.search_prompt);
+    if (found) {
+      statusLabel.setText(
+          String.format("%s %s", getString(R.string.search_target_found_message), searchTargetName));
+      promptText.setVisibility(View.GONE);
+    } else {
+      statusLabel.setText(
+          String.format("%s %s", getString(R.string.search_target_looking_message),
+              searchTargetName));
+      promptText.setVisibility(View.VISIBLE);
+    }
+  }
+
   @Override
   protected void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
@@ -1085,9 +1111,8 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
       controller.teleport(target);
     }
 
-    TextView searchPromptText = findViewById(R.id.search_status_label);
-    searchPromptText.setText(
-        String.format("%s %s", getString(R.string.search_target_looking_message), searchTerm));
+    lastSearchFocusState = false;
+    updateSearchPrompt(false);
     View searchControlBar = findViewById(R.id.search_control_bar);
     searchControlBar.setVisibility(View.VISIBLE);
   }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderer/OverlayManager.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderer/OverlayManager.java
@@ -134,6 +134,10 @@ public class OverlayManager extends RendererObjectManager {
     mSearching = false;
   }
 
+  public boolean isSearchTargetInFocus() {
+    return mSearching && mSearchHelper.targetInFocusRadius();
+  }
+
   private void setupMatrices(GL10 gl) {
     // Save the matrix values.
     gl.glMatrixMode(GL10.GL_PROJECTION);

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderer/RendererController.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderer/RendererController.java
@@ -94,4 +94,9 @@ public class RendererController extends RendererControllerBase {
       }
     }});
   }
+
+  // Must only be called from within an update closure (GL thread).
+  public boolean isSearchTargetInFocus() {
+    return mRenderer.isSearchTargetInFocus();
+  }
 }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderer/SkyRenderer.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderer/SkyRenderer.java
@@ -268,6 +268,10 @@ public class SkyRenderer implements GLSurfaceView.Renderer {
     mOverlayManager.disableSearchOverlay();
   }
 
+  public boolean isSearchTargetInFocus() {
+    return mOverlayManager.isSearchTargetInFocus();
+  }
+
   public void setNightVisionMode(boolean enabled) {
     mRenderState.setNightVisionMode(enabled);
   }

--- a/stardroid-v1/app/src/main/res/values-ar/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ar/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">معرض خريطة السماء</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">صور هابل</string>
     <string name="search_overlay_title" translation_description="title for search overlay">وجّه هاتفك نحو السهم</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">البحث عن:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">البحث عن: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">الشمس لن تغيب خلال الـ 24 ساعة القادمة في موقعك الحالي.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -133,7 +133,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">星空地图哈勃图片库</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">哈勃图片</string>
     <string name="search_overlay_title" translation_description="title for search overlay">将手机朝向箭头所指的方向</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">查找内容：</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">查找内容： %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">在未来 24 小时内太阳不会在您当前所在的位置落下。</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -136,7 +136,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">星空圖哈伯望遠鏡圖庫</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">哈伯望遠鏡影像</string>
     <string name="search_overlay_title" translation_description="title for search overlay">將手機指向箭頭方向</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">正在尋找：</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">正在尋找： %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">您目前的位置未來 24 小時之內看不到日落。</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-cs/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-cs/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galerie snímků z Hubbleova teleskopu na Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Snímek z Hubbleova teleskopu</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Namiřte směrem k šipce</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Hledám:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Hledám: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Při vaší poloze slunce během následujících 24 hodin nezapadne.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-cy/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-cy/strings.xml
@@ -140,7 +140,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Oriel Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Delwedd Hubble</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Pwyntia dy ddyfais tua\'r saeth</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Yn chwilio am:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Yn chwilio am: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Dyw\'r haul ddim yn machlud o fewn y 24 awr nesaf yn dy leoliad cyfredol.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-da/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-da/strings.xml
@@ -140,7 +140,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Sky Map Galleri</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Hubble-billede</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Peg din telefon mod pilen</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Søger efter:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Søger efter: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Solen vil ikke gå ned i løbet af de næste 24 timer på dit nuværende sted.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-de/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-de/strings.xml
@@ -144,7 +144,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Hubble-Galerie</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Hubble-Bild</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Bewegen Sie Ihr Telefon in Richtung des Pfeils.</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Suche nach:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Suche nach: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">
     Die Sonne geht in den nächsten 24 Stunden nicht an Ihrem aktuellen Standort unter.
     </string>

--- a/stardroid-v1/app/src/main/res/values-el/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-el/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Συλλογή του Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Εικόνα του Hubble</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Μετακινήστε τη συσκευή σας προς το βέλος</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Αναζήτηση για:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Αναζήτηση για: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Ο ήλιος δε θα δύσει μέσα στις επόμενες 24 ώρες στην τρέχουσα τοποθεσία σας.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-es/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-es/strings.xml
@@ -140,7 +140,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galería de Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Imagen del Hubble</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Apunta tu teléfono hacia la flecha</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Buscando:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Buscando: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">El Sol no se pondrá durante las próximas 24 horas en tu ubicación actual.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-fa/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-fa/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">آلبوم برنامه</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">تصاویر (تلسکوپ) هابل</string>
     <string name="search_overlay_title" translation_description="title for search overlay">تلفن خود را به سمت فلش قرار دهید</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">جستجو برای:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">جستجو برای: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">در مکان انتخابی شما، خورشید تا ۲۴ ساعت آینده غروب نمی‌کند.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-fr/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-fr/strings.xml
@@ -140,7 +140,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galerie Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Image Hubble</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Dirigez votre téléphone vers la flèche</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Vous recherchez :</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Vous recherchez : %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">
     À votre position actuelle, le soleil ne se couchera pas au cours des prochaines 24 heures.
     </string>

--- a/stardroid-v1/app/src/main/res/values-hi/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-hi/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Sky Map गैलरी</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">हबल इमेज</string>
     <string name="search_overlay_title" translation_description="title for search overlay">अपने फोन को तीर की ओर इशारा करें</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">खोज रहे हैं:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">खोज रहे हैं: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">आपके वर्तमान स्थान पर अगले 24 घंटों में सूर्य अस्त नहीं होगा।</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-id/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-id/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galeri Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Gambar Hubble</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Arahkan ponsel Anda ke arah panah</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Mencari:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Mencari: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Matahari tidak akan terbenam selama 24 jam ke depan di lokasi Anda saat ini.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-it/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-it/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galleria Hubble di Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Immagine di Hubble</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Punta il telefono verso la freccia</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Ricerca di:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Ricerca di: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Nella tua località corrente, il sole non tramonterà per le prossime 24 ore</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-ja/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ja/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Skyマップのハッブルギャラリー</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">ハッブル画像</string>
     <string name="search_overlay_title" translation_description="title for search overlay">携帯を矢印の方に向けます</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">探しています:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">探しています: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">この場所では今後24時間以内に太陽が沈むことはありません。</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-ko/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ko/strings.xml
@@ -92,7 +92,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">별지도 허블 갤러리</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">허블 이미지</string>
     <string name="search_overlay_title" translation_description="title for search overlay">휴대전화로 화살표 방향 가리키기</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">찾는 중:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">찾는 중: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">현재 위치에서 다음 24시간 동안 태양이 지지 않습니다.</string>
 
     <string name="menu_tos" translation_description="Menu item label to view the Terms of Service">서비스 약관</string>

--- a/stardroid-v1/app/src/main/res/values-ms/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ms/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galeri Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Imej Hubble</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Arahkan telefon anda ke arah anak panah</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Mencari:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Mencari: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Matahari tidak akan terbenam dalam 24 jam ke depan di lokasi semasa anda.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-nb/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-nb/strings.xml
@@ -139,7 +139,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Sky Map Galleri</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Hubble-bilde</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Beveg telefonen din i pilretning</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Ser etter:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Ser etter: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Solen går ikke ned i løpet av de neste 24 timene på ditt nåværende sted.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-nl/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-nl/strings.xml
@@ -140,7 +140,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Hubble-galerij met sterrenkaarten</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Hubble-beeld</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Richt uw telefoon in de richting van de pijl</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Zoeken naar:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Zoeken naar: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">De zon gaat op uw huidige locatie niet onder in de komende 24 uur.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-pl/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-pl/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galeria Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Zdjęcie z teleskopu Hubble’a</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Kieruj telefon zgodnie ze wskazaniem strzałki</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Wyszukiwanie:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Wyszukiwanie: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">W Twojej bieżącej lokalizacji Słońce nie zejdzie w ciągu następnych 24 godzin.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-pt/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-pt/strings.xml
@@ -140,7 +140,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galeria do Hubble do Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Imagem do Hubble</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Aponte o seu telefone em direção à seta</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Procurando:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Procurando: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">O sol não irá se pôr durante as próximas 24 horas no seu local atual.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-ru/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ru/strings.xml
@@ -94,7 +94,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Галерея Хаббл для Карты звездного неба</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Фотография, отснятая телескопом Хаббл</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Поверните телефон в направлении стрелки</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Поиск:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Поиск: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">В течение ближайших 24 часов захода Солнца в вашем местоположении не будет.</string>
 
     <string name="menu_tos" translation_description="Menu item label to view the Terms of Service">Условия предоставления услуг</string>

--- a/stardroid-v1/app/src/main/res/values-sk/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-sk/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galéria v Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Snímok z Hubblovho teleskopu</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Nasmerujte telefón podľa šípky</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Hľadám:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Hľadám: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Na vašej aktuálnej polohe nezapadne Slnko počas nasledujúcich 24 hodín.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-sl/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-sl/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Galerija Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Hubblova slika</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Usmerite telefon proti puščici</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Iskanje:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Iskanje: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Sonce se ne bo zašlo v naslednjih 24 urah na vaši trenutni lokaciji.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-sv/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-sv/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Sky Map-galleri</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Hubble-bild</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Peka din telefon mot pilen</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Söker efter:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Söker efter: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Solen kommer inte att gå ned under de nästa 24 timmarna på din nuvarande plats.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-th/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-th/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">แกลเลอรี่ Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">ภาพจากกล้องโทรทรรศน์ฮับเบิล</string>
     <string name="search_overlay_title" translation_description="title for search overlay">ชี้โทรศัพท์ของคุณไปยังลูกศร</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">กำลังค้นหา:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">กำลังค้นหา: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">ดวงอาทิตย์จะไม่ตกในช่วง 24 ชั่วโมงถัดไปที่ตำแหน่งปัจจุบันของคุณ</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-tr/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-tr/strings.xml
@@ -138,7 +138,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Sky Map Galerisi</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Hubble Görüntüsü</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Telefonunuzu ok yönüne çevirin</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Aranıyor:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Aranıyor: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">24 saat boyunca güneş, mevcut konumunuzda batmayacak.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-uk/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-uk/strings.xml
@@ -140,7 +140,7 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Галерея Хаббл для Sky Map</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Фотографія, відзнята телескопом Хаббл</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Поверніть телефон в напрямку стрілки</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Пошук:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Пошук: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">Протягом найближчих 24 годин заходу Сонця в вашому місці розташування не буде.</string>
 
     <!-- tm:omitted name="missing_label" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -146,6 +146,7 @@
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Hubble Image</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Point your phone toward the arrow</string>
     <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Looking for:</string>
+    <string name="search_target_found_message" translation_description="displayed when a search target has been found and is centered on screen">Found:</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">The sun will not set during the next 24 hours at your current location.</string>
 
     <string name="missing_label" translation_description="Do not translate this" translatable="false">MISSING_LBL</string>

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -145,8 +145,8 @@
     <string name="hubble_image_gallery_title" translation_description="Title of the image gallery screen">Sky Map Gallery</string>
     <string name="hubble_image" translation_description="Label or caption for a Hubble Space Telescope image in the gallery">Hubble Image</string>
     <string name="search_overlay_title" translation_description="title for search overlay">Point your phone toward the arrow</string>
-    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Looking for:</string>
-    <string name="search_target_found_message" translation_description="displayed when a search target has been found and is centered on screen">Found:</string>
+    <string name="search_target_looking_message" translation_description="displayed when a search target is being searched for">Looking for: %s</string>
+    <string name="search_target_found_message" translation_description="displayed when a search target has been found and is centered on screen">Found: %s</string>
     <string name="sun_wont_set_message" translation_description="Message shown when the sun will not set during the next 24 hours (polar day / midnight sun)">The sun will not set during the next 24 hours at your current location.</string>
 
     <string name="missing_label" translation_description="Do not translate this" translatable="false">MISSING_LBL</string>


### PR DESCRIPTION
When the search ring appears (target enters focus radius), the prompt changes from "Looking for: X" / "Point your phone toward the arrow" to "Found: X" with the subtitle hidden. Reverts when the target leaves focus.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
