### PR TITLE
Fix pre-existing German locale validation errors

### DIFF
--- a/stardroid-v1/app/src/main/res/values-de/credits.xml
+++ b/stardroid-v1/app/src/main/res/values-de/credits.xml
@@ -54,6 +54,8 @@ Lior Ron.&lt;/p&gt;
 &lt;li&gt;Sternbildkarten: IAU und Sky &amp; Telescope (Roger Sinnott &amp; Rick Fienberg), CC BY 4.0&lt;/li&gt;
 &lt;li&gt;Zusätzliche Messier-Bilder: Gemini Observatory/NOIRLab/NSF/AURA (&lt;a href="https://noirlab.edu/"&gt;noirlab.edu&lt;/a&gt;)&lt;/li&gt;
 &lt;li&gt;M31-Bild: Peter Kennett (&lt;a href="https://commons.wikimedia.org/wiki/File:M31(Kennett).jpg"&gt;Wikimedia Commons&lt;/a&gt;)&lt;/li&gt;
+&lt;li&gt;Sagittarius A* Bild: EHT Collaboration (&lt;a href="https://www.eso.org/public/images/eso2208-eht-mwa/"&gt;eso.org&lt;/a&gt;), CC BY 4.0&lt;/li&gt;
+&lt;li&gt;Cygnus X-1 Illustration: NASA/CXC/M.Weiss (&lt;a href="https://chandra.harvard.edu/photo/2011/cygx1/"&gt;chandra.harvard.edu&lt;/a&gt;)&lt;/li&gt;
 &lt;/ul&gt;
     </string>
 </resources>

--- a/stardroid-v1/app/src/main/res/values-de/help.xml
+++ b/stardroid-v1/app/src/main/res/values-de/help.xml
@@ -2,106 +2,170 @@
 <resources>
 <string name="help_text" translation_description="This is the help text for the app Google Sky Map. It includes placeholders where other text is inserted. Please do not change the &lt; and &gt; markup">
     &lt;h1&gt;Sky Map für Android&lt;/h1&gt;
-&lt;p class="version"&gt;Version %s&lt;/p&gt;
-
+&lt;p class="version"&gt;Version %1$s&lt;/p&gt;
 &lt;p class="url"&gt;&lt;a href="https://stardroid.app"&gt;https://stardroid.app&lt;/a&gt;&lt;/p&gt;
 
+%4$s
+
 &lt;h2&gt;Einführung und Schnellstart&lt;/h2&gt;
-&lt;p&gt;Sky Map verwandelt Ihr Android-Handy in ein Fenster zum Nachthimmel. Sobald Sie Ihr Handy nach oben richten, sehen Sie eine Karte mit den hellsten Sternen, Konstellationen und Planeten in diesem Himmelsabschnitt.&lt;/p&gt;
-&lt;p&gt;Wenn Sie das nächste Mal einen hellen Stern sehen und wissen möchten, wie er heißt, fragen Sie einfach Sky Map!&lt;/p&gt;
+&lt;p&gt;Halte dein Telefon hoch und schau hindurch wie durch ein Fenster ins All. Sky Map nutzt Kompass, Beschleunigungssensor und Gyroskop deines Telefons, um die Richtung zu verfolgen, in die du zeigst, und die Karte in Echtzeit zu aktualisieren.&lt;/p&gt;
+&lt;p class="callout"&gt;Nicht alle Telefone können Sky Map vollständig unterstützen! Siehe den Abschnitt zu den Hardwareanforderungen unten.&lt;/p&gt;
+&lt;p&gt;Bei der ersten Nutzung:&lt;/p&gt;
+&lt;ol&gt;
+&lt;li&gt;Standortzugriff erlauben, wenn du dazu aufgefordert wirst – Sky Map benötigt deinen ungefähren Standort, um den richtigen Himmel für deinen Ort anzuzeigen&lt;/li&gt;
+&lt;li&gt;Richte dein Telefon in eine beliebige Richtung zum Himmel&lt;/li&gt;
+&lt;li&gt;Die Karte bewegt sich entsprechend der Richtung, in die du zeigst&lt;/li&gt;
+&lt;li&gt;Tippe irgendwo auf den Bildschirm, um die Steuerelemente anzuzeigen&lt;/li&gt;
+&lt;/ol&gt;
+
+&lt;h2&gt;Den Himmel erkunden&lt;/h2&gt;
+&lt;h3&gt;Automatischer Modus&lt;/h3&gt;
+&lt;p&gt;Im automatischen Modus (Standard) nutzt Sky Map die Sensoren deines Telefons, um das anzuzeigen, was in der Richtung liegt, auf die du zeigst. Bewege einfach dein Telefon und die Karte folgt.&lt;/p&gt;
+&lt;h3&gt;Manueller Modus&lt;/h3&gt;
+&lt;p&gt;Tippe auf das Sensor-/Kompass-Symbol in den Steuerelementen, um in den manuellen Modus zu wechseln. In diesem Modus kannst du:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Die Karte mit einem Finger verschieben&lt;/li&gt;
+&lt;li&gt;Mit zwei Fingern zoomen&lt;/li&gt;
+&lt;li&gt;Mit zwei Fingern drehen, um die Ausrichtung zu ändern&lt;/li&gt;
+&lt;li&gt;Doppeltippen, um den automatisch ausgerichteten Horizont ein-/auszuschalten&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Der manuelle Modus ist praktisch, wenn du den Himmel erkunden möchtest, ohne dein Telefon hochhalten zu müssen.&lt;/p&gt;
 
 &lt;h2&gt;Sichtbare Ebenen&lt;/h2&gt;
