### PR TITLE
Fix Hindi crux string containing Chinese character

### DIFF
--- a/stardroid-v1/app/src/main/res/values-hi/celestial_objects.xml
+++ b/stardroid-v1/app/src/main/res/values-hi/celestial_objects.xml
@@ -14,7 +14,7 @@
     <string name="cassiopeia" translation_description="Name of the Cassiopeia constellation">कसिओपिया</string>
     <string name="centaurus" translation_description="Name of the Centaurus constellation">सेंटोरस</string>
     <string name="cetus" translation_description="Name of the Cetus constellation">व्हेल</string>
-    <string name="crux" translation_description="Name of the Crux constellation">दक्षिणी十字</string>
+    <string name="crux" translation_description="Name of the Crux constellation">दक्षिणी क्रॉस</string>
     <string name="cygnus" translation_description="Name of the Cygnus constellation">हंस</string>
     <string name="draco" translation_description="Name of the Draco constellation">ड्रैगन</string>
     <string name="eridanus" translation_description="Name of the Eridanus constellation">नदी</string>


### PR DESCRIPTION
Replace "दक्षिणी十字" with "दक्षिणी क्रॉस" — the Chinese character 十字 was erroneously mixed into the Hindi translation.

https://claude.ai/code/session_01NgXTXMogzHQgcAGb6bFGkv

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [x] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
