### PR TITLE
Fix see-also links closing dialog when opened from gallery

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/ImageGalleryActivity.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/ImageGalleryActivity.kt
@@ -26,7 +26,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class ImageGalleryActivity : FragmentActivity(),
     ActivityLightLevelChanger.NightModeable,
-    ObjectInfoDialogFragment.OnFindClickedListener {
+    ObjectInfoDialogFragment.OnFindClickedListener,
+    ObjectInfoDialogFragment.OnSeeAlsoClickedListener {
 
     @Inject lateinit var registry: ObjectInfoRegistry
     @Inject lateinit var activityLightLevelManager: ActivityLightLevelManager
@@ -70,6 +71,14 @@ class ImageGalleryActivity : FragmentActivity(),
     override fun setNightMode(nightMode: Boolean) {
         NightModeHelper.applyActionBarNightMode(actionBar, this, nightMode)
         galleryAdapter.notifyDataSetChanged()
+    }
+
+    override fun onSeeAlsoClicked(objectId: String) {
+        val info = registry.getInfo(objectId) ?: return
+        if (!supportFragmentManager.isStateSaved) {
+            ObjectInfoDialogFragment.newInstance(info)
+                .show(supportFragmentManager, "ObjectInfo:$objectId")
+        }
     }
 
     override fun onFindClicked(info: ObjectInfo) {

--- a/stardroid-v1/app/src/test/java/com/google/android/stardroid/education/ObjectInfoTest.kt
+++ b/stardroid-v1/app/src/test/java/com/google/android/stardroid/education/ObjectInfoTest.kt
@@ -106,7 +106,7 @@ class ObjectInfoTest {
 
     @Test
     fun testObjectTypeValues() {
-        assertThat(ObjectType.values()).hasLength(9)
+        assertThat(ObjectType.values()).hasLength(10)
         assertThat(ObjectType.PLANET.name).isEqualTo("PLANET")
         assertThat(ObjectType.STAR.name).isEqualTo("STAR")
         assertThat(ObjectType.MOON.name).isEqualTo("MOON")
@@ -116,5 +116,6 @@ class ObjectInfoTest {
         assertThat(ObjectType.CLUSTER.name).isEqualTo("CLUSTER")
         assertThat(ObjectType.CONSTELLATION.name).isEqualTo("CONSTELLATION")
         assertThat(ObjectType.BLACK_HOLE.name).isEqualTo("BLACK_HOLE")
+        assertThat(ObjectType.METEOR_SHOWER.name).isEqualTo("METEOR_SHOWER")
     }
 }


### PR DESCRIPTION
ImageGalleryActivity was missing OnSeeAlsoClickedListener, so tapping a see-also link only called dismiss() with no navigation. Now the activity implements the interface and shows the linked object's info card.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