-
-&lt;p&gt;Sky Map organisiert die dargestellten Objekte in Ebenen. Mithilfe der Bildschirmsteuerelemente können Sie zwischen den Ebenen wechseln. Folgende Ebenen sind verfügbar:&lt;/p&gt;
+&lt;p&gt;Sky Map organisiert die Darstellung in Ebenen, die jeweils unabhängig ein- und ausgeschaltet werden können. Tippe auf den Bildschirm, um die Ebenensteuerung auf der Seite anzuzeigen – sie leuchten orange, wenn eine Ebene aktiv ist, und erscheinen gedimmt, wenn sie deaktiviert ist.&lt;/p&gt;
 &lt;ul&gt;
-&lt;li&gt;Sterne&lt;/li&gt;
-&lt;li&gt;Konstellationen&lt;/li&gt;
-&lt;li&gt;Messier-Objekte&lt;/li&gt;
-&lt;li&gt;Planeten&lt;/li&gt;
-&lt;li&gt;Rektazension und Deklination&lt;/li&gt;
-&lt;li&gt;Horizont und Himmelsrichtungen&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Sterne:&lt;/b&gt; Die hellsten Sterne mit Beschriftungen für bekannte Sterne&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Konstellationen:&lt;/b&gt; Sternbildumrisse und -namen&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Besondere Himmelsobjekte:&lt;/b&gt; Galaxien, Nebel, Sternhaufen und andere bemerkenswerte Objekte&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Planeten:&lt;/b&gt; Die Planeten unseres Sonnensystems als Bilder&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Meteorschauer:&lt;/b&gt; Aktive und bevorstehende Radiantenpunkte von Meteorschauern&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Ekliptik &amp; RA/Dek-Gitter:&lt;/b&gt; Die Ekliptik ist die jährliche Bahn der Sonne durch den Himmel&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Horizont:&lt;/b&gt; Die Horizontlinie und Himmelsrichtungen (N, S, O, W)&lt;/li&gt;
 &lt;/ul&gt;
-&lt;p&gt;Die hellsten Sterne und bekanntesten Konstellationen sowie die Planeten sind benannt. Die Planeten werden mit extragroßen Abbildungen dargestellt. Der Horizont wird als gerade Linie angezeigt. Sky Map zeigt Ihnen wahrscheinlich auch Objekte über der Horizontlinie, die Sie nur sehen können, wenn Ihnen keine Gebäude die Sicht versperren und die Landschaft völlig flach ist.&lt;/p&gt;
+&lt;p class="callout"&gt;&lt;b&gt;Wissenswert:&lt;/b&gt; Sky Map zeigt den geometrischen Horizont – eine vollkommen flache, unverstellte Sicht. Objekte knapp darüber können in der Praxis noch durch Gebäude, Hügel oder Bäume verdeckt sein.&lt;/p&gt;
 
-&lt;h2&gt;Bildschirmsteuerelemente&lt;/h2&gt;
-&lt;p&gt;Tippen Sie auf den Bildschirm, um die Steuerelemente anzuzeigen. Auf der einen Seite befinden sich die Umschaltflächen zum Wechseln der Ebenen. Sie sind orange, wenn die Ebenen aktiviert sind, und weiß, falls sie nicht aktiviert sind.&lt;/p&gt;
-
-&lt;p&gt;Am unteren Bildschirmrand befinden sich die Zoomsteuerelemente und eine Umschaltfläche zum Wechsel zwischen automatischem und manuellem Modus.&lt;/p&gt;
-
-&lt;h2&gt;Navigationsmodi&lt;/h2&gt;
-&lt;p&gt;Nach der Erstinstallation befindet sich Sky Map im automatischen Modus und verwendet die Sensoren des Telefons, um Ihnen eine Karte des Himmelsabschnitts zu zeigen, auf den Sie Ihr Handy richten. Durch den Wechsel in den manuellen Modus können Sie die Karte mit Ihrem Finger ziehen, um den Himmel weiter zu erforschen. Bewegen Sie den Trackball oder das Steuerkreuz nach links und rechts, um die Karte zu drehen. Auf Geräten mit Mehrfingereingabe können Sie die Karte auch mit zwei Fingern drehen und durch Auf- und Zuziehen der Finger heran- und herauszoomen.&lt;/p&gt;
+&lt;h2&gt;Bildschirmsteuerung&lt;/h2&gt;
+&lt;p&gt;Tippe irgendwo auf den Bildschirm, um die Steuerelemente ein- oder auszublenden. Auf einer Seite findest du die oben beschriebenen Ebenenregler. Auf der anderen Seite befindet sich die Schaltfläche zum Wechseln zwischen automatischem und manuellem Modus.&lt;/p&gt;
+&lt;p&gt;Die Steuerelemente blenden sich nach einigen Sekunden automatisch aus, um die Sicht freizuhalten.&lt;/p&gt;
 
 &lt;h2&gt;Suche&lt;/h2&gt;
