### PR TITLE
Fix WarmWelcome vibration not firing with touch feedback disabled

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/ApplicationModule.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/ApplicationModule.kt
@@ -110,6 +110,7 @@ class ApplicationModule {
   fun provideVibrator(@ApplicationContext context: Context) =
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         context.getSystemService<VibratorManager>()?.defaultVibrator
+            ?: @Suppress("DEPRECATION") context.getSystemService<android.os.Vibrator>()
       } else {
         @Suppress("DEPRECATION")
         context.getSystemService<android.os.Vibrator>()

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/ApplicationModule.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/ApplicationModule.kt
@@ -8,7 +8,9 @@ import android.content.res.Resources
 import android.hardware.SensorManager
 import android.location.LocationManager
 import android.net.ConnectivityManager
+import android.os.Build
 import android.os.PowerManager
+import android.os.VibratorManager
 import android.util.Log
 import androidx.core.content.getSystemService
 import androidx.preference.PreferenceManager
@@ -106,7 +108,12 @@ class ApplicationModule {
   @Provides
   @Singleton
   fun provideVibrator(@ApplicationContext context: Context) =
-      context.getSystemService<android.os.Vibrator>()
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        context.getSystemService<VibratorManager>()?.defaultVibrator
+      } else {
+        @Suppress("DEPRECATION")
+        context.getSystemService<android.os.Vibrator>()
+      }
 
   @Provides
   @Singleton

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
@@ -7,8 +7,10 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.os.Vibrator
+import android.os.VibrationAttributes
 import android.os.VibrationEffect
+import android.os.Vibrator
+import android.media.AudioAttributes
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -189,15 +191,34 @@ class WarmWelcomeActivity : AppCompatActivity(), WhatsNewDialogFragment.CloseLis
     fun buzz(happy: Boolean) {
         val v = vibrator ?: return
         if (!v.hasVibrator()) return
-        val effect = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val effect = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val effectId = if (happy) VibrationEffect.EFFECT_CLICK else VibrationEffect.EFFECT_DOUBLE_CLICK
-            VibrationEffect.createPredefined(effectId)
+            if (v.areEffectsSupported(effectId)[0] == Vibrator.VIBRATION_EFFECT_SUPPORT_YES) {
+                VibrationEffect.createPredefined(effectId)
+            } else {
+                buzzFallback(happy)
+            }
         } else {
-            if (happy) VibrationEffect.createOneShot(50, VibrationEffect.DEFAULT_AMPLITUDE)
-            else VibrationEffect.createWaveform(longArrayOf(0, 80, 80, 80), -1)
+            buzzFallback(happy)
         }
-        v.vibrate(effect)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val attrs = VibrationAttributes.Builder()
+                .setUsage(VibrationAttributes.USAGE_NOTIFICATION)
+                .build()
+            v.vibrate(effect, attrs)
+        } else {
+            val attrs = AudioAttributes.Builder()
+                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                .setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
+                .build()
+            @Suppress("DEPRECATION")
+            v.vibrate(effect, attrs)
+        }
     }
+
+    private fun buzzFallback(happy: Boolean) =
+        if (happy) VibrationEffect.createOneShot(50, VibrationEffect.DEFAULT_AMPLITUDE)
+        else VibrationEffect.createWaveform(longArrayOf(0, 80, 80, 80), -1)
 
     private class WelcomePagerAdapter(fa: AppCompatActivity) : FragmentStateAdapter(fa) {
         override fun createFragment(position: Int): Fragment {


### PR DESCRIPTION
## Summary

- Vibrate using `VibrationAttributes.USAGE_NOTIFICATION` (API 33+) / `AudioAttributes.USAGE_NOTIFICATION_EVENT` (API 26–32) so the sensor-check buzz is not silenced by the system "Touch feedback" / "Haptic feedback" toggle — matching behaviour of apps like Duolingo that vibrate on meaningful events
- Check `areEffectsSupported()` before using predefined haptic effects, which silently no-op on hardware that doesn't support them, falling back to `createOneShot`/`createWaveform`
- Obtain `Vibrator` via `VibratorManager.defaultVibrator` on API 31+ where `getSystemService<Vibrator>()` is deprecated and can return a stub

## Test plan

- [ ] Go through WarmWelcome sensor check slides with "Touch feedback" **off** in Settings → Sound & Vibration → Vibration & Haptics — buzz should fire on each sensor slide
- [ ] Repeat with "Touch feedback" **on** — buzz should still fire
- [ ] Test on a device/emulator running API < 31 to exercise the legacy Vibrator path

🤖 Generated with [Claude Code](https://claude.com/claude-code)