### PR TITLE
Fix Draco Thai translation from zodiac term to constellation term

### DIFF
--- a/stardroid-v1/app/src/main/res/values-th/celestial_objects.xml
+++ b/stardroid-v1/app/src/main/res/values-th/celestial_objects.xml
@@ -15,7 +15,7 @@
     <string name="cetus" translation_description="Name of the Cetus constellation">ราศีวาฬ</string>
     <string name="crux" translation_description="Name of the Crux constellation">ราศีกางเขน</string>
     <string name="cygnus" translation_description="Name of the Cygnus constellation">ราศีหงส์</string>
-    <string name="draco" translation_description="Name of the Draco constellation">ราศีมังกร</string>
+    <string name="draco" translation_description="Name of the Draco constellation">กลุ่มดาวมังกร</string>
     <string name="eridanus" translation_description="Name of the Eridanus constellation">ราศีแม่น้ำ</string>
     <string name="gemini" translation_description="Name of the Gemini constellation">ราศีเมถุน</string>
     <!-- tm:omitted name="grus" reason="identical_to_source" -->

--- a/stardroid-v1/app/src/main/res/values-th/celestial_objects.xml
+++ b/stardroid-v1/app/src/main/res/values-th/celestial_objects.xml
@@ -12,11 +12,11 @@
     <string name="carina" translation_description="Name of the Carina constellation">ราศีเรือ</string>
     <string name="cassiopeia" translation_description="Name of the Cassiopeia constellation">ราศีแคสสิโอเปีย</string>
     <string name="centaurus" translation_description="Name of the Centaurus constellation">ราศีเคนทอรัส</string>
-    <string name="cetus" translation_description="Name of the Cetus constellation">ราศีวาฬ</string>
-    <string name="crux" translation_description="Name of the Crux constellation">ราศีกางเขน</string>
-    <string name="cygnus" translation_description="Name of the Cygnus constellation">ราศีหงส์</string>
+    <string name="cetus" translation_description="Name of the Cetus constellation">กลุ่มดาววาฬ</string>
+    <string name="crux" translation_description="Name of the Crux constellation">กลุ่มดาวกางเขน</string>
+    <string name="cygnus" translation_description="Name of the Cygnus constellation">กลุ่มดาวหงส์</string>
     <string name="draco" translation_description="Name of the Draco constellation">กลุ่มดาวมังกร</string>
-    <string name="eridanus" translation_description="Name of the Eridanus constellation">ราศีแม่น้ำ</string>
+    <string name="eridanus" translation_description="Name of the Eridanus constellation">กลุ่มดาวแม่น้ำ</string>
     <string name="gemini" translation_description="Name of the Gemini constellation">ราศีเมถุน</string>
     <!-- tm:omitted name="grus" reason="identical_to_source" -->
     <!-- tm:omitted name="hercules" reason="identical_to_source" -->


### PR DESCRIPTION
"ราศีมังกร" implies a zodiac sign; Draco is not a zodiac constellation. Changed to "กลุ่มดาวมังกร" (dragon star group) to correctly identify it as a constellation.

https://claude.ai/code/session_01Vjy9JKv89WpKN6MPSiAoaz

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [x] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