-&lt;p&gt;Sie möchten wissen, wie dieser Stern dort oben heißt? Sky Map gibt Ihnen die Antwort. Sky Map kann Ihnen auch sagen, wo sich ein bestimmtes Objekt befindet. Rufen Sie die Suchfunktion über die Menütaste Ihres Telefons oder direkt über das Schnellsuchfeld auf dem Bildschirm auf. Beginnen Sie mit der Eingabe eines Planeten-, Sternen- oder Konstellationennamens. Sky Map zeigt Ihnen dann eine Liste passender Suchelemente an. Nachdem Sie ein Suchergebnis ausgewählt haben, zeigt Ihnen Sky Map anhand eines Zielkreises und eines Pfeils, wohin Sie Ihr Telefon bewegen müssen, um das Objekt zu finden. Sobald Sie in der Nähe des Ziels sind, wechselt der Kreis von blau zu rot und wird schließlich orange, wenn sich das Objekt in Ihrem Sichtfeld befindet.&lt;/p&gt;
-&lt;p&gt;Hinweis: Im manuellen Modus verschiebt Sky Map einfach die Karte, um Ihnen das Objekt zu zeigen.\n Tippen Sie zum Verlassen des Suchmodus auf das kleine Kreuz in der Ecke des Bildschirms.&lt;/p&gt;
-&lt;p&gt;Tippen Sie zum Verlassen des Suchmodus auf das kleine Kreuz in der Ecke des Bildschirms.&lt;/p&gt;
+&lt;p&gt;Tippe auf das Lupensymbol, um nach allem am Himmel zu suchen. Du kannst suchen nach:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;b&gt;Sternen&lt;/b&gt; – nach Name, z.B. „Sirius", „Beteigeuze", „Polaris"&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Planeten&lt;/b&gt; – z.B. „Mars", „Saturn"&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Konstellationen&lt;/b&gt; – z.B. „Orion", „Kassiopeia"&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Tiefen-Himmelsobjekten&lt;/b&gt; – z.B. „M31", „Andromedagalaxie", „Plejaden"&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Kometen und Meteorschauern&lt;/b&gt; – nach Name&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;&lt;b&gt;Im automatischen Modus:&lt;/b&gt; Nach der Auswahl eines Ergebnisses zeigt Sky Map einen Zielkreis und einen Richtungspfeil. Folge dem Pfeil, indem du dein Telefon drehst – der Kreis wechselt von blau zu rot, dann orange, wenn das Objekt in deinem Sichtfeld ist. Tippe auf ✕, um die Suche zu beenden.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;Im manuellen Modus:&lt;/b&gt; Die Karte springt einfach zum Objekt.&lt;/p&gt;
 
-&lt;h2&gt;Zeitreise (Neu!)&lt;/h2&gt;
+&lt;h2&gt;Zeitreise&lt;/h2&gt;
+&lt;p&gt;Mit der Zeitreise kannst du den Himmel zu jedem Zeitpunkt zwischen 1900 und 2100 sehen. Wähle das &lt;b&gt;Zeitreise&lt;/b&gt;-Symbol (wirbelnde Kreise) in der Aktionsleiste.&lt;/p&gt;
+&lt;p&gt;Du kannst ein voreingestelltes Datum wählen (Sonnenwenden, Finsternisse, berühmte Himmelsereignisse, historische Momente) oder dein eigenes Datum und Uhrzeit eingeben. Tippe auf &lt;b&gt;Los!&lt;/b&gt;, um dorthin zu reisen.&lt;/p&gt;
+&lt;p&gt;Im Zeitreisemodus wird das Datum auf dem Bildschirm angezeigt und Wiedergabesteuerungen ermöglichen dir, durch die Zeit zu navigieren:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Tippe auf die Vor- oder Zurück-Wiedergabetasten, um die Bewegung zu starten&lt;/li&gt;
+&lt;li&gt;Tippe erneut, um schneller zu werden&lt;/li&gt;
+&lt;li&gt;Tippe auf Stopp, um anzuhalten&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Mögliche Anwendungen:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;i&gt;Was kann ich kurz nach Sonnenuntergang heute Abend sehen?&lt;/i&gt;&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;Wann ist die nächste gute Gelegenheit, Merkur zu beobachten?&lt;/i&gt;&lt;/li&gt;
+&lt;li&gt;&lt;i&gt;Wie sah der Himmel in der Nacht meiner Geburt aus?&lt;/i&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Die Genauigkeit nimmt für Daten ab, die weit von der Gegenwart entfernt sind, hauptsächlich aufgrund des Gravitationseinflusses des Jupiters.&lt;/p&gt;
 
