### PR TITLE
Guard external startActivity in WhatsNewDialogFragment WebView

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/WhatsNewDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/WhatsNewDialogFragment.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.webkit.WebView;
@@ -89,7 +90,11 @@ public class WhatsNewDialogFragment extends DialogFragment {
       public boolean shouldOverrideUrlLoading(WebView view, String url) {
         // Open links in external browser
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        parentActivity.startActivity(intent);
+        try {
+          parentActivity.startActivity(intent);
+        } catch (android.content.ActivityNotFoundException e) {
+          Log.w(TAG, "No handler for " + url, e);
+        }
         return true;
       }
     });


### PR DESCRIPTION
Closes #891.

`WhatsNewDialogFragment` calls `parentActivity.startActivity(intent)` directly inside its WebView's `shouldOverrideUrlLoading`. If no installed app can handle `Intent.ACTION_VIEW` for the URL, it raises `ActivityNotFoundException` and the dialog's host activity crashes. The other three dialog fragments (Credits, EULA, Help) were fixed in #877, but this one was missed.

This applies the same try / catch wrap and `Log.w(TAG, "No handler for " + url, e)` pattern used in #877. `TAG` is already declared on this class.

```diff
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
@@
     webView.setWebViewClient(new WebViewClient() {
       @Override
       public boolean shouldOverrideUrlLoading(WebView view, String url) {
         // Open links in external browser
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        parentActivity.startActivity(intent);
+        try {
+          parentActivity.startActivity(intent);
+        } catch (android.content.ActivityNotFoundException e) {
+          Log.w(TAG, "No handler for " + url, e);
+        }
         return true;
       }
     });
```

Nothing else moves.