### PR TITLE
Replace fully qualified class names with imports

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/StardroidApplication.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/StardroidApplication.kt
@@ -109,12 +109,12 @@ open class StardroidApplication : Application() {
         newUser = true
       }
     }
-    analytics.setUserProperty(AnalyticsInterface.NEW_USER, java.lang.Boolean.toString(newUser))
+    analytics.setUserProperty(AnalyticsInterface.NEW_USER, newUser.toString())
     if (newUser) {
       analytics.setUserProperty(AnalyticsInterface.FIRST_INSTALL_VERSION, versionName)
     }
     analytics.setUserProperty(AnalyticsInterface.USER_LOCALE,
-        java.util.Locale.getDefault().toLanguageTag())
+        Locale.getDefault().toLanguageTag())
     preferences.edit().putString(PREVIOUS_APP_VERSION_PREF, versionName).apply()
     if (previousVersion != versionName) {
       // It's either an upgrade or a new installation

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/CompassCalibrationActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/CompassCalibrationActivity.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.text.Html;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.CheckBox;
@@ -59,7 +60,7 @@ public class CompassCalibrationActivity extends androidx.fragment.app.FragmentAc
     setContentView(R.layout.activity_compass_calibration);
     EdgeToEdgeFixer.applyEdgeToEdgeFixForActionBarActivity(this);
     webView = findViewById(R.id.compass_calib_activity_webview);
-    android.webkit.WebSettings webSettings = webView.getSettings();
+    WebSettings webSettings = webView.getSettings();
     webSettings.setJavaScriptEnabled(true);
     webView.setWebViewClient(new WebViewClient() {
       @Override

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -44,6 +44,7 @@ import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -431,7 +432,7 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
       if (timePlayerUI instanceof ViewGroup group) {
         for (int i = 0; i < group.getChildCount(); i++) {
           View child = group.getChildAt(i);
-          if (child instanceof android.widget.RelativeLayout) {
+          if (child instanceof RelativeLayout) {
             child.setBackgroundColor(nightMode ? getColor(R.color.night_bar_bg) : getColor(R.color.day_bar_bg));
           }
         }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
@@ -5,6 +5,8 @@ import android.hardware.Sensor
 import android.hardware.SensorManager
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.Vibrator
 import android.os.VibrationEffect
 import android.util.Log
@@ -214,7 +216,7 @@ class WarmWelcomeActivity : AppCompatActivity(), WhatsNewDialogFragment.CloseLis
         fun onSelected();
     }
     class Slide1Fragment : Fragment() {
-        private val handler = android.os.Handler(android.os.Looper.getMainLooper())
+        private val handler = Handler(Looper.getMainLooper())
         private var currentIndex = 0
         private val highlightGroups = intArrayOf(
             R.id.highlight_stars,
@@ -300,7 +302,7 @@ class WarmWelcomeActivity : AppCompatActivity(), WhatsNewDialogFragment.CloseLis
         private lateinit var gyroSpinner: View
         private lateinit var accelSpinner: View
         private lateinit var compassSpinner: View
-        private val handler = android.os.Handler(android.os.Looper.getMainLooper())
+        private val handler = Handler(Looper.getMainLooper())
         private var hasCompass = false
         private var hasAccel = false
         private var hasGyro = false

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/AcquiringLocationTimeoutDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/AcquiringLocationTimeoutDialogFragment.kt
@@ -4,7 +4,7 @@ import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
-import Button
+import android.widget.Button
 import com.google.android.stardroid.R
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/AcquiringLocationTimeoutDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/AcquiringLocationTimeoutDialogFragment.kt
@@ -1,8 +1,10 @@
 package com.google.android.stardroid.activities.dialogs
 
+import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
+import Button
 import com.google.android.stardroid.R
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -20,17 +22,17 @@ class AcquiringLocationTimeoutDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val view = LayoutInflater.from(requireContext())
             .inflate(R.layout.dialog_acquiring_timeout, null)
-        view.findViewById<android.widget.Button>(R.id.acquiring_keep_waiting_button)
+        view.findViewById<Button>(R.id.acquiring_keep_waiting_button)
             .setOnClickListener {
                 dismiss()
                 onKeepWaiting?.invoke()
             }
-        view.findViewById<android.widget.Button>(R.id.acquiring_enter_manually_button)
+        view.findViewById<Button>(R.id.acquiring_enter_manually_button)
             .setOnClickListener {
                 dismiss()
                 onEnterManually?.invoke()
             }
-        return android.app.AlertDialog.Builder(requireContext())
+        return AlertDialog.Builder(requireContext())
             .setTitle(R.string.location_acquiring_title)
             .setView(view)
             .create()

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/LocationPermissionPermanentlyDeniedDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/LocationPermissionPermanentlyDeniedDialogFragment.kt
@@ -7,7 +7,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
 import android.view.LayoutInflater
-import Button
+import android.widget.Button
 import com.google.android.stardroid.R
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/LocationPermissionPermanentlyDeniedDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/LocationPermissionPermanentlyDeniedDialogFragment.kt
@@ -1,11 +1,13 @@
 package com.google.android.stardroid.activities.dialogs
 
+import android.app.AlertDialog
 import android.app.Dialog
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
 import android.view.LayoutInflater
+import Button
 import com.google.android.stardroid.R
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -20,7 +22,7 @@ class LocationPermissionPermanentlyDeniedDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val view = LayoutInflater.from(requireContext())
             .inflate(R.layout.dialog_location_permanently_denied, null)
-        view.findViewById<android.widget.Button>(R.id.permanently_denied_settings_button)
+        view.findViewById<Button>(R.id.permanently_denied_settings_button)
             .setOnClickListener {
                 dismiss()
                 startActivity(
@@ -29,12 +31,12 @@ class LocationPermissionPermanentlyDeniedDialogFragment : DialogFragment() {
                     }
                 )
             }
-        view.findViewById<android.widget.Button>(R.id.permanently_denied_manually_button)
+        view.findViewById<Button>(R.id.permanently_denied_manually_button)
             .setOnClickListener {
                 dismiss()
                 onEnterManually?.invoke()
             }
-        return android.app.AlertDialog.Builder(requireContext())
+        return AlertDialog.Builder(requireContext())
             .setTitle(R.string.location_permanently_denied_title)
             .setView(view)
             .create()

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/LocationPermissionRationaleDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/LocationPermissionRationaleDialogFragment.kt
@@ -4,7 +4,7 @@ import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
-import Button
+import android.widget.Button
 import com.google.android.stardroid.R
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/LocationPermissionRationaleDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/LocationPermissionRationaleDialogFragment.kt
@@ -1,8 +1,10 @@
 package com.google.android.stardroid.activities.dialogs
 
+import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
+import Button
 import com.google.android.stardroid.R
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -23,19 +25,19 @@ class LocationPermissionRationaleDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val view = LayoutInflater.from(requireContext())
             .inflate(R.layout.dialog_location_rationale, null)
-        view.findViewById<android.widget.Button>(R.id.rationale_grant_button).setOnClickListener {
+        view.findViewById<Button>(R.id.rationale_grant_button).setOnClickListener {
             dismiss()
             onGrant?.invoke()
         }
-        view.findViewById<android.widget.Button>(R.id.rationale_manually_button).setOnClickListener {
+        view.findViewById<Button>(R.id.rationale_manually_button).setOnClickListener {
             dismiss()
             onEnterManually?.invoke()
         }
-        view.findViewById<android.widget.Button>(R.id.rationale_later_button).setOnClickListener {
+        view.findViewById<Button>(R.id.rationale_later_button).setOnClickListener {
             dismiss()
             onLater?.invoke()
         }
-        return android.app.AlertDialog.Builder(requireContext())
+        return AlertDialog.Builder(requireContext())
             .setTitle(R.string.location_permission_dialog_title)
             .setView(view)
             .create()

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
@@ -1,5 +1,6 @@
 package com.google.android.stardroid.activities.dialogs
 
+import android.app.AlertDialog
 import android.app.Dialog
 import android.location.Geocoder
 import android.os.Bundle
@@ -14,6 +15,8 @@ import com.google.android.stardroid.control.LocationController
 import com.google.android.stardroid.math.LatLong
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.IOException
+import java.text.NumberFormat
+import java.text.ParsePosition
 import java.util.concurrent.ScheduledExecutorService
 import javax.inject.Inject
 
@@ -62,7 +65,7 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
             trySetLocation()
         }
 
-        return android.app.AlertDialog.Builder(requireContext())
+        return AlertDialog.Builder(requireContext())
             .setTitle(R.string.location_manual_entry_title)
             .setView(view)
             .create()
@@ -118,8 +121,8 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
     }
 
     private fun parseCoordinate(str: String): Float? {
-        val format = java.text.NumberFormat.getInstance()
-        val pos = java.text.ParsePosition(0)
+        val format = NumberFormat.getInstance()
+        val pos = ParsePosition(0)
         val number = format.parse(str, pos)
         if (pos.index == str.length && pos.errorIndex == -1 && number != null) {
             return number.toFloat()

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ObjectInfoDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ObjectInfoDialogFragment.kt
@@ -19,6 +19,7 @@ import android.graphics.PorterDuff
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
@@ -179,7 +180,7 @@ class ObjectInfoDialogFragment : DialogFragment() {
                         if (isNight) R.color.night_link_color
                         else R.color.day_link_color
                     ))
-                    val outValue = android.util.TypedValue()
+                    val outValue = TypedValue()
                     parentActivity.theme.resolveAttribute(
                         android.R.attr.selectableItemBackground, outValue, true)
                     setBackgroundResource(outValue.resourceId)

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/EdgeToEdgeFixer.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/EdgeToEdgeFixer.java
@@ -16,6 +16,7 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.util.TypedValue;
 import android.view.View;
+import android.view.ViewGroup;
 
 import com.google.android.stardroid.R;
 
@@ -105,8 +106,8 @@ public class EdgeToEdgeFixer {
 
     // For scrollable content (like ListView in PreferenceFragment), disable clip to padding
     // so content scrolls under the padding area
-    if (contentView instanceof android.view.ViewGroup) {
-      ((android.view.ViewGroup) contentView).setClipToPadding(false);
+    if (contentView instanceof ViewGroup) {
+      ((ViewGroup) contentView).setClipToPadding(false);
     }
   }
 }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/TooltipUtil.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/TooltipUtil.kt
@@ -1,5 +1,6 @@
 package com.google.android.stardroid.activities.util
 
+import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.widget.Toast
@@ -34,7 +35,7 @@ object TooltipUtil {
             when (position) {
                 Position.RIGHT -> xOffset += v.width
                 Position.BELOW -> yOffset += v.height
-                else -> android.util.Log.w("TooltipUtil", "Unknown position: $position")
+                else -> Log.w("TooltipUtil", "Unknown position: $position")
             }
 
             // Note that the gravity setting will be ignored on recent API levels (30+),

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/CometsLayer.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/CometsLayer.kt
@@ -107,7 +107,7 @@ class CometsLayer(private val model: AstronomerModel, resources: Resources,
       val zValues = mutableListOf<Float>()
       val mags = mutableListOf<Float>()
       for (entry in positions) {
-        if (entry.date.before(previous)) throw java.lang.IllegalStateException(
+        if (entry.date.before(previous)) throw IllegalStateException(
           "Comet dates not " +
               "in ascending order"
         )

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderables/ImagePrimitive.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderables/ImagePrimitive.java
@@ -19,6 +19,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.BitmapFactory.Options;
 import android.graphics.Color;
+import android.util.Log;
 
 import com.google.android.stardroid.math.CoordinateManipulationsKt;
 import com.google.android.stardroid.math.Vector3;
@@ -91,7 +92,7 @@ public class ImagePrimitive extends AbstractPrimitive {
 
     Bitmap newImage = BitmapFactory.decodeResource(resources, imageId, opts);
     if (newImage == null) {
-      android.util.Log.e("ImagePrimitive", "Could not decode image " + imageId);
+      Log.e("ImagePrimitive", "Could not decode image " + imageId);
       return;
     }
     this.image = newImage;

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderer/SkyRenderer.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderer/SkyRenderer.java
@@ -17,6 +17,7 @@ package com.google.android.stardroid.renderer;
 import android.content.res.Resources;
 import android.opengl.GLSurfaceView;
 import android.opengl.GLU;
+import android.os.Build;
 import android.util.Log;
 
 import com.google.android.stardroid.math.MathUtils;
@@ -177,12 +178,12 @@ public class SkyRenderer implements GLSurfaceView.Renderer {
         "Behold",
     };
     for (String model : badModels) {
-      if (android.os.Build.MODEL.contains(model)) {
+      if (Build.MODEL.contains(model)) {
         canUseVBO = false;
         break;
       }
     }
-    Log.i("SkyRenderer", "Model: " + android.os.Build.MODEL);
+    Log.i("SkyRenderer", "Model: " + Build.MODEL);
     Log.i("SkyRenderer", canUseVBO ? "VBOs enabled" : "VBOs disabled");
     GLBuffer.setCanUseVBO(canUseVBO);
 

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/views/PreferencesButton.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/views/PreferencesButton.java
@@ -34,7 +34,7 @@ import com.google.android.stardroid.util.AnalyticsInterface;
 import com.google.android.stardroid.util.MiscUtil;
 
 public class PreferencesButton extends ImageButton
-    implements android.view.View.OnClickListener, OnSharedPreferenceChangeListener {
+    implements View.OnClickListener, OnSharedPreferenceChangeListener {
   private static final String TAG = MiscUtil.getTag(PreferencesButton.class);
   private static AnalyticsInterface analytics;
   private OnClickListener secondaryOnClickListener;


### PR DESCRIPTION
Replaces inline fully qualified class names with proper import statements across 15 files. Adds missing imports and removes package prefixes from usages in method bodies and class declarations.

Fixes #878

Generated with [Claude Code](https://claude.ai/code)