### PR TITLE
Fix RTL text overlap with close icons in UI bars

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v3
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
@@ -101,7 +101,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run connected tests
-        uses: reactivecircus/android-emulator-runner@v3
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v3
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
@@ -101,7 +101,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run connected tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v3
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/stardroid-v1/app/src/main/res/layout/skyrenderer.xml
+++ b/stardroid-v1/app/src/main/res/layout/skyrenderer.xml
@@ -49,7 +49,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="2dip"
                 android:layout_toEndOf="@id/search_icon"
-                android:layout_toStartOf="@id/cancel_search_button"
+                android:layout_toStartOf="@+id/cancel_search_button"
                 android:paddingStart="10dip"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
@@ -59,7 +59,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/search_status_label"
                 android:layout_toEndOf="@id/search_icon"
-                android:layout_toStartOf="@id/cancel_search_button"
+                android:layout_toStartOf="@+id/cancel_search_button"
                 android:paddingStart="10dip"
                 android:text="@string/search_overlay_title"
                 android:textAppearance="?android:attr/textAppearanceSmall" />

--- a/stardroid-v1/app/src/main/res/layout/skyrenderer.xml
+++ b/stardroid-v1/app/src/main/res/layout/skyrenderer.xml
@@ -40,15 +40,17 @@
                 android:layout_width="34dip"
                 android:layout_height="wrap_content"
                 android:paddingTop="10dip"
+                android:layout_alignParentStart="true"
                 android:src="@drawable/search_lens_very_small" />
 
             <TextView
                 android:id="@+id/search_status_label"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="2dip"
-                android:layout_toRightOf="@id/search_icon"
-                android:paddingLeft="10dip"
+                android:layout_marginStart="2dip"
+                android:layout_toEndOf="@id/search_icon"
+                android:layout_toStartOf="@id/cancel_search_button"
+                android:paddingStart="10dip"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
             <TextView
@@ -56,8 +58,9 @@
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/search_status_label"
-                android:layout_toRightOf="@id/search_icon"
-                android:paddingLeft="10dip"
+                android:layout_toEndOf="@id/search_icon"
+                android:layout_toStartOf="@id/cancel_search_button"
+                android:paddingStart="10dip"
                 android:text="@string/search_overlay_title"
                 android:textAppearance="?android:attr/textAppearanceSmall" />
 
@@ -65,8 +68,8 @@
                 android:id="@+id/cancel_search_button"
                 android:layout_width="48dip"
                 android:layout_height="48dip"
-                android:layout_alignParentRight="true"
-                android:layout_marginRight="8dip"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="8dip"
                 android:background="@android:color/transparent"
                 android:clickable="true"
                 android:padding="8dip"

--- a/stardroid-v1/app/src/main/res/layout/time_player.xml
+++ b/stardroid-v1/app/src/main/res/layout/time_player.xml
@@ -38,7 +38,7 @@
     android:layout_height="wrap_content"
     android:text="Time travel: Fill in label ..."
     android:layout_toEndOf="@id/time_travel_icon"
-    android:layout_toStartOf="@id/time_player_close"
+    android:layout_toStartOf="@+id/time_player_close"
     android:paddingStart="10dip"
     android:textAppearance="?android:attr/textAppearanceMedium"
     android:layout_marginStart="2dip"
@@ -51,7 +51,7 @@
     android:text="Fill in today's date ..."
     android:layout_below="@id/time_travel_status_label"
     android:layout_toEndOf="@id/time_travel_icon"
-    android:layout_toStartOf="@id/time_player_close"
+    android:layout_toStartOf="@+id/time_player_close"
     android:paddingStart="10dip"
     android:textAppearance="?android:attr/textAppearanceSmall"
     />

--- a/stardroid-v1/app/src/main/res/layout/time_player.xml
+++ b/stardroid-v1/app/src/main/res/layout/time_player.xml
@@ -29,6 +29,7 @@
     android:layout_width="34dip"
     android:layout_height="wrap_content"
     android:src="@drawable/time_travel_small_icon"
+    android:layout_alignParentStart="true"
     android:paddingTop="10dip"/>
 
   <TextView
@@ -36,10 +37,11 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:text="Time travel: Fill in label ..."
-    android:layout_toRightOf="@id/time_travel_icon"
-    android:paddingLeft="10dip"
+    android:layout_toEndOf="@id/time_travel_icon"
+    android:layout_toStartOf="@id/time_player_close"
+    android:paddingStart="10dip"
     android:textAppearance="?android:attr/textAppearanceMedium"
-    android:layout_marginLeft="2dip"
+    android:layout_marginStart="2dip"
     />
 
   <TextView
@@ -48,8 +50,9 @@
     android:layout_height="wrap_content"
     android:text="Fill in today's date ..."
     android:layout_below="@id/time_travel_status_label"
-    android:layout_toRightOf="@id/time_travel_icon"
-    android:paddingLeft="10dip"
+    android:layout_toEndOf="@id/time_travel_icon"
+    android:layout_toStartOf="@id/time_player_close"
+    android:paddingStart="10dip"
     android:textAppearance="?android:attr/textAppearanceSmall"
     />
 
@@ -62,8 +65,8 @@
     android:padding="8dip"
     android:scaleType="centerInside"
     android:src="@drawable/time_travel_close"
-    android:layout_alignParentRight="true"
-    android:layout_marginRight="8dip"
+    android:layout_alignParentEnd="true"
+    android:layout_marginEnd="8dip"
     />
   </RelativeLayout>
 
@@ -85,8 +88,8 @@
     android:layout_width="32dip"
     android:layout_height="32dip"
     android:src="@drawable/timetravel_back_btn"
-    android:layout_marginLeft="5dip"
-    android:layout_marginRight="18dip"
+    android:layout_marginStart="5dip"
+    android:layout_marginEnd="18dip"
     android:layout_marginBottom="3dip"
     />
 
@@ -97,7 +100,7 @@
     android:layout_width="32dip"
     android:layout_height="32dip"
     android:src="@drawable/timetravel_stop_btn"
-    android:layout_marginRight="18dip"
+    android:layout_marginEnd="18dip"
     android:layout_marginBottom="1dip"
     />
 
@@ -108,7 +111,7 @@
     android:layout_width="32dip"
     android:layout_height="32dip"
     android:src="@drawable/timetravel_fwd_btn"
-    android:layout_marginRight="1dip"
+    android:layout_marginEnd="1dip"
     android:layout_marginBottom="3dip"
     />
 
@@ -118,7 +121,7 @@
     android:layout_height="wrap_content"
     android:text="Traveling @ 1 day/sec"
     android:textAppearance="?android:attr/textAppearanceSmall"
-    android:paddingLeft="8dip"
+    android:paddingStart="8dip"
     android:paddingBottom="10dip"
     />
 


### PR DESCRIPTION
## Description

Arabic and other RTL languages had a bad UX which I only just noticed with the new screen grabs.

## Type of Change

- [x] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