-&lt;p&gt;Mithilfe des Zeitreisemodus von Sky Map haben Sie die Möglichkeit, den Himmel auch vor oder nach dem aktuellen Zeitpunkt zu betrachten. Wählen Sie \"Zeitreise\" aus dem Hauptmenü und wählen Sie dann einen der beliebten Tage. In den Dialogfeldern \"Datum ändern\" und \"Uhrzeit ändern\" können Sie auch Ihr eigenes Datum und eine eigene Uhrzeit bestimmen. Aus Gründen der Genauigkeit, in erster Line bedingt durch die Gravitationseinflüsse durch den Jupiter, ist die Auswahl auf die Jahre 1900 - 2100 beschränkt. Klicken Sie abschließend auf \"Los!\", um die Zeitreise zu beginnen. Sky Map befindet sich daraufhin im Zeitreisemodus und zeigt das von Ihnen besuchte Datum an. Mithilfe der Steuerelemente können Sie sich von dort aus vor- und rückwärts in der Zeit bewegen. Klicken Sie einmal auf diese Schaltflächen, um sich langsam durch die Zeit zu bewegen, und mehrmals, um die Geschwindigkeit zu erhöhen.&lt;/p&gt;
+&lt;h2&gt;Infokarten&lt;/h2&gt;
+&lt;p&gt;Tippe auf ein beschriftetes Himmelsobjekt auf der Sternkarte, um eine Infokarte anzuzeigen – ein Bereich mit einem Foto und Details zu diesem Objekt. Infokarten sind für mehr als 150 Objekte verfügbar, darunter Sterne, Planeten, der Mond, besondere Tiefenhimmelobjekte und Konstellationen.&lt;/p&gt;
+&lt;p&gt;Jede Karte zeigt:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Ein Foto oder eine Karte des Objekts&lt;/li&gt;
+&lt;li&gt;Eine kurze Beschreibung und eine interessante Tatsache&lt;/li&gt;
+&lt;li&gt;Wissenschaftliche Daten wie Entfernung, Größe und Objekttyp&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Tippe auf das Bild in der Karte, um es im Vollbildmodus anzuzeigen. Schließe die Karte, indem du außerhalb davon tippst oder &lt;b&gt;Zurück&lt;/b&gt; drückst.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;Infokarten aktivieren:&lt;/b&gt; Standardmäßig erscheinen sie nur im manuellen Modus; gehe zu den Einstellungen, um sie auch im automatischen (sensorgesteuerten) Modus zu aktivieren.&lt;/p&gt;
 
-&lt;p&gt;Mit der Zeitreise können zum Beispiel folgende Fragen beantwortet werden: \"Was kann ich direkt heute Abend nach Sonnenuntergang sehen?\", \"Wann habe ich das nächste Mal gute Chancen, den Merkur zu sehen?\" und \"Wann sollte ich laut Hesiod mit der Weinlese beginnen?\"&lt;/p&gt;
-
-&lt;h2&gt;Hubble-Galerie&lt;/h2&gt;
-&lt;p&gt;Sky Map enthält einen Teil der Hubble-Galerie von Sky Map. Nachdem Sie die Galerie über die entsprechende Option im Menü aufgerufen haben, können Sie die verfügbaren Bilder durchsuchen, indem Sie mit dem Finger durchscrollen. Wenn Sie auf eine Miniaturansicht tippen, zeigt Sky Map das Bild im Vollbildmodus an. Wenn Sie auf die Suchschaltfläche tippen, wechselt Sky Map in den Suchmodus und sucht nach dem zu dem Bild passenden Objekt.&lt;/p&gt;
+&lt;h2&gt;Galerie&lt;/h2&gt;
+&lt;p&gt;Die Galerie enthält eine Sammlung von Bildern des Hubble-Weltraumteleskops und anderer Quellen. Öffne sie über das Hauptmenü.&lt;/p&gt;
+&lt;p&gt;Durchsuche Miniaturansichten durch Scrollen und tippe auf eine, um das vollständige Bild zu sehen. Verwende die Schaltfläche &lt;b&gt;Am Himmel suchen&lt;/b&gt;, um in den Suchmodus zu wechseln und das Objekt auf deiner aktuellen Sternkarte zu finden.&lt;/p&gt;
 
 &lt;h2&gt;Nachtsichtmodus&lt;/h2&gt;
