### PR TITLE
Update dependencies to latest stable versions

### DIFF
--- a/stardroid-v1/app/build.gradle
+++ b/stardroid-v1/app/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'com.android.application' version '8.13.2'
-    id 'org.jetbrains.kotlin.android' version '2.0.20'
-    id 'org.jetbrains.kotlin.kapt' version '2.0.20'
-    id 'org.jetbrains.kotlin.plugin.parcelize' version '2.0.20'
-    id 'com.google.dagger.hilt.android' version '2.48'
+    id 'org.jetbrains.kotlin.android' version '2.1.21'
+    id 'org.jetbrains.kotlin.kapt' version '2.1.21'
+    id 'org.jetbrains.kotlin.plugin.parcelize' version '2.1.21'
+    id 'com.google.dagger.hilt.android' version '2.56.2'
 }
 
 
@@ -143,19 +143,19 @@ dependencies {
     implementation "androidx.appcompat:appcompat-resources:$appcompat_version"
     implementation 'androidx.preference:preference-ktx:1.2.1'
     implementation "androidx.viewpager2:viewpager2:1.1.0"
-    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+    implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation "androidx.core:core-ktx:1.15.0"
 
 // Third-party
     implementation 'com.google.guava:guava:33.3.1-jre'
-    def dagger_version = "2.48"
+    def dagger_version = "2.56.2"
     implementation "com.google.dagger:hilt-android:$dagger_version"
     kapt "com.google.dagger:hilt-android-compiler:$dagger_version"
     // For annotations not in Android but needed by Dagger
     implementation 'javax.annotation:jsr250-api:1.0'
     // Lite version for Android - it's lighter (obviously) but also doesn't use reflection
     // which can cause no end of problems with minifiers like proguard.
-    implementation 'com.google.protobuf:protobuf-javalite:3.13.0'
+    implementation 'com.google.protobuf:protobuf-javalite:4.28.3'
 
     // Image loading and caching
     implementation "io.coil-kt:coil:2.7.0"
@@ -170,7 +170,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.14.2'
     testImplementation 'org.robolectric:robolectric:4.14.1'
     testImplementation 'org.easymock:easymock:2.5.2'
-    testImplementation 'com.google.truth:truth:1.0.1'
+    testImplementation 'com.google.truth:truth:1.4.4'
     androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'org.easymock:easymock:2.5.2'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'

--- a/stardroid-v1/datamodel/build.gradle
+++ b/stardroid-v1/datamodel/build.gradle
@@ -11,13 +11,13 @@ plugins {
 //compileSdkVersion 26
 
 dependencies {
-    implementation 'com.google.protobuf:protobuf-javalite:3.13.0'
+    implementation 'com.google.protobuf:protobuf-javalite:4.28.3'
 }
 
 protobuf {
     protoc {
         // Download from repositories
-        artifact = 'com.google.protobuf:protoc:3.13.0'
+        artifact = 'com.google.protobuf:protoc:4.28.3'
     }
 
     generateProtoTasks {

--- a/stardroid-v1/tools/build.gradle
+++ b/stardroid-v1/tools/build.gradle
@@ -19,15 +19,15 @@ sourceSets {
 protobuf {
     protoc {
         // Download from repositories
-        artifact = 'com.google.protobuf:protoc:3.13.0'
+        artifact = 'com.google.protobuf:protoc:4.28.3'
     }
 }
 
 dependencies {
     // Unlike the Android App which should only use the lite version of protos we need the full
     // version here as we need TextFormat which doesn't exist in the lite app.
-    implementation 'com.google.protobuf:protobuf-java:3.13.0'
-    implementation 'com.google.guava:guava:24.1-jre'
+    implementation 'com.google.protobuf:protobuf-java:4.28.3'
+    implementation 'com.google.guava:guava:33.3.1-jre'
 }
 
 // Gradle fail.  Creating multiple distributions in a distributions {} does not generate


### PR DESCRIPTION
Update several outdated dependencies to their latest stable versions:

- Kotlin plugins (android/kapt/parcelize): 2.0.20 → 2.1.21
- Hilt/Dagger (plugin + deps): 2.48 → 2.56.2
- protobuf: 3.13.0 → 4.28.3
- guava (tools): 24.1-jre → 33.3.1-jre
- truth (test): 1.0.1 → 1.4.4
- constraintlayout: 2.1.4 → 2.2.1

Coil 2→3 and EasyMock 2→5 are left for separate migration work due to breaking API changes.

Fixes #874

Generated with [Claude Code](https://claude.ai/code)