### PR TITLE
Use Coil for async image loading in WarmWelcome slides

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
@@ -19,6 +19,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
+import coil.load
 import com.google.android.stardroid.ApplicationConstants
 import com.google.android.stardroid.R
 import com.google.android.stardroid.StardroidApplication
@@ -202,15 +203,10 @@ class WarmWelcomeActivity : AppCompatActivity() {
 
         override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
             super.onViewCreated(view, savedInstanceState)
-            val bgView = view.findViewById<ImageView>(R.id.slide2_background)
-            try {
-                requireContext().assets.open("celestial_images/deep_sky_objects/hubble_m1.jpg").use { istr ->
-                    val drawable = android.graphics.drawable.Drawable.createFromStream(istr, null)
-                    bgView.setImageDrawable(drawable)
+            view.findViewById<ImageView>(R.id.slide2_background)
+                .load("file:///android_asset/celestial_images/deep_sky_objects/hubble_m1.jpg") {
+                    crossfade(true)
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
         }
     }
 
@@ -221,15 +217,10 @@ class WarmWelcomeActivity : AppCompatActivity() {
             inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
         ): View {
             val view = inflater.inflate(R.layout.fragment_welcome_slide_3, container, false)
-            val bgView = view.findViewById<ImageView>(R.id.slide3_background)
-            try {
-                requireContext().assets.open("celestial_images/planets/cassini_iapetus.webp").use { istr ->
-                    val drawable = android.graphics.drawable.Drawable.createFromStream(istr, null)
-                    bgView.setImageDrawable(drawable)
+            view.findViewById<ImageView>(R.id.slide3_background)
+                .load("file:///android_asset/celestial_images/planets/cassini_iapetus.webp") {
+                    crossfade(true)
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
 
             val compassIcon = view.findViewById<ImageView>(R.id.compass_status_icon)
             val accelIcon = view.findViewById<ImageView>(R.id.accelerometer_status_icon)


### PR DESCRIPTION
## Summary

- Slides 2 and 3 of `WarmWelcomeActivity` previously loaded celestial images synchronously on the main thread via `assets.open()` → `Drawable.createFromStream()`, risking UI jank during ViewPager transitions
- Replaced with Coil's asset URI scheme (`file:///android_asset/...`) which decodes off-thread and fades in via `crossfade(true)`
- Coil was already a dependency (used for map tiles in `StadiaMapsAdapter`) so no new library added

## Test plan

- [ ] Open the app fresh (or clear the warm welcome pref) to trigger the welcome flow
- [ ] Swipe to slide 2 — Hubble M1 image should load with a crossfade, no jank on transition
- [ ] Swipe to slide 3 — Iapetus image should load with a crossfade; sensor status icons animate in as before
- [ ] Verify on a low-end device / slow emulator that transitions feel smooth compared to before
- [ ] Rotate the device on slide 2 and 3 — images should reload cleanly without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)