### PR TITLE
767: grey out past events in drop down

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/TimeTravelDialog.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/TimeTravelDialog.java
@@ -217,6 +217,14 @@ public class TimeTravelDialog extends Dialog {
         return position != 0;
       }
 
+
+      // returns true if an event has passed based on its timestamp, used to grey out past events in the dropdown (but leave them enabled)
+      public boolean hasPassed(int position) {
+        TimeTravelEvent event = events.get(position);
+        return event.getType() == TimeTravelEvent.Type.FIXED // only fixed events have a timestamp to compare against
+            && event.getTimestampMs() < System.currentTimeMillis();
+      }
+
       @Override
       public View getView(int position, @Nullable View convertView,
           @NonNull ViewGroup parent) {
@@ -224,7 +232,8 @@ public class TimeTravelDialog extends Dialog {
         // Colors the collapsed spinner face (the currently selected item shown when closed).
         if (view instanceof TextView) {
           int activeColor = isNight ? context.getColor(R.color.night_text_color) : Color.WHITE;
-          ((TextView) view).setTextColor(position == 0 ? Color.GRAY : activeColor);
+          ((TextView) view).setTextColor(position == 0 || hasPassed(position) ? Color.GRAY
+              : activeColor);
         }
         return view;
       }
@@ -237,7 +246,8 @@ public class TimeTravelDialog extends Dialog {
         // spinner_dropdown_item.xml has a dark background; use GRAY for the hint row.
         if (view instanceof TextView) {
           int activeColor = isNight ? context.getColor(R.color.night_text_color) : Color.WHITE;
-          ((TextView) view).setTextColor(position == 0 ? Color.GRAY : activeColor);
+          ((TextView) view).setTextColor(position == 0 || hasPassed(position) ? Color.GRAY
+              : activeColor);
         }
         return view;
       }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/TimeTravelDialog.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/TimeTravelDialog.java
@@ -219,7 +219,7 @@ public class TimeTravelDialog extends Dialog {
 
 
       // returns true if an event has passed based on its timestamp, used to grey out past events in the dropdown (but leave them enabled)
-      public boolean hasPassed(int position) {
+      private boolean isPastEvent(int position) {
         TimeTravelEvent event = events.get(position);
         return event.getType() == TimeTravelEvent.Type.FIXED // only fixed events have a timestamp to compare against
             && event.getTimestampMs() < System.currentTimeMillis();
@@ -232,7 +232,7 @@ public class TimeTravelDialog extends Dialog {
         // Colors the collapsed spinner face (the currently selected item shown when closed).
         if (view instanceof TextView) {
           int activeColor = isNight ? context.getColor(R.color.night_text_color) : Color.WHITE;
-          ((TextView) view).setTextColor(position == 0 || hasPassed(position) ? Color.GRAY
+          ((TextView) view).setTextColor(position == 0 || isPastEvent(position) ? Color.GRAY
               : activeColor);
         }
         return view;
@@ -246,7 +246,7 @@ public class TimeTravelDialog extends Dialog {
         // spinner_dropdown_item.xml has a dark background; use GRAY for the hint row.
         if (view instanceof TextView) {
           int activeColor = isNight ? context.getColor(R.color.night_text_color) : Color.WHITE;
-          ((TextView) view).setTextColor(position == 0 || hasPassed(position) ? Color.GRAY
+          ((TextView) view).setTextColor(position == 0 || isPastEvent(position) ? Color.GRAY
               : activeColor);
         }
         return view;


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->
This PR handles #767, which de-emphasizes past events in the case where a user does not update the app frequently. Previously, all events would show in the drop-down, regardless of whether they were past or future; now, these past events are greyed out, similar to the hint option.

## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [x] Other (enhancement)

## Checklist

- [x] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [x] For major changes, I've emailed skymapdevs@gmail.com first
- [x] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [x] I've tested on a device/emulator if applicable
- [x] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