-&lt;p&gt;Der Nachtsichtmodus dient dem Schutz Ihrer an die Dunkelheit angepassten Augen. Bei Auswahl des Nachtsichtmodus zeigt Sky Map alles in Rottönen an. Wählen Sie die Option erneut aus, um wieder zu den normalen Farben zu wechseln.&lt;/p&gt;
-
-&lt;h2&gt;Festlegen Ihres Standorts&lt;/h2&gt;
-&lt;p&gt;Sky Map benötigt Ihren ungefähren Standort, um Ihnen die richtige Sternenkarte zeigen zu können. Standardmäßig wird Ihr Standort über Ihr Mobilfunknetz bestimmt. Falls Sie sich außer Reichweite befinden oder die Netzwerkstandortbestimmung deaktiviert haben, verwendet Sky Map das GPS Ihres Telefons. Sie können Ihren Standort in den Einstellungen auch manuell festlegen, entweder durch die Angabe eines Ortsnamens oder des Längen- und Breitengrades. Beachten Sie, dass Sky Map eine Datenverbindung benötigt, um anhand eines Ortsnamens Ihren Längen- und Breitengrad zu bestimmen.&lt;/p&gt;
-
-&lt;h2&gt;Problembehebung und Beschränkungen&lt;/h2&gt;
-&lt;h3&gt;Die Karte ist ungenau.&lt;/h3&gt;
-&lt;p&gt;Falls die Karte den Himmel Ihrer Ansicht nach nicht korrekt darstellt, kann dies mehrere Ursachen haben:&lt;/p&gt;
-&lt;ol&gt;
-&lt;li&gt;Ist Ihr Kompass kalibriert? Nehmen Sie das Telefon in die Hand und bewegen Sie es in Form einer Acht, um es zu kalibrieren. Sie müssen dies möglicherweise gelegentlich wiederholen. Dies ist eher eine Funktion des Telefons als von Sky Map.&lt;/li&gt;
-&lt;li&gt;Kennt die Anwendung Ihren genauen Standort? Ist Ihr GPS bzw. Ihr Netzwerkstandort aktiviert?&lt;/li&gt;
-&lt;li&gt;Haben Sie die richtige Uhrzeit und die richtige Zeitzone ausgewählt? Sky Map muss die Universalzeit berechnen und benötigt dazu Ihre Ortszeit UND Ihre Zeitzone. Falls Sie in Ihrem Gerät eine SIM-Karte verwenden, ist diese normalerweise korrekt eingestellt.&lt;/li&gt;
-&lt;li&gt;Ist die magnetische Korrektur aktiviert? In einigen Teilen der Erde kann die Abweichung zwischen dem magnetischen und dem geografischen Nordpol bis zu 20 Grad betragen.&lt;/li&gt;
-&lt;/ol&gt;
-&lt;h3&gt;Die Karte bewegt sich nicht.&lt;/h3&gt;
-&lt;p&gt;Befinden Sie sich im manuellen Modus? Falls nicht, ist der Kompass möglicherweise nicht kalibriert. Führen Sie die oben beschriebenen Schritte aus, um ihn zu kalibrieren.&lt;/p&gt;
-
-&lt;h2&gt;Support Development&lt;/h2&gt;
-&lt;p&gt;Sky Map is free, open source, and ad-free. If you enjoy using it, please
-consider supporting continued development at
-&lt;a href="https://github.com/sky-map-team/stardroid#support"&gt;our GitHub page&lt;/a&gt;.&lt;/p&gt;
-
-&lt;h2&gt;Mitwirkung&lt;/h2&gt;
-&lt;h3&gt;Engineering und Design&lt;/h3&gt;
-&lt;p&gt;Brent Bryan, Dominic Widdows, Hector Ouilhet, James Powell, John Taylor,
-Kevin Serafini&lt;/p&gt;
-
-&lt;h3&gt;Produktmanagement&lt;/h3&gt;
-&lt;p&gt;Lior Ron&lt;/p&gt;
-
-&lt;h3&gt;Public Relations&lt;/h3&gt;
-&lt;p&gt;Aaron Stein, Erin Gleason&lt;/p&gt;
-
-&lt;h3&gt;Produktmarketing&lt;/h3&gt;
-&lt;p&gt;Effie Seiberg, Linda Tong&lt;/p&gt;
-
-&lt;h3&gt;Übersetzungen&lt;/h3&gt;
-&lt;p&gt;Jelena Oertel&lt;/p&gt;
-
-
-&lt;h2&gt;Danksagung&lt;/h2&gt;
-&lt;p&gt;Sky Map basiert auf Daten von:&lt;/p&gt;
-&lt;ul class="credits"&gt;
-&lt;li&gt;Centre de Données astronomiques de Strasbourg (&lt;a href="https://cdsweb.u-strasbg.fr/"&gt;https://cdsweb.u-strasbg.fr/&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;The Bright Star Catalogue, 5th Revised Ed. (Hoffleit D., Warren Jr W.H.)&lt;/li&gt;
-&lt;li&gt;The HYG Database, HYG v1.0. (&lt;a href="https://www.astronexus.com/"&gt;https://www.astronexus.com/&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;History and Accurate Positions for the NGC/IC Objects (Harold G. Corwin Jr)&lt;/li&gt;
-&lt;li&gt;Revised New General Catalogue of Nonstellar Astronomical Objects
-(Sulentic J.W., Tifft W.G.)&lt;/li&gt;
-&lt;li&gt;SFA Star Charts
-(&lt;a href="https://observe.phy.sfasu.edu/SFAStarCharts/SFAStarChartFAQ.html"&gt;https://observe.phy.sfasu.edu/SFAStarCharts/SFAStarChartFAQ.html&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;Die Positionen der Objekte im Sonnensystem wurden anhand von Daten des USNO (&lt;a href="https://www.usno.navy.mil/USNO/astronomical-applications"&gt;https://www.usno.navy.mil/USNO/astronomical-applications&lt;/a&gt;) berechnet.&lt;/li&gt;
-&lt;li&gt;Die Daten zur sphärischen Darstellung stammen von (&lt;a href="https://www2.research.att.com/~njas/coverings"&gt;https://www2.research.att.com/~njas/coverings&lt;/a&gt;).&lt;/li&gt;
-&lt;li&gt;Die Hubble-Bilder werden bereitgestellt vom NASA Space Telescope Science Institute
-(&lt;a href="https://hubblesite.org/"&gt;https://hubblesite.org/&lt;/a&gt;).&lt;/li&gt;
-&lt;li&gt;M31 image Peter Kennett (&lt;a href="https://commons.wikimedia.org/wiki/File:M31(Kennett).jpg"&gt;https://commons.wikimedia.org/wiki/File:M31(Kennett).jpg&lt;/a&gt;)&lt;/li&gt;
+&lt;p&gt;Wenn du draußen beobachtest, hilft der Nachtsichtmodus, deine dunkeladaptierte Sehfähigkeit zu erhalten. Schalte ihn über die Aktionsleiste mit dem augenförmigen &lt;b&gt;Nachtsicht&lt;/b&gt;-Symbol ein.&lt;/p&gt;
+&lt;p&gt;Im Nachtsichtmodus wechselt Sky Map:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Die Anzeige auf tiefe Rottöne&lt;/li&gt;
+&lt;li&gt;Dimmt den Bildschirm erheblich&lt;/li&gt;
+&lt;li&gt;Reduziert die Tastenhintergrundbeleuchtung&lt;/li&gt;
 &lt;/ul&gt;
-    </string>
+&lt;p&gt;Schalte ihn erneut ein, um zur normalen Ansicht zurückzukehren. Die Option &lt;b&gt;Bildschirmdimmen&lt;/b&gt; unter &lt;b&gt;Einstellungen → Erscheinungsbild&lt;/b&gt; gibt dir zusätzliche Kontrolle darüber, wie dunkel der Bildschirm wird.&lt;/p&gt;
+
+&lt;h2&gt;Standort festlegen&lt;/h2&gt;
+&lt;p&gt;Sky Map benötigt deinen ungefähren Standort, um den richtigen Himmel anzuzeigen. Standardmäßig werden die Standortdienste deines Geräts (Mobilfunknetz oder GPS) verwendet. Wenn du keinen Zugriff gewährst, platziert Sky Map dich bei (0, 0) – einem Punkt mitten im Ozean!&lt;/p&gt;
+&lt;p&gt;Wenn der Standortzugriff nicht verfügbar ist oder du ihn lieber manuell festlegen möchtest, gehe zu &lt;b&gt;Einstellungen → Standort&lt;/b&gt; und gib entweder:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Einen &lt;b&gt;Ortsnamen&lt;/b&gt; ein (erfordert eine Internetverbindung zum Nachschlagen der Koordinaten), oder&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Breitengrad und Längengrad&lt;/b&gt; direkt in Grad ein (kein Internet erforderlich)&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Wenn du Sky Map den Standortzugriff zuvor verweigert hast, musst du ihn möglicherweise unter &lt;b&gt;App-Einstellungen → Berechtigungen&lt;/b&gt; deines Geräts wieder aktivieren.&lt;/p&gt;
+
+&lt;h2&gt;Teleskopnutzer – Zeigermodus&lt;/h2&gt;
+&lt;p&gt;Unter &lt;b&gt;Einstellungen → Sensoreinstellungen&lt;/b&gt; ändere die &lt;b&gt;Blickrichtung&lt;/b&gt; auf &lt;b&gt;Zeigermodus&lt;/b&gt;. In diesem Modus zeigt Sky Map, worauf die &lt;i&gt;Längskante&lt;/i&gt; des Telefons zeigt, anstatt wohin der Bildschirm ausgerichtet ist.&lt;/p&gt;
+&lt;p&gt;Damit kannst du dein Telefon entlang der Seite eines Teleskoprohrs befestigen, sodass der Bildschirm senkrecht zum Rohr steht, während die Karte weiterhin verfolgt, wohin das Teleskop gerichtet ist.&lt;/p&gt;
+
+&lt;h2&gt;Nützliche Tipps und Einstellungen&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;b&gt;Diagnose:&lt;/b&gt; Wenn etwas falsch erscheint, öffne das Überlaufmenü und tippe auf &lt;b&gt;Diagnose&lt;/b&gt;. Diese Seite zeigt deinen aktuellen Standort, die Uhrzeit, den Sensorstatus und Genauigkeitswerte – sehr nützlich, wenn du ein Problem melden musst.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Schriftgröße:&lt;/b&gt; Passe die Beschriftungsgröße unter &lt;b&gt;Einstellungen → Erscheinungsbild&lt;/b&gt; an.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Zitternde Karte:&lt;/b&gt; Experimentiere mit &lt;b&gt;Sensorgeschwindigkeit&lt;/b&gt; und &lt;b&gt;Sensordämpfung&lt;/b&gt; unter &lt;b&gt;Einstellungen → Sensoreinstellungen (Experten)&lt;/b&gt;.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Kein Gyroskop?&lt;/b&gt; Wenn dein Telefon kein Gyroskop hat, aktiviere &lt;b&gt;Gyroskop deaktivieren&lt;/b&gt; in den Sensoreinstellungen, um einen alternativen Sensormodus zu verwenden.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Magnetische Korrektur:&lt;/b&gt; Sky Map kann eine Magnetdeklinations-Korrektur anwenden, damit die Karte mit dem geografischen Norden statt dem magnetischen Norden übereinstimmt. Schalte dies unter &lt;b&gt;Einstellungen → Standort&lt;/b&gt; um. In einigen Teilen der Welt kann der Unterschied 20 Grad oder mehr betragen.&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;Hardwareanforderungen&lt;/h2&gt;
+&lt;p&gt;Nicht alle Geräte können Sky Map vollständig unterstützen! Du benötigst mindestens ein Telefon mit:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Einem Magnetfeldsensor (auch Kompass genannt) – um die Richtung zu bestimmen, in die du schaust&lt;/li&gt;
+&lt;li&gt;Einem Beschleunigungssensor – um zu bestimmen, wie hoch am Himmel du schaust&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Idealerweise auch:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Ein Gyroskop – dies macht die Bewegung gleichmäßiger und weniger ruckartig&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p class="callout"&gt;Telefonkompasse sind notorisch problematisch. Wenn Sky Map den Himmel nicht korrekt anzeigt, liegt es fast immer an einem Hardwareproblem mit dem Kompass, nicht an Sky Map selbst. Siehe den Abschnitt zur Fehlerbehebung für mögliche Hilfen.&lt;/p&gt;
+&lt;h3&gt;Woher weiß ich, welche Sensoren mein Telefon hat?&lt;/h3&gt;
+&lt;p&gt;Öffne die Sky Map-Diagnoseseite – alle Sensoren, die dein Telefon nicht hat, werden als „--,--,--" angezeigt.&lt;/p&gt;
+&lt;h3&gt;Was, wenn meinem Gerät erforderliche Sensoren fehlen?&lt;/h3&gt;
+&lt;p&gt;Sky Map wechselt in den manuellen Modus. Du kannst den Himmel immer noch erkunden, aber ohne die Sensoren gibt es keine Möglichkeit für eine App, dir deine Richtung anzuzeigen.&lt;/p&gt;
+
+&lt;h2&gt;Fehlerbehebung&lt;/h2&gt;
+&lt;h3&gt;Die Karte bewegt sich nicht&lt;/h3&gt;
+&lt;ul&gt;
+&lt;li&gt;Überprüfe, ob du im automatischen Modus bist (nicht manuell)&lt;/li&gt;
+&lt;li&gt;Überprüfe die Diagnoseseite, um zu bestätigen, dass dein Gerät einen Kompass und Beschleunigungssensor hat&lt;/li&gt;
+&lt;li&gt;Versuche die Acht-Kalibrierungsgeste: Bewege dein Telefon langsam in einer großen, gleichmäßigen Acht&lt;/li&gt;
+&lt;/ul&gt;
+&lt;h3&gt;Die Karte zeigt in die falsche Richtung oder ist ungenau&lt;/h3&gt;
+&lt;p&gt;Sky Map benötigt drei Dinge, um den richtigen Himmel anzuzeigen: die Richtung, in die dein Telefon zeigt, deinen Standort und die aktuelle Uhrzeit. Wenn die Karte falsch aussieht, ist wahrscheinlich eines davon nicht korrekt.&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;b&gt;Kompass:&lt;/b&gt; Die häufigste Ursache – ein Hardwareproblem, kein Sky Map-Fehler. Versuche zu kalibrieren (Acht-Geste), entferne dich von Metallobjekten und schalte &lt;b&gt;Magnetische Korrektur&lt;/b&gt; unter &lt;b&gt;Einstellungen → Standort&lt;/b&gt; um.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Standort:&lt;/b&gt; Gewähre die Standortberechtigung über &lt;b&gt;App-Einstellungen → Berechtigungen&lt;/b&gt;. Überprüfe die Diagnoseseite, um deine Koordinaten zu bestätigen.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Uhrzeit:&lt;/b&gt; Seltener, aber eine falsche Zeitzone verschiebt den gesamten Himmel. Überprüfe die Diagnoseseite, um zu bestätigen, dass Uhrzeit und Zeitzone deines Geräts korrekt sind.&lt;/li&gt;
+&lt;/ul&gt;
+&lt;h3&gt;Die Karte zittert&lt;/h3&gt;
+&lt;ul&gt;
+&lt;li&gt;Passe &lt;b&gt;Sensorgeschwindigkeit&lt;/b&gt; und &lt;b&gt;Sensordämpfung&lt;/b&gt; unter &lt;b&gt;Einstellungen → Sensoreinstellungen (Experten)&lt;/b&gt; an&lt;/li&gt;
+&lt;li&gt;Wenn dein Telefon kein Gyroskop hat, aktiviere &lt;b&gt;Gyroskop deaktivieren&lt;/b&gt; in den Sensoreinstellungen&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Ausführliche Hinweise zur Fehlerbehebung findest du im Online-&lt;a href="https://github.com/sky-map-team/stardroid/blob/master/troubleshooting.md"&gt;Fehlerbehebungshandbuch&lt;/a&gt;.&lt;/p&gt;
+&lt;p class="callout"&gt;Wenn du immer noch nicht weiterkommst, schreib uns eine E-Mail an skymapdevs@gmail.com – ein Screenshot deiner Diagnoseseite ist sehr hilfreich.&lt;/p&gt;
+
+&lt;h1&gt;Was ist neu in Sky Map?&lt;/h1&gt;
+
+%3$s
+
+%2$s
+</string>
 </resources>

--- a/stardroid-v1/app/src/main/res/values-de/whatsnew.xml
+++ b/stardroid-v1/app/src/main/res/values-de/whatsnew.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
-    <string name="whats_new_text" translation_description="HTML structure for a page describing new features in this version of Sky Map. Please do not change the &lt; and &gt; markup">
-    &lt;h1&gt;Neu in Version %1$s&lt;/h1&gt;
+    <string name="whats_new_text" translation_description="HTML structure for a page describing new features in this version of Sky Map. Please do not change the &lt; and &gt; markup">%3$s
+&lt;h1&gt;Neu in Version %1$s&lt;/h1&gt;
 %2$s
 
 &lt;h1&gt;Sky Map unterstützen&lt;/h1&gt;


### PR DESCRIPTION
## Summary

- **credits.xml**: Added the 2 missing `<li>` image credit entries (Sagittarius A\* — EHT Collaboration, and Cygnus X-1 — NASA/CXC/M.Weiss) to match English; total is now 19 items in both locales
- **whatsnew.xml**: Added the missing `%3$s` placeholder at the start of `whats_new_text`, matching the English structure
- **help.xml**: Replaced the entirely outdated German content with a full German translation of the current English help text — fixes `%s` → `%1$s`, adds the missing `%2$s`/`%3$s`/`%4$s` placeholders at the correct positions, and restores `<b>`/`<i>` tag parity (40 tags each)

All three errors pre-existed at HEAD before the Saturn release work and were not introduced by it.

## Test plan

- [ ] Build passes with `assembleGmsDebug`
- [ ] Locale validation tool reports no errors for `values-de/credits.xml`, `values-de/help.xml`, `values-de/whatsnew.xml`
- [ ] Help screen, credits screen, and what's new dialog render correctly on a German-locale device/emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)