### PR TITLE
Guard external startActivity calls in Credits/Eula/Help dialog WebViews

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
@@ -65,8 +65,8 @@ public class CreditsDialogFragment extends DialogFragment {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         try {
           parentActivity.startActivity(intent);
-        } catch (android.content.ActivityNotFoundException e) {
-          android.util.Log.w("CreditsDialogFragment", "No handler for " + url, e);
+        } catch (ActivityNotFoundException e) {
+          Log.w(TAG, "No handler for " + url, e);
         }
         return true;
       }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
@@ -63,7 +63,11 @@ public class CreditsDialogFragment extends DialogFragment {
       @Override
       public boolean shouldOverrideUrlLoading(WebView view, String url) {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        parentActivity.startActivity(intent);
+        try {
+          parentActivity.startActivity(intent);
+        } catch (android.content.ActivityNotFoundException e) {
+          android.util.Log.w("CreditsDialogFragment", "No handler for " + url, e);
+        }
         return true;
       }
     });

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
@@ -65,7 +65,7 @@ public class CreditsDialogFragment extends DialogFragment {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         try {
           parentActivity.startActivity(intent);
-        } catch (ActivityNotFoundException e) {
+        } catch (android.content.ActivityNotFoundException e) {
           Log.w(TAG, "No handler for " + url, e);
         }
         return true;

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
@@ -128,7 +128,7 @@ public class EulaDialogFragment extends DialogFragment {
           Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
           try {
             parentActivity.startActivity(intent);
-          } catch (ActivityNotFoundException e) {
+          } catch (android.content.ActivityNotFoundException e) {
             Log.w(TAG, "No handler for " + url, e);
           }
           return true;

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
@@ -128,8 +128,8 @@ public class EulaDialogFragment extends DialogFragment {
           Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
           try {
             parentActivity.startActivity(intent);
-          } catch (android.content.ActivityNotFoundException e) {
-            android.util.Log.w("EulaDialogFragment", "No handler for " + url, e);
+          } catch (ActivityNotFoundException e) {
+            Log.w(TAG, "No handler for " + url, e);
           }
           return true;
         }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
@@ -126,7 +126,11 @@ public class EulaDialogFragment extends DialogFragment {
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
           // Open links in external browser
           Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-          parentActivity.startActivity(intent);
+          try {
+            parentActivity.startActivity(intent);
+          } catch (android.content.ActivityNotFoundException e) {
+            android.util.Log.w("EulaDialogFragment", "No handler for " + url, e);
+          }
           return true;
         }
       });

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
@@ -76,8 +76,8 @@ public class HelpDialogFragment extends DialogFragment {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         try {
           activity.startActivity(intent);
-        } catch (android.content.ActivityNotFoundException e) {
-          android.util.Log.w("HelpDialogFragment", "No handler for " + url, e);
+        } catch (ActivityNotFoundException e) {
+          Log.w(TAG, "No handler for " + url, e);
         }
         return true;
       }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
@@ -74,7 +74,11 @@ public class HelpDialogFragment extends DialogFragment {
       public boolean shouldOverrideUrlLoading(WebView view, String url) {
         // Open links in external browser
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        activity.startActivity(intent);
+        try {
+          activity.startActivity(intent);
+        } catch (android.content.ActivityNotFoundException e) {
+          android.util.Log.w("HelpDialogFragment", "No handler for " + url, e);
+        }
         return true;
       }
     });

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
@@ -76,7 +76,7 @@ public class HelpDialogFragment extends DialogFragment {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         try {
           activity.startActivity(intent);
-        } catch (ActivityNotFoundException e) {
+        } catch (android.content.ActivityNotFoundException e) {
           Log.w(TAG, "No handler for " + url, e);
         }
         return true;


### PR DESCRIPTION
Closes #876.

`CreditsDialogFragment`, `EulaDialogFragment` and `HelpDialogFragment` each host a small WebView for the bundled credits / EULA / help HTML. Their `shouldOverrideUrlLoading` overrides route every link tap to `Intent.ACTION_VIEW` without a try/catch:

```java
public boolean shouldOverrideUrlLoading(WebView view, String url) {
  Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
  parentActivity.startActivity(intent);
  return true;
}
```

If the HTML body ever contains a link whose scheme has no installed handler on the device (`mailto:` on a device with no mail app, `sms:`, custom dependency-specific schemes), `startActivity` raises `ActivityNotFoundException` and the host activity crashes.

### Change

Wrap the three `startActivity` calls in `try { ... } catch (ActivityNotFoundException e)` and log a warning via `android.util.Log.w` instead of crashing.

Branch follows the `AGENTS.md` `feature/<short-description>` convention.
