### PR TITLE
Overhaul compass/calibration messaging to clarify hardware vs app responsibility

### DIFF
--- a/stardroid-v1/.claude/skills/skymap.respond-reviews/SKILL.md
+++ b/stardroid-v1/.claude/skills/skymap.respond-reviews/SKILL.md
@@ -43,14 +43,19 @@ The same filters apply: `startDate`, `endDate`, `searchText`, `language`, `unans
 
 ## Step 2 — Classify each review
 
-For each review, classify the issue before drafting:
+For each review, classify the issue before drafting. Use the most specific matching class —
+the sub-classes below have different response framing.
 
 | Class | Signals |
 |---|---|
-| **compass** | "wrong direction", "points wrong way", "inaccurate", "off by X degrees", "compass", "calibration", "calibrate" |
+| **compass-inaccurate** | "wrong direction", "points wrong way", "inaccurate", "off by X degrees", "compass" |
+| **compass-calibrated-still-wrong** | "I calibrated it but it's still wrong/inaccurate", "figure-8 doesn't help", "calibrated 50 times" |
+| **compass-broke-after-update** | "worked before the update", "broke after update", "used to work fine", "last update ruined it" |
+| **map-frozen** | "doesn't move", "stuck", "frozen", "won't track" |
 | **jitter** | "jittery", "shaky", "jumpy", "wobbles", "stutters", "jerky" |
 | **location** | "wrong location", "wrong city", "Polaris near horizon", "latitude", "permission" |
 | **time/timezone** | "wrong time", "time zone", "off by hours", "clock" |
+| **very-negative** | 1–2 stars with no specific technical complaint, "useless", "garbage" |
 | **positive** | 4–5 stars with no complaint |
 | **other** | anything else |
 
@@ -58,10 +63,13 @@ For each review, classify the issue before drafting:
 
 ## Step 3 — Draft the reply
 
-Read `@../troubleshooting.md` before drafting any complaint reply. You only need to read this if there are complaints or issues - it's not needed to respond to purely positive reviews.
-Base all advice strictly on
-what that document says — **do not invent steps, settings, or explanations not found there**. DO NOT SPECULATE that changes in Android APIs or updates to Sky Map might have been the cause. If in doubt, ask me. Replies
-need to be limited to 350 characters.
+Read `@../troubleshooting-llm.md` before drafting any complaint reply — it contains response
+framing, ordered steps, and phrases to avoid for each complaint class. Also read
+`@../troubleshooting.md` for the full technical detail. You only need to read these if there are
+complaints or issues — not needed for purely positive reviews.
+Base all advice strictly on what those documents say — **do not invent steps, settings, or
+explanations not found there**. DO NOT SPECULATE that changes in Android APIs or updates to Sky Map
+might have been the cause. If in doubt, ask me. Replies need to be limited to 350 characters.
 
 ### Complaint replies
 

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
@@ -8,6 +8,7 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.util.Log
+import com.google.android.stardroid.R
 import com.google.android.stardroid.activities.CompassCalibrationActivity
 import com.google.android.stardroid.base.TimeConstants
 import com.google.android.stardroid.util.MiscUtil.getTag
@@ -83,7 +84,7 @@ class SensorAccuracyMonitor @Inject internal constructor(
     )
     if (dontShowDialog) {
       analytics.trackEvent(AnalyticsInterface.CALIBRATION_TOAST_SHOWN_EVENT, null)
-      toaster.toastLong("Inaccurate compass - please calibrate")
+      toaster.toastLong(context.getString(R.string.compass_low_accuracy_toast))
     } else {
       analytics.trackEvent(AnalyticsInterface.CALIBRATION_AUTO_TRIGGERED_EVENT, null)
       val intent = Intent(context, CompassCalibrationActivity::class.java)

--- a/stardroid-v1/app/src/main/res/values/help.xml
+++ b/stardroid-v1/app/src/main/res/values/help.xml
@@ -134,7 +134,7 @@
 &lt;ul&gt;
 &lt;li&gt;A gyroscope — this will smooth out the motion and make it less jerky&lt;/li&gt;
 &lt;/ul&gt;
-&lt;p class="callout"&gt;Phone compasses are notoriously unreliable. If the sky map looks wrong, it is almost always a hardware issue with your phone\'s compass — not a bug in Sky Map. Sky Map reads exactly what your phone\'s sensor reports; it cannot override a bad or biased reading. See Troubleshooting below.&lt;/p&gt;
+&lt;p class="callout"&gt;Phone compasses are notoriously unreliable. If the sky map looks wrong, it is almost always a hardware issue with your phone\'s compass — not a bug in Sky Map. Sky Map reads exactly what your phone\'s sensor reports; it has no way to automatically correct a bad or biased reading, though a manual offset is available in Settings for phones with a consistent error. See Troubleshooting below.&lt;/p&gt;
 &lt;h3&gt;How do I know which sensors my phone has?&lt;/h3&gt;
 &lt;p&gt;Open Sky Map\'s Diagnostics page — any sensors your phone doesn\'t have will show up as \"--,--,--\".&lt;/p&gt;
 &lt;h3&gt;What if my device is missing required sensors?&lt;/h3&gt;

--- a/stardroid-v1/app/src/main/res/values/help.xml
+++ b/stardroid-v1/app/src/main/res/values/help.xml
@@ -134,7 +134,7 @@
 &lt;ul&gt;
 &lt;li&gt;A gyroscope — this will smooth out the motion and make it less jerky&lt;/li&gt;
 &lt;/ul&gt;
-&lt;p class="callout"&gt;Phone compasses are notoriously troublesome. If Sky Map is not showing the sky accurately it\'s almost always a hardware issue with the compass, not an issue with Sky Map. See the troubleshooting section for some things that might help.&lt;/p&gt;
+&lt;p class="callout"&gt;Phone compasses are notoriously unreliable. If the sky map looks wrong, it is almost always a hardware issue with your phone\'s compass — not a bug in Sky Map. Sky Map reads exactly what your phone\'s sensor reports; it cannot override a bad or biased reading. See Troubleshooting below.&lt;/p&gt;
 &lt;h3&gt;How do I know which sensors my phone has?&lt;/h3&gt;
 &lt;p&gt;Open Sky Map\'s Diagnostics page — any sensors your phone doesn\'t have will show up as \"--,--,--\".&lt;/p&gt;
 &lt;h3&gt;What if my device is missing required sensors?&lt;/h3&gt;
@@ -150,7 +150,7 @@
 &lt;h3&gt;The map is pointing the wrong way or is inaccurate&lt;/h3&gt;
 &lt;p&gt;Sky Map needs three things to show the correct sky: the direction your phone is facing, your location, and the current time. If the map looks wrong, one of these is likely off.&lt;/p&gt;
 &lt;ul&gt;
-&lt;li&gt;&lt;b&gt;Compass:&lt;/b&gt; The most common cause — a hardware issue, not a Sky Map bug. Try calibrating (figure-8 gesture), move away from metal objects, and toggle &lt;b&gt;Magnetic Correction&lt;/b&gt; in &lt;b&gt;Settings → Location&lt;/b&gt;. A manual compass offset is available under &lt;b&gt;Settings → Sensor Settings (Experts)&lt;/b&gt; for compasses with a consistent error.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Compass (most common cause):&lt;/b&gt; This is a hardware issue with your phone — not a Sky Map bug. The figure-8 calibration gesture asks your phone to reset its compass sensor internally, but &lt;i&gt;a calibrated compass is not necessarily an accurate one&lt;/i&gt;. If you\'re near a metal object, car dashboard, or magnetic phone case the map can still be off even after calibrating. Move to an open area, repeat the figure-8 gesture, then toggle &lt;b&gt;Magnetic Correction&lt;/b&gt; in &lt;b&gt;Settings → Location&lt;/b&gt;. If your phone has a consistent directional error, use the manual offset under &lt;b&gt;Settings → Sensor Settings (Experts)&lt;/b&gt;.&lt;/li&gt;
 &lt;li&gt;&lt;b&gt;Location:&lt;/b&gt; Grant location permission via &lt;b&gt;App Settings → Permissions&lt;/b&gt;. Check the Diagnostics page to confirm your coordinates. A telltale symptom of missing location is Polaris appearing near the horizon.&lt;/li&gt;
 &lt;li&gt;&lt;b&gt;Time:&lt;/b&gt; Less common, but an incorrect time zone shifts the whole sky. Check the Diagnostics page to confirm your device\'s time and time zone are correct.&lt;/li&gt;
 &lt;/ul&gt;

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -234,7 +234,7 @@ Move to an open area away from metal and try again. See <i>Troubleshooting</i> i
     <string name="compass_calib_what_to_do_user"
         translation_description="Information for the user on how to calibrate the compass when they invoke the calibration dialog. Placeholder is the video URL"><![CDATA[
 Your phone is reporting its compass accuracy as shown above. The figure-8 motion (%s) prompts your phone\'s hardware to recalibrate its compass sensor.<br/><br/>
-<b>Important distinction:</b> calibration helps the sensor normalise itself internally. A calibrated compass is not necessarily an accurate one — local magnetic interference (metal objects, car dashboards, magnetic phone cases) can still cause the map to point the wrong way. Sky Map reads exactly what your phone\'s sensor reports; it has no way to correct for your environment.<br/><br/>
+<b>Important distinction:</b> calibration helps the sensor normalize itself internally. A calibrated compass is not necessarily an accurate one — local magnetic interference (metal objects, car dashboards, magnetic phone cases) can still cause the map to point the wrong way. Sky Map reads exactly what your phone\'s sensor reports; it has no way to correct for your environment.<br/><br/>
 See <i>Troubleshooting</i> in <i>Help</i> for other steps, including the manual compass offset for phones with a consistent directional error.
     ]]></string>
     <string name="compass_low_accuracy_toast" translation_description="Brief toast shown when compass accuracy is low and the user has disabled the calibration dialog">Your phone\'s compass is reporting low accuracy</string>

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -223,18 +223,21 @@
     <string name="menu_calibrate" translation_description="Menu item label to open the compass calibration screen">Calibrate</string>
     <string name="compass_calibration_activity_heading_compass" translation_description="Static label in the compass calibration screen placed inline to the left of the live compass accuracy value (e.g. displayed as \'Compass - Accuracy: High\')">Compass -</string>
     <string name="compass_calibration_activity_do_not_show_this_again" translation_description="Checkbox label in the compass calibration dialog to suppress future automatic appearances">Do not show this again</string>
-    <string name="compass_calibration_activity_warning" translation_description="Heading/reason text shown in the compass calibration dialog when it opens automatically due to low accuracy">Hardware Calibration Required</string>
-    <string name="compass_calibration_activity_user_heading" translation_description="Heading shown in the compass calibration dialog when the user opens it manually from the menu">Improve Your Alignment</string>
+    <string name="compass_calibration_activity_warning" translation_description="Heading/reason text shown in the compass calibration dialog when it opens automatically due to low accuracy">Your Phone\'s Compass Needs Attention</string>
+    <string name="compass_calibration_activity_user_heading" translation_description="Heading shown in the compass calibration dialog when the user opens it manually from the menu">Your Phone\'s Compass</string>
     <string name="compass_calib_what_to_do"
         translation_description="Information for the user on how to calibrate the compass when the dialog auto-opens. Placeholder is the video URL"><![CDATA[
-Sky Map relies on your phone\'s built-in compass sensor. If the accuracy shown above is low, the sensor needs to be \"reset\" by moving the phone in a figure-8 motion: %s.<br/><br/>
-<b>Important:</b> Calibration is a hardware process handled by your device. While it improves the sensor\'s reliability, external magnetic interference can still cause a \"bias\" or slight drift. This is a physical limitation of mobile compasses and not an error within the app. See <i>Troubleshooting</i> in <i>Help</i> for other things to try.
+Your phone\'s compass sensor is reporting low accuracy. The figure-8 motion (%s) prompts your phone to recalibrate its hardware sensor — Sky Map has no control over this process.<br/><br/>
+<b>Calibrated does not mean accurate.</b> The figure-8 gesture helps the sensor normalise itself internally, but it cannot remove interference from nearby metal objects, car dashboards, or magnetic phone cases. If the map is still off after calibrating, those external sources are the most likely cause — not Sky Map.<br/><br/>
+Move to an open area away from metal and try again. See <i>Troubleshooting</i> in <i>Help</i> for more steps.
     ]]></string>
     <string name="compass_calib_what_to_do_user"
         translation_description="Information for the user on how to calibrate the compass when they invoke the calibration dialog. Placeholder is the video URL"><![CDATA[
-Your phone reports its compass accuracy as shown above. To improve this, please perform a figure-8 motion with your device (%s).<br/><br/>
-<b>Note on Accuracy:</b> Calibration is a hardware-level requirement of your phone, not a Sky Map setting. Even when calibrated, local magnetic fields (like car dashboards or magnets) may cause a slight bias in direction. See <i>Troubleshooting</i> in <i>Help</i> for other things to try.
+Your phone is reporting its compass accuracy as shown above. The figure-8 motion (%s) prompts your phone\'s hardware to recalibrate its compass sensor.<br/><br/>
+<b>Important distinction:</b> calibration helps the sensor normalise itself internally. A calibrated compass is not necessarily an accurate one — local magnetic interference (metal objects, car dashboards, magnetic phone cases) can still cause the map to point the wrong way. Sky Map reads exactly what your phone\'s sensor reports; it has no way to correct for your environment.<br/><br/>
+See <i>Troubleshooting</i> in <i>Help</i> for other steps, including the manual compass offset for phones with a consistent directional error.
     ]]></string>
+    <string name="compass_low_accuracy_toast" translation_description="Brief toast shown when compass accuracy is low and the user has disabled the calibration dialog">Your phone\'s compass is reporting low accuracy</string>
     <string name="sensor_reverse_preference_title" translation_description="Preference title for reversing the magnetic Z-axis sensor reading, a fix for certain phones with incorrectly implemented sensors">Reverse Magnetic Z</string>
     <string name="sensor_reverse_preference_summary" translation_description="Summary for the Reverse Magnetic Z preference">Fix for phones with incorrectly implemented sensors - requires restart</string>
     <string name="whats_new_dialog_title" translation_description="Title of the dialog shown on first launch after an update, listing new features">What\'s new</string>

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -228,7 +228,7 @@
     <string name="compass_calib_what_to_do"
         translation_description="Information for the user on how to calibrate the compass when the dialog auto-opens. Placeholder is the video URL"><![CDATA[
 Your phone\'s compass sensor is reporting low accuracy. The figure-8 motion (%s) prompts your phone to recalibrate its hardware sensor — Sky Map has no control over this process.<br/><br/>
-<b>Calibrated does not mean accurate.</b> The figure-8 gesture helps the sensor normalise itself internally, but it cannot remove interference from nearby metal objects, car dashboards, or magnetic phone cases. If the map is still off after calibrating, those external sources are the most likely cause — not Sky Map.<br/><br/>
+<b>Calibrated does not mean accurate.</b> The figure-8 gesture helps the sensor normalize itself internally, but it cannot remove interference from nearby metal objects, car dashboards, or magnetic phone cases. If the map is still off after calibrating, those external sources are the most likely cause — not Sky Map.<br/><br/>
 Move to an open area away from metal and try again. See <i>Troubleshooting</i> in <i>Help</i> for more steps.
     ]]></string>
     <string name="compass_calib_what_to_do_user"

--- a/troubleshooting-llm.md
+++ b/troubleshooting-llm.md
@@ -50,8 +50,8 @@ These facts should be expressed naturally (not recited verbatim) wherever releva
 - Phone OS/firmware update resetting the sensor's calibration
 
 **Response framing:** Acknowledge frustration, then explain that Sky Map reads the phone's compass
-sensor and has no ability to override what it reports. This is a phone hardware issue. Offer the
-steps below. Do not imply Sky Map has a bug.
+sensor and cannot automatically correct what it reports. This is a phone hardware issue. Offer the
+steps below (including the manual offset for persistent cases). Do not imply Sky Map has a bug.
 
 **Steps to suggest (in this order):**
 1. Remove any magnetic phone case and test without it
@@ -175,8 +175,9 @@ Offer the email address for direct support with a Diagnostics screenshot.
 
 - Lead with empathy: "Sorry to hear Sky Map isn't working as expected for you."
 - Be clear but not dismissive when the issue is hardware: "Sky Map reads directly from your
-  phone's compass sensor and has no way to override what it reports — this means compass
-  accuracy is ultimately determined by your phone's hardware and environment."
+  phone's compass sensor and cannot automatically correct what it reports — compass accuracy
+  is ultimately determined by your phone's hardware and environment, though a manual offset
+  is available in Settings for phones with a consistent error."
 - Never be defensive or blame the user. Frame hardware limitations as facts, not excuses.
 - Keep responses concise. Offer the most relevant 2–3 steps, not all of them.
 - If steps were already tried and failed, acknowledge that and escalate to email support.

--- a/troubleshooting-llm.md
+++ b/troubleshooting-llm.md
@@ -72,7 +72,7 @@ not fix a hardware compass issue.
 **What users say:** "I did the figure-8 but it's still pointing the wrong direction",
 "calibration doesn't work", "I've calibrated it 50 times"
 
-**Real cause:** User has confused calibration with accuracy. The figure-8 gesture is a hardware
+normalization process — it does not guarantee the compass points correctly. External magnetic
 normalisation process — it does not guarantee the compass points correctly. External magnetic
 interference is still causing a bias after calibration.
 

--- a/troubleshooting-llm.md
+++ b/troubleshooting-llm.md
@@ -1,0 +1,195 @@
+# Sky Map — Play Store Review Response Reference
+
+This document is structured for use by an LLM-based tool responding to Play Store reviews.
+For the human-readable version see [troubleshooting.md](troubleshooting.md).
+
+---
+
+## How to use this document
+
+- Match the review to a **complaint category** below.
+- Each category provides: the real cause, the correct response framing, specific steps to suggest,
+  and phrases to avoid.
+- Always be sympathetic and never dismissive. Acknowledge the frustration before explaining.
+- Never imply that a reinstall or app update will fix a compass/sensor issue.
+- Sky Map's sensor code has barely changed in years. If a user says "it worked before your update",
+  a phone OS/firmware update or environment change is almost certainly what changed.
+
+---
+
+## Core facts to repeat consistently
+
+These facts should be expressed naturally (not recited verbatim) wherever relevant:
+
+1. **Sky Map reads the phone's compass sensor; it does not control it.** If the sensor gives a
+   wrong reading, the map points the wrong way. This is a phone hardware issue.
+2. **Calibration ≠ Accuracy.** The figure-8 gesture normalises the sensor internally (removes
+   self-caused distortions). It does not remove external magnetic interference. A sensor that reads
+   "High accuracy" can still point in the wrong direction if it's near a metal object or magnetic
+   phone case.
+3. **Sky Map cannot compensate for external interference.** No app can. The phone's sensor reports
+   what it measures, including any bias from the environment.
+4. **The sensor code in Sky Map has barely changed in years.** Accuracy regressions after an
+   update are almost always caused by a phone OS/firmware update that reset the sensor calibration,
+   or a change in the user's environment.
+
+---
+
+## Complaint categories
+
+### CAT-1 · Map points in the wrong direction / is inaccurate
+
+**What users say:** "the map is completely wrong", "it points south when I'm facing north",
+"it's off by 90 degrees", "it broke after an update"
+
+**Real cause:** Phone compass sensor is giving a bad reading. Most commonly caused by:
+- Magnetic phone case
+- Being inside a car or near a vehicle
+- Standing near a metal structure, appliance, or reinforced concrete
+- Sensor needing hardware calibration (figure-8 gesture)
+- Phone OS/firmware update resetting the sensor's calibration
+
+**Response framing:** Acknowledge frustration, then explain that Sky Map reads the phone's compass
+sensor and has no ability to override what it reports. This is a phone hardware issue. Offer the
+steps below. Do not imply Sky Map has a bug.
+
+**Steps to suggest (in this order):**
+1. Remove any magnetic phone case and test without it
+2. Move to open ground, away from vehicles, buildings, and metal structures
+3. Perform the figure-8 calibration gesture (wave the phone in a large, slow figure-8 shape)
+4. Go to Settings → Location and toggle Magnetic Correction on or off
+5. If the phone has a consistent offset in all environments, use the manual compass offset in
+   Settings → Sensor Settings (Experts)
+6. Check the Diagnostics page (overflow menu) for sensor accuracy readings
+
+**Do NOT suggest:** reinstalling the app, clearing app data, waiting for an update. These will
+not fix a hardware compass issue.
+
+---
+
+### CAT-2 · "I calibrated it but it's still wrong"
+
+**What users say:** "I did the figure-8 but it's still pointing the wrong direction",
+"calibration doesn't work", "I've calibrated it 50 times"
+
+**Real cause:** User has confused calibration with accuracy. The figure-8 gesture is a hardware
+normalisation process — it does not guarantee the compass points correctly. External magnetic
+interference is still causing a bias after calibration.
+
+**Response framing:** Gently explain the calibration/accuracy distinction. Calibration helps the
+sensor's internal consistency; it cannot remove external interference. Suggest moving to a
+magnetically clean environment and trying again.
+
+**Key point to convey:** A compass reporting "High accuracy" after calibration can still point in
+the wrong direction if it's in a magnetically disturbed environment.
+
+**Steps to suggest:**
+1. Move well away from metal objects, vehicles, and buildings
+2. Remove any magnetic phone case
+3. Repeat the figure-8 gesture in the clear environment
+4. Toggle Magnetic Correction in Settings → Location
+
+---
+
+### CAT-3 · "It worked fine before / broke after an update"
+
+**What users say:** "last update broke it", "used to work great, now it's wrong",
+"every update makes it worse"
+
+**Real cause:** Sky Map's sensor code has barely changed in years. Most likely causes:
+- A phone OS/firmware update reset the sensor's hardware calibration
+- The user's phone case, mount, or environment changed
+- The phone's magnetometer has degraded over time (physical hardware wear)
+
+**Response framing:** Acknowledge the frustration. Explain that Sky Map's compass handling has
+been stable for a long time and that OS/firmware updates frequently reset sensor calibration as
+a known side-effect. This is not a Sky Map change.
+
+**Steps to suggest:**
+1. Perform a fresh figure-8 calibration in an open, interference-free area
+2. Check if the problem appeared after a specific Android or manufacturer update (if so, that
+   update likely reset the sensor)
+3. Check Diagnostics to see current sensor accuracy levels
+4. Try toggling Magnetic Correction in Settings → Location
+
+---
+
+### CAT-4 · Map doesn't move / is frozen
+
+**What users say:** "the map is stuck", "it doesn't move when I move my phone",
+"it's frozen in one direction"
+
+**Real cause (check in order):**
+1. User is in Manual Mode (most common)
+2. Phone lacks a compass or accelerometer (sensor absent)
+3. Compass is extremely uncalibrated
+
+**Response framing:** Start with the manual/automatic mode check since it's most often the cause.
+
+**Steps to suggest:**
+1. Tap the sensor icon on screen to make sure Automatic Mode is on (not Manual)
+2. Open Diagnostics — if any sensor shows `--,--,--` it is absent and the phone cannot run
+   Sky Map in automatic mode
+3. Try the figure-8 calibration gesture
+
+---
+
+### CAT-5 · Map is jittery / shaky
+
+**What users say:** "the map jumps around", "it's shaky", "very unstable"
+
+**Real cause:** Phone lacks a gyroscope, or sensor settings need tuning.
+
+**Steps to suggest:**
+1. Go to Settings → Sensor Settings (Experts) and enable Disable Gyro
+2. Adjust Sensor Speed and Sensor Damping in the same settings section
+
+---
+
+### CAT-6 · Location wrong / sky is completely wrong / stars are in wrong positions
+
+**What users say:** "Polaris is near the horizon", "the whole sky is shifted", "stars are in
+completely wrong positions", "it doesn't know where I am"
+
+**Real cause:** Sky Map does not have the user's location. It defaults to 0°/0° (ocean).
+
+**Telltale symptom:** Polaris near the horizon instead of high in the northern sky.
+
+**Steps to suggest:**
+1. Grant location permission: Settings → Apps → Sky Map → Permissions → Location
+2. Open Diagnostics and confirm the lat/lon shown there matches the user's actual location
+
+---
+
+### CAT-7 · "App is useless" / very negative (1–2 star, no specific technical complaint)
+
+**Response framing:** Express genuine regret. Ask what specifically went wrong so the team can
+help. Mention that compass problems are hardware limitations that affect all astronomy apps.
+Offer the email address for direct support with a Diagnostics screenshot.
+
+**Contact:** skymapdevs@gmail.com
+
+---
+
+## Tone guidelines
+
+- Lead with empathy: "Sorry to hear Sky Map isn't working as expected for you."
+- Be clear but not dismissive when the issue is hardware: "Sky Map reads directly from your
+  phone's compass sensor and has no way to override what it reports — this means compass
+  accuracy is ultimately determined by your phone's hardware and environment."
+- Never be defensive or blame the user. Frame hardware limitations as facts, not excuses.
+- Keep responses concise. Offer the most relevant 2–3 steps, not all of them.
+- If steps were already tried and failed, acknowledge that and escalate to email support.
+
+---
+
+## Suggested opening lines (use as starting points, not verbatim)
+
+- "Sorry the map isn't pointing correctly — this almost always comes down to the phone's compass
+  sensor rather than Sky Map itself."
+- "Thanks for the feedback. What you're describing sounds like a compass calibration issue with
+  your phone's hardware."
+- "We're sorry to hear this. Sky Map reads directly from your phone's built-in compass, so
+  accuracy is tied to your phone's sensor and environment."
+- "Sky Map's compass handling has been stable for years, so if this started after a phone update,
+  that update likely reset your sensor's calibration."

--- a/troubleshooting-llm.md
+++ b/troubleshooting-llm.md
@@ -23,7 +23,7 @@ These facts should be expressed naturally (not recited verbatim) wherever releva
 
 1. **Sky Map reads the phone's compass sensor; it does not control it.** If the sensor gives a
    wrong reading, the map points the wrong way. This is a phone hardware issue.
-2. **Calibration ≠ Accuracy.** The figure-8 gesture normalises the sensor internally (removes
+2. **Calibration ≠ Accuracy.** The figure-8 gesture normalizes the sensor internally (removes
    self-caused distortions). It does not remove external magnetic interference. A sensor that reads
    "High accuracy" can still point in the wrong direction if it's near a metal object or magnetic
    phone case.

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -11,9 +11,10 @@ are on the planet, and the current time. If the map looks wrong, one of these is
 
 ### Phone direction (the most common cause by far)
 
-Sky Map reads direction data from your phone's built-in compass sensor (magnetometer). **It has no
-ability to override or correct what the sensor reports.** If the sensor gives a wrong reading, the
-map will point the wrong way — and that is a phone hardware issue, not a Sky Map bug.
+Sky Map reads direction data from your phone's built-in compass sensor (magnetometer). If the
+sensor gives a wrong reading, the map will point the wrong way — and that is a phone hardware
+issue, not a Sky Map bug. Sky Map cannot automatically correct what the sensor reports, though a
+manual offset is available in Settings for phones with a consistent directional error.
 
 **"I calibrated it but it's still wrong."** This is the most common misunderstanding. Calibration
 and accuracy are two different things:

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -18,7 +18,7 @@ map will point the wrong way — and that is a phone hardware issue, not a Sky M
 **"I calibrated it but it's still wrong."** This is the most common misunderstanding. Calibration
 and accuracy are two different things:
 
-- **Calibration** (the figure-8 gesture) asks your phone's hardware to normalise its sensor
+- **Calibration** (the figure-8 gesture) asks your phone's hardware to normalize its sensor
   internally. It removes distortions caused by the phone's own components. Sky Map has no control
   over this process — it is handled entirely by the phone.
 - **Accuracy** is whether that normalised sensor is actually pointing in the right direction. A

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,132 +1,159 @@
 # Sky Map — Troubleshooting & FAQ
 
-For general help and a feature overview, see [help.md](help.md).
-
+For a general feature overview, see [help.md](help.md).
 
 ---
 
 ## The map is pointing in the wrong direction or is inaccurate
 
-To produce an accurate sky map, Sky Map needs three things: the direction your phone is facing,
-where you are on the planet, and the current time. If the map looks wrong, one of these is likely
-off.
+Sky Map needs three things to show the correct sky: the direction your phone is facing, where you
+are on the planet, and the current time. If the map looks wrong, one of these is likely off.
 
-### Phone direction
+### Phone direction (the most common cause by far)
 
-The most common cause is the device's compass providing Sky Map with an incorrect direction.
-**This is a hardware issue — it has nothing to do with Sky Map itself.** Sky Map can only work
-with the data the sensor provides.
+Sky Map reads direction data from your phone's built-in compass sensor (magnetometer). **It has no
+ability to override or correct what the sensor reports.** If the sensor gives a wrong reading, the
+map will point the wrong way — and that is a phone hardware issue, not a Sky Map bug.
 
-Things to try:
+**"I calibrated it but it's still wrong."** This is the most common misunderstanding. Calibration
+and accuracy are two different things:
 
-- **Calibrate the compass:** Wave your phone in a slow, smooth figure-8 motion. You may need to
-  repeat this occasionally — it is a hardware-level process, not something Sky Map controls.
-- **Remove magnetic interference:** Metal structures, car dashboards, and magnets in phone cases
-  are common culprits. Move away from them and try again.
-- **Toggle Magnetic Correction:** Go to **Settings → Location** and try switching this on or off.
-  In some parts of the world, magnetic north and true north differ by 20 degrees or more — this
-  setting corrects for that.
-- **Manual compass offset:** If your compass has a consistent offset, go to
-  **Settings → Sensor Settings (Experts)** and enter an estimate of the offset in degrees. This
-  requires some trial and error.
+- **Calibration** (the figure-8 gesture) asks your phone's hardware to normalise its sensor
+  internally. It removes distortions caused by the phone's own components. Sky Map has no control
+  over this process — it is handled entirely by the phone.
+- **Accuracy** is whether that normalised sensor is actually pointing in the right direction. A
+  calibrated compass is not necessarily an accurate one.
 
-See [About phone compasses](#about-phone-compasses) for a deeper explanation of how phone compasses
-work and why they can go wrong.
+Even after a successful calibration, external magnetic interference will still shift the reading:
+
+| Source | Effect |
+|---|---|
+| Metal structures, reinforced concrete | Can deflect the magnetic field by 5–30° |
+| Car dashboards | Very common — many contain magnets and motor components |
+| Magnetic phone cases | Extremely common cause of persistent compass errors |
+| Nearby electronics | Smaller effect but can add up |
+
+The Earth's magnetic field is a weak signal. Your phone's sensor has no way of knowing it's
+sitting next to a source of interference — it just reports what it measures.
+
+**Things to try, in order:**
+
+1. **Move to open ground.** Go somewhere flat and away from buildings, vehicles, and metal
+   structures. If the map improves, magnetic interference was the cause — not Sky Map.
+2. **Perform the figure-8 gesture** — wave your phone slowly in a large, smooth figure-8 shape.
+   You may need to repeat several times. The compass accuracy indicator in the calibration dialog
+   shows whether the phone has accepted the calibration.
+3. **Remove your phone case.** Magnetic cases are a very common culprit. Try without it.
+4. **Toggle Magnetic Correction.** Go to **Settings → Location**. In some parts of the world,
+   magnetic north and true north differ by 20° or more. Switching this on or off can sometimes
+   dramatically improve alignment.
+5. **Use a manual compass offset.** If your phone has a consistent directional error regardless of
+   environment, go to **Settings → Sensor Settings (Experts)** and enter an offset in degrees.
+   This is a workaround for phones with persistently biased hardware.
+
+> **If a recent phone update broke your compass:** this is unfortunately common. Android updates
+> and manufacturer firmware patches can reset or alter how the sensor is calibrated. Sky Map's
+> sensor code has barely changed in years — if it worked before a system update, the update is
+> almost certainly what changed, not Sky Map.
 
 ### Location
 
-Sky Map must know where on Earth you are to draw the correct sky. Without this, Sky Map defaults
-to 0° latitude / 0° longitude — a point in the middle of the ocean — and the map will look
-completely wrong wherever you are.
+Sky Map must know where on Earth you are to draw the correct sky. Without location access it
+defaults to 0° latitude / 0° longitude — a point in the ocean — and the map will look completely
+wrong anywhere else.
 
-**A telltale symptom:** if Polaris (the Pole Star) appears near the horizon instead of high in the
-northern sky, Sky Map almost certainly doesn't know your location.
+**Telltale symptom:** Polaris (the Pole Star) appearing near the horizon rather than high in the
+northern sky almost always means Sky Map doesn't know your location.
 
 To fix:
 
-- Grant Sky Map location permission. Open your device's **Settings → Apps → Sky Map → Permissions**
-  and enable **Location**. Sky Map should have requested this when it first launched — if you
-  declined, this is the most likely cause.
-- Open the **Diagnostics** page (overflow menu) and confirm that the latitude and longitude shown
-  there look correct for where you are.
+- Grant location permission. Open **Settings → Apps → Sky Map → Permissions** and enable
+  **Location**. If you declined the permission on first launch, this is the most likely cause.
+- Open the **Diagnostics** page (overflow menu) and confirm the latitude and longitude shown there
+  are correct for where you are.
 
 See also: [Google's guide to app permissions](https://support.google.com/googleplay/answer/6270602?p=app_permissions_m)
 
 ### Time
 
-Sky Map uses your device's clock and time zone to calculate where objects appear in the sky. Time
-errors are uncommon, but an incorrect time zone in particular can shift the entire sky by several
-hours.
+Sky Map uses your device's clock and time zone. An incorrect time zone in particular can shift the
+entire sky by several hours — making it look completely wrong even with a good compass and correct
+location.
 
-Open the **Diagnostics** page and confirm that the time and time zone shown there are correct. If
-they are wrong, that is a device clock issue rather than a Sky Map problem — correct it in your
-device's system settings.
+Open the **Diagnostics** page and check that the time and time zone shown are correct. If they
+are wrong, fix them in your device's system settings.
 
 ---
 
 ## About phone compasses
 
-Sky Map doesn't calculate your orientation from scratch — it reads the data provided by your
-phone's built-in magnetometer. If the phone reports that its sensor is uncalibrated, Sky Map
-displays an accuracy warning.
+This section explains the physics behind why phone compasses fail, for users who want a deeper
+understanding.
 
-### What calibration actually does
+### What the figure-8 gesture actually does
 
-Calibration is a hardware-level process that helps the sensor account for "Hard Iron" and "Soft
-Iron" distortions caused by the components inside the phone itself.
+The figure-8 calibration gesture forces your phone's magnetometer to sample the magnetic field
+from many different orientations. The sensor's firmware uses these samples to estimate and cancel
+out "Hard Iron" distortions — constant magnetic fields produced by permanent magnets in the
+phone's own components — and "Soft Iron" distortions from ferrous metals in the chassis that
+distort external fields.
 
-**The goal:** to ensure the sensor sees a consistent "circle" of magnetic data as you rotate the
-phone through all orientations.
+The goal is to make the sensor's response consistent as you rotate the phone through all
+orientations. Think of it as the phone learning to ignore its own internal magnetic noise.
 
-**The reality:** calibration makes the sensor internally consistent, but it does not guarantee that
-it is pointing to True North.
+**What it does not do:** it cannot remove the effect of magnetic sources outside the phone. Once
+calibrated, the sensor faithfully reports the field it is in — including any bias from a nearby
+car dashboard or magnetic case.
 
-### Why the map might still be off — magnetic bias
+### The calibrated-but-inaccurate compass
 
-Even a perfectly calibrated sensor can suffer from magnetic bias. The Earth's magnetic field is a
-relatively weak signal, easily disturbed by:
+This is the crucial distinction most guides skip:
 
-- **Local interference:** metal structures, car dashboards, or magnets in phone cases
-- **Environmental offset:** a calibrated sensor knows how to read itself, but has no way of knowing
-  you're standing next to a refrigerator. This creates a constant bias that shifts the star map
-  regardless of calibration status.
-- **Hardware quality:** some phones simply have poor magnetometers. If yours has a consistent
-  offset of several degrees, the manual compass offset in
-  **Settings → Sensor Settings (Experts)** is your best option.
+- Android reports compass *calibration status* as Unknown → Unreliable → Low → Medium → High.
+  Sky Map displays this status and shows a warning when it is below Medium.
+- Calibration status reflects internal consistency, not pointing accuracy. A sensor with
+  "Accuracy: High" simply means the phone is confident in its own internal calibration — it says
+  nothing about whether the phone is free from external interference.
 
-The figure-8 calibration gesture ([see video](https://www.youtube.com/watch?v=-Uq7AmSAjt8)) forces
-the sensor to sample the magnetic field from many angles, allowing the hardware to filter out
-internal noise. Move to a clear area away from metal objects and magnetic sources before performing
-it.
+A sensor that reads "High" accuracy near a refrigerator will confidently and consistently point in
+the wrong direction.
 
-> This is a physical property of mobile hardware. If the map remains slightly shifted, your
-> environment is likely causing a magnetic bias that the software cannot fully correct.
+### Why hardware quality matters
+
+Not all magnetometers are equal. Some phones — particularly cheaper models or certain
+manufacturer lines — have sensors with a persistent bias of 5–15° regardless of environment or
+calibration. For these devices, the manual compass offset (**Settings → Sensor Settings
+(Experts)**) is the best available workaround. No app can compensate for a fundamentally poor
+sensor.
+
+> Sky Map can only display what your phone reports. If the phone's compass is biased, the map
+> will be biased by the same amount. This is a physical property of mobile hardware, not a
+> software problem.
 
 ---
 
 ## The map doesn't move
 
-- Make sure you haven't switched into Manual Mode — tap the sensor icon to return to Automatic Mode.
-- Your phone must have at minimum a compass (magnetometer) and an accelerometer. A gyroscope is
-  strongly recommended. Check the **Diagnostics** page (overflow menu) to see which sensors your
-  device has — missing sensors show as `--,--,--`.
-- If you have all the required sensors but the map is still stuck, try the figure-8 compass
-  calibration — see [About phone compasses](#about-phone-compasses).
+- Make sure you haven't switched to Manual Mode — tap the sensor icon to return to Automatic Mode.
+- Your phone needs at minimum a compass (magnetometer) and an accelerometer. Check the
+  **Diagnostics** page — missing sensors appear as `--,--,--`.
+- If sensors are present but the map is stuck, try the figure-8 calibration gesture.
 
 ---
 
 ## The map is jittery
 
-- If your phone lacks a gyroscope, some jitter is normal. Enable **Disable Gyro** under
-  **Settings → Sensor Settings (Experts)** to use the alternative sensor mode.
-- Try adjusting **Sensor Speed** and **Sensor Damping** in the same settings section.
+- Some jitter is normal if your phone has no gyroscope. Enable **Disable Gyro** under
+  **Settings → Sensor Settings (Experts)** to switch to the alternative sensor mode.
+- Adjust **Sensor Speed** and **Sensor Damping** in the same section to tune the response.
 
 ---
 
 ## Do I need an internet connection?
 
 No. Sky Map works fully offline. An internet connection is only needed to:
-- Look up a location by place name (you can enter lat/long manually instead)
+
+- Look up a location by place name (you can enter lat/long directly instead)
 - Load Hubble Gallery images (previously cached images may still be available offline)
 
 ---
@@ -134,16 +161,15 @@ No. Sky Map works fully offline. An internet connection is only needed to:
 ## Can I help test the latest features?
 
 Yes! Join the [beta testing program](https://play.google.com/apps/testing/com.google.android.stardroid)
-on Google Play to get the latest version before it goes public.
-
+on Google Play.
 
 ---
 
 ## Still stuck?
 
 Open the **Diagnostics** page from the overflow menu and email us at **skymapdevs@gmail.com** with
-a screenshot. It contains your sensor status, location, and time info which helps us diagnose
-problems quickly.
+a screenshot. It contains your sensor readings, location, and time info which helps us understand
+what's happening on your device.
 
 ---
 


### PR DESCRIPTION
## Summary

- Rewrites all user-facing compass/calibration text around two key messages that were missing or buried: **Sky Map reads the phone sensor and cannot override it**, and **a calibrated compass is not necessarily an accurate one**
- Splits the `compass` review class into three sub-classes with distinct response framing for the LLM-based Play Store review responder
- Adds `troubleshooting-llm.md` — a new document structured specifically for the review responder, with per-category framing, ordered steps, and phrases to avoid

## Changes

**`strings.xml`** — calibration dialog headings and body text rewritten to lead with the calibration/accuracy distinction; "Improve Your Alignment" heading replaced with "Your Phone's Compass"; hardcoded toast string extracted to a resource (`compass_low_accuracy_toast`)

**`SensorAccuracyMonitor.kt`** — hardcoded toast literal replaced with the new string resource

**`help.xml`** — hardware callout and compass troubleshooting bullet strengthened with the calibrated≠accurate message

**`troubleshooting.md`** — compass section rewritten with a clear calibration/accuracy distinction, an interference source table, and a note on why "it broke after an update" is almost always a phone OS change not a Sky Map change

**`troubleshooting-llm.md`** *(new)* — structured reference for the Play Store review responder: complaint categories (CAT-1 through CAT-7), response framing per category, steps to suggest in order, phrases to avoid, tone guidelines, and suggested opening lines

**`SKILL.md` (respond-reviews skill)** — Step 2 classification table split into sub-classes; Step 3 now reads `troubleshooting-llm.md` as primary reference

## Test plan

- [ ] Build and verify calibration dialog text renders correctly (portrait and landscape)
- [ ] Trigger low-accuracy toast (suppress the dialog via checkbox) and confirm new wording appears
- [ ] Read through in-app help and confirm compass troubleshooting section reads clearly
- [ ] Run the respond-reviews skill against a batch of compass-complaint reviews and confirm it correctly sub-classifies and applies appropriate framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)