### PR TITLE
Fix Action Bar tooltips visibility and modernize app theme

### DIFF
--- a/stardroid-v1/app/src/main/AndroidManifest.xml
+++ b/stardroid-v1/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
         <activity
             android:name=".activities.SplashScreenActivity"
             android:screenOrientation="nosensor"
-            android:theme="@android:style/Theme.Holo.NoActionBar.Fullscreen"
+            android:theme="@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -282,10 +282,10 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
       doSearchWithIntent(intent);
     }
     
-    android.app.ActionBar actionBar = getActionBar();
+    ActionBar actionBar = getActionBar();
     if (actionBar != null) {
-        actionBar.setDisplayShowHomeEnabled(true);
-        actionBar.setDisplayUseLogoEnabled(true);
+      actionBar.setDisplayShowHomeEnabled(true);
+      actionBar.setDisplayUseLogoEnabled(true);
     }
     
     Log.d(TAG, "-onCreate at " + System.currentTimeMillis());

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -45,6 +45,11 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.ForegroundColorSpan;
+
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.graphics.Insets;
@@ -279,6 +284,13 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
       Log.d(TAG, "Started as a result of a search");
       doSearchWithIntent(intent);
     }
+    
+    android.app.ActionBar actionBar = getActionBar();
+    if (actionBar != null) {
+        actionBar.setDisplayShowHomeEnabled(true);
+        actionBar.setDisplayUseLogoEnabled(true);
+    }
+    
     Log.d(TAG, "-onCreate at " + System.currentTimeMillis());
   }
 
@@ -456,7 +468,33 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
     super.onCreateOptionsMenu(menu);
     MenuInflater inflater = getMenuInflater();
     inflater.inflate(R.menu.main, menu);
+    
+    setupActionItem(menu, R.id.menu_item_search, android.R.drawable.ic_menu_search, R.string.menu_search);
+    setupActionItem(menu, R.id.menu_item_dim, android.R.drawable.ic_menu_view, R.string.menu_toggle_dim);
+    setupActionItem(menu, R.id.menu_item_time, R.drawable.time_travel_icon, R.string.menu_time);
+    
     return true;
+  }
+
+  private void setupActionItem(Menu menu, int itemId, int iconRes, @StringRes int stringRes) {
+    MenuItem item = menu.findItem(itemId);
+    if (item != null) {
+        View view = item.getActionView();
+        if (view instanceof ImageButton) {
+            ImageButton btn = (ImageButton) view;
+            btn.setImageResource(iconRes);
+            btn.setContentDescription(getString(stringRes));
+            btn.setOnClickListener(v -> onOptionsItemSelected(item));
+            btn.setOnLongClickListener(v -> {
+                Toast toast = Toast.makeText(this, stringRes, Toast.LENGTH_SHORT);
+                int[] pos = new int[2];
+                v.getLocationOnScreen(pos);
+                toast.setGravity(android.view.Gravity.TOP | android.view.Gravity.LEFT, pos[0], pos[1] + v.getHeight());
+                toast.show();
+                return true;
+            });
+        }
+    }
   }
 
   @Override

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -45,10 +45,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import android.text.SpannableString;
-import android.text.Spanned;
-import android.text.style.BackgroundColorSpan;
-import android.text.style.ForegroundColorSpan;
+import android.app.ActionBar;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;

--- a/stardroid-v1/app/src/main/res/layout/action_item.xml
+++ b/stardroid-v1/app/src/main/res/layout/action_item.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageButton xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/action_icon"
+    style="?android:attr/actionButtonStyle"
+    android:layout_width="?android:attr/actionBarSize"
+    android:layout_height="?android:attr/actionBarSize"
+    android:scaleType="centerInside"
+    android:contentDescription="@null" />

--- a/stardroid-v1/app/src/main/res/menu/main.xml
+++ b/stardroid-v1/app/src/main/res/menu/main.xml
@@ -20,18 +20,21 @@
           android:orderInCategory="1"
           android:title="@string/menu_search"
           android:icon="@android:drawable/ic_menu_search"
+          android:actionLayout="@layout/action_item"
           android:showAsAction="always"/>
 
     <item android:id="@+id/menu_item_dim"
           android:orderInCategory="2"
           android:title="@string/menu_toggle_dim"
           android:icon="@android:drawable/ic_menu_view"
+          android:actionLayout="@layout/action_item"
           android:showAsAction="always"/>
 
     <item android:id="@+id/menu_item_time"
         android:orderInCategory="3"
         android:title="@string/menu_time"
         android:icon="@drawable/time_travel_icon"
+        android:actionLayout="@layout/action_item"
         android:showAsAction="always"/>
 
     <item android:id="@+id/menu_item_settings"

--- a/stardroid-v1/app/src/main/res/values/styles.xml
+++ b/stardroid-v1/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Main App Theme to make global changes easier -->
-    <style name = "AppTheme" parent="@android:style/Theme.Holo">
+    <style name="AppTheme" parent="@android:style/Theme.DeviceDefault">
     </style>
 
     <style name="FullscreenTheme" parent="AppTheme">
@@ -11,7 +11,7 @@
         <item name="metaButtonBarButtonStyle">?android:attr/buttonBarButtonStyle</item>
     </style>
 
-    <style name="FullscreenActionBarStyle" parent="android:Widget.Holo.ActionBar">
+    <style name="FullscreenActionBarStyle" parent="android:Widget.DeviceDefault.ActionBar">
         <item name="android:background">@color/black_overlay</item>
     </style>
 


### PR DESCRIPTION
Fixes #791.

### Changes:
- **Theme Modernization**: Migrated base app theme from legacy `Theme.Holo` to `Theme.DeviceDefault` for modern Material styling. This brings rounded dialogs and improved visual consistency across Android versions.
- **Action Bar Logo**: Restored the Action Bar logo explicitly, which is otherwise hidden by default when using `Theme.DeviceDefault`.
- **Tooltip Bug Fix**: Bypassed a persistent native rendering bug on certain Android 14 devices (e.g., OnePlus OxygenOS) where Action Bar tooltips rendered as white-on-white. Using the native Tooltip API was ineffective due to private framework attribute limitations. Instead, I introduced a custom `ImageButton` Action Layout (`action_item.xml`) for the Search, Night Mode, and Time Travel items. Their long-click listeners now spawn standard `Toast`s, which accurately respect the OS's light/dark mode and provide perfectly readable tooltips.
- **Icon Sizing**: Constrained the custom Action Layout bounds to `?android:attr/actionBarSize` with `centerInside` scaling to ensure larger icons (like `time_travel_icon`) scale down properly and maintain uniform Action Bar proportions.