### PR TITLE
Fix manual location entry for locales with comma decimal separator

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
@@ -4,6 +4,7 @@ import android.app.AlertDialog
 import android.app.Dialog
 import android.location.Geocoder
 import android.os.Bundle
+import android.text.InputType
 import android.text.method.DigitsKeyListener
 import android.view.LayoutInflater
 import android.view.View
@@ -52,9 +53,15 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
         @Suppress("DEPRECATION")
         val coordKeyListener = DigitsKeyListener.getInstance("-0123456789.,")
         latEdit.keyListener = coordKeyListener
-        latEdit.setRawInputType(android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_FLAG_SIGNED or android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL)
+        latEdit.setRawInputType(
+            InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED or
+                InputType.TYPE_NUMBER_FLAG_DECIMAL
+        )
         lonEdit.keyListener = coordKeyListener
-        lonEdit.setRawInputType(android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_FLAG_SIGNED or android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL)
+        lonEdit.setRawInputType(
+            InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED or
+                InputType.TYPE_NUMBER_FLAG_DECIMAL
+        )
 
         if (!prefillLat.isNaN() && !prefillLon.isNaN() && (prefillLat != 0f || prefillLon != 0f)) {
             val coordinateFormat = getString(R.string.location_coordinate_format)

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
@@ -4,6 +4,7 @@ import android.app.AlertDialog
 import android.app.Dialog
 import android.location.Geocoder
 import android.os.Bundle
+import android.text.method.DigitsKeyListener
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Button
@@ -15,8 +16,6 @@ import com.google.android.stardroid.control.LocationController
 import com.google.android.stardroid.math.LatLong
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.IOException
-import java.text.NumberFormat
-import java.text.ParsePosition
 import java.util.concurrent.ScheduledExecutorService
 import javax.inject.Inject
 
@@ -50,9 +49,14 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
         val prefillLon = arguments?.getFloat(ARG_LON, Float.NaN) ?: Float.NaN
         val prefillName = arguments?.getString(ARG_NAME, "") ?: ""
 
+        val coordKeyListener = DigitsKeyListener.getInstance("-0123456789.,")
+        latEdit.keyListener = coordKeyListener
+        lonEdit.keyListener = coordKeyListener
+
         if (!prefillLat.isNaN() && !prefillLon.isNaN() && (prefillLat != 0f || prefillLon != 0f)) {
-            latEdit.setText(prefillLat.toString())
-            lonEdit.setText(prefillLon.toString())
+            val format = getString(R.string.location_coordinate_format)
+            latEdit.setText(format.format(prefillLat))
+            lonEdit.setText(format.format(prefillLon))
         }
         if (prefillName.isNotEmpty()) placeNameEdit.setText(prefillName)
 
@@ -120,16 +124,8 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
         placeErrorText.visibility = View.VISIBLE
     }
 
-    private fun parseCoordinate(str: String): Float? {
-        val format = NumberFormat.getInstance()
-        val pos = ParsePosition(0)
-        val number = format.parse(str, pos)
-        if (pos.index == str.length && pos.errorIndex == -1 && number != null) {
-            return number.toFloat()
-        }
-        // Fallback to strict period/comma-lenient parsing to support cross-locale copy-paste
-        return str.replace(',', '.').toFloatOrNull()
-    }
+    private fun parseCoordinate(str: String): Float? =
+        str.trim().replace(',', '.').toFloatOrNull()
 
     private fun trySetLocation() {
         var valid = true

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
@@ -51,7 +51,9 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
 
         val coordKeyListener = DigitsKeyListener.getInstance("-0123456789.,")
         latEdit.keyListener = coordKeyListener
+        latEdit.setRawInputType(android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_FLAG_SIGNED or android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL)
         lonEdit.keyListener = coordKeyListener
+        lonEdit.setRawInputType(android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_FLAG_SIGNED or android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL)
 
         if (!prefillLat.isNaN() && !prefillLon.isNaN() && (prefillLat != 0f || prefillLon != 0f)) {
             val format = getString(R.string.location_coordinate_format)

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
@@ -49,6 +49,7 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
         val prefillLon = arguments?.getFloat(ARG_LON, Float.NaN) ?: Float.NaN
         val prefillName = arguments?.getString(ARG_NAME, "") ?: ""
 
+        @Suppress("DEPRECATION")
         val coordKeyListener = DigitsKeyListener.getInstance("-0123456789.,")
         latEdit.keyListener = coordKeyListener
         latEdit.setRawInputType(android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_FLAG_SIGNED or android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL)
@@ -56,9 +57,9 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
         lonEdit.setRawInputType(android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_FLAG_SIGNED or android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL)
 
         if (!prefillLat.isNaN() && !prefillLon.isNaN() && (prefillLat != 0f || prefillLon != 0f)) {
-            val format = getString(R.string.location_coordinate_format)
-            latEdit.setText(format.format(prefillLat))
-            lonEdit.setText(format.format(prefillLon))
+            val coordinateFormat = getString(R.string.location_coordinate_format)
+            latEdit.setText(coordinateFormat.format(prefillLat))
+            lonEdit.setText(coordinateFormat.format(prefillLon))
         }
         if (prefillName.isNotEmpty()) placeNameEdit.setText(prefillName)
 

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
@@ -51,7 +51,10 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
         val prefillName = arguments?.getString(ARG_NAME, "") ?: ""
 
         @Suppress("DEPRECATION")
-        val coordKeyListener = DigitsKeyListener.getInstance("-0123456789.,")
+        // Arabic-Indic (٠-٩), Eastern Arabic-Indic (۰-۹), and Arabic decimal separator (٫)
+        val coordKeyListener = DigitsKeyListener.getInstance(
+            "-0123456789.,٫٠١٢٣٤٥٦٧٨٩۰۱۲۳۴۵۶۷۸۹"
+        )
         latEdit.keyListener = coordKeyListener
         latEdit.setRawInputType(
             InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED or
@@ -65,8 +68,8 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
 
         if (!prefillLat.isNaN() && !prefillLon.isNaN() && (prefillLat != 0f || prefillLon != 0f)) {
             val coordinateFormat = getString(R.string.location_coordinate_format)
-            latEdit.setText(coordinateFormat.format(java.util.Locale.US, prefillLat))
-            lonEdit.setText(coordinateFormat.format(java.util.Locale.US, prefillLon))
+            latEdit.setText(coordinateFormat.format(prefillLat))
+            lonEdit.setText(coordinateFormat.format(prefillLon))
         }
         if (prefillName.isNotEmpty()) placeNameEdit.setText(prefillName)
 
@@ -134,8 +137,19 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
         placeErrorText.visibility = View.VISIBLE
     }
 
-    private fun parseCoordinate(str: String): Float? =
-        str.trim().replace(',', '.').toFloatOrNull()
+    private fun parseCoordinate(str: String): Float? {
+        val normalized = buildString {
+            for (char in str.trim()) {
+                when (char) {
+                    ',', '٫' -> append('.')
+                    in '٠'..'٩' -> append('0' + (char - '٠'))
+                    in '۰'..'۹' -> append('0' + (char - '۰'))
+                    else -> append(char)
+                }
+            }
+        }
+        return normalized.toFloatOrNull()
+    }
 
     private fun trySetLocation() {
         var valid = true

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
@@ -65,8 +65,8 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
 
         if (!prefillLat.isNaN() && !prefillLon.isNaN() && (prefillLat != 0f || prefillLon != 0f)) {
             val coordinateFormat = getString(R.string.location_coordinate_format)
-            latEdit.setText(coordinateFormat.format(prefillLat))
-            lonEdit.setText(coordinateFormat.format(prefillLon))
+            latEdit.setText(coordinateFormat.format(java.util.Locale.US, prefillLat))
+            lonEdit.setText(coordinateFormat.format(java.util.Locale.US, prefillLon))
         }
         if (prefillName.isNotEmpty()) placeNameEdit.setText(prefillName)
 

--- a/stardroid-v1/app/src/test/java/com/google/android/stardroid/control/ManualLocationValidationTest.kt
+++ b/stardroid-v1/app/src/test/java/com/google/android/stardroid/control/ManualLocationValidationTest.kt
@@ -38,4 +38,32 @@ class ManualLocationValidationTest {
         assertThat("".toFloatOrNull()).isNull()
         assertThat("12.3".toFloatOrNull()).isEqualTo(12.3f)
     }
+
+    // Tests for parseCoordinate logic (str.trim().replace(',', '.').toFloatOrNull())
+    private fun parseCoordinate(str: String): Float? = str.trim().replace(',', '.').toFloatOrNull()
+
+    @Test fun parseCoordinate_dotDecimal_parsesCorrectly() {
+        assertThat(parseCoordinate("52.63")).isWithin(0.0001f).of(52.63f)
+    }
+
+    @Test fun parseCoordinate_commaDecimal_parsesCorrectly() {
+        assertThat(parseCoordinate("52,63")).isWithin(0.0001f).of(52.63f)
+    }
+
+    @Test fun parseCoordinate_negativeDotDecimal_parsesCorrectly() {
+        assertThat(parseCoordinate("-20.69")).isWithin(0.0001f).of(-20.69f)
+    }
+
+    @Test fun parseCoordinate_negativeCommaDecimal_parsesCorrectly() {
+        assertThat(parseCoordinate("-20,69")).isWithin(0.0001f).of(-20.69f)
+    }
+
+    @Test fun parseCoordinate_leadingTrailingWhitespace_parsesCorrectly() {
+        assertThat(parseCoordinate("  52.63  ")).isWithin(0.0001f).of(52.63f)
+    }
+
+    @Test fun parseCoordinate_invalidString_returnsNull() {
+        assertThat(parseCoordinate("abc")).isNull()
+        assertThat(parseCoordinate("")).isNull()
+    }
 }

--- a/stardroid-v1/app/src/test/java/com/google/android/stardroid/control/ManualLocationValidationTest.kt
+++ b/stardroid-v1/app/src/test/java/com/google/android/stardroid/control/ManualLocationValidationTest.kt
@@ -39,8 +39,21 @@ class ManualLocationValidationTest {
         assertThat("12.3".toFloatOrNull()).isEqualTo(12.3f)
     }
 
-    // Tests for parseCoordinate logic (str.trim().replace(',', '.').toFloatOrNull())
-    private fun parseCoordinate(str: String): Float? = str.trim().replace(',', '.').toFloatOrNull()
+    // Tests for parseCoordinate logic — normalises Arabic-Indic/Eastern Arabic-Indic digits
+    // and comma/Arabic decimal separators to ASCII before parsing.
+    private fun parseCoordinate(str: String): Float? {
+        val normalized = buildString {
+            for (char in str.trim()) {
+                when (char) {
+                    ',', '٫' -> append('.')
+                    in '٠'..'٩' -> append('0' + (char - '٠'))
+                    in '۰'..'۹' -> append('0' + (char - '۰'))
+                    else -> append(char)
+                }
+            }
+        }
+        return normalized.toFloatOrNull()
+    }
 
     @Test fun parseCoordinate_dotDecimal_parsesCorrectly() {
         assertThat(parseCoordinate("52.63")).isWithin(0.0001f).of(52.63f)
@@ -65,5 +78,21 @@ class ManualLocationValidationTest {
     @Test fun parseCoordinate_invalidString_returnsNull() {
         assertThat(parseCoordinate("abc")).isNull()
         assertThat(parseCoordinate("")).isNull()
+    }
+
+    @Test fun parseCoordinate_arabicIndicDigits_parsesCorrectly() {
+        assertThat(parseCoordinate("٥٢٫٦٣")).isWithin(0.0001f).of(52.63f)
+    }
+
+    @Test fun parseCoordinate_arabicIndicNegative_parsesCorrectly() {
+        assertThat(parseCoordinate("-٢٠٫٦٩")).isWithin(0.0001f).of(-20.69f)
+    }
+
+    @Test fun parseCoordinate_easternArabicIndicDigits_parsesCorrectly() {
+        assertThat(parseCoordinate("۵۲٫۶۳")).isWithin(0.0001f).of(52.63f)
+    }
+
+    @Test fun parseCoordinate_easternArabicIndicNegative_parsesCorrectly() {
+        assertThat(parseCoordinate("-۲۰٫۶۹")).isWithin(0.0001f).of(-20.69f)
     }
 }


### PR DESCRIPTION
Fixes #908

Keeps `inputType="numberSigned|numberDecimal"` in XML (numeric keyboard with locale-appropriate decimal key), and overrides the KeyListener with `DigitsKeyListener.getInstance("-0123456789.,")` to allow commas. Also fixes `parseCoordinate` (NumberFormat misparses dots in Polish locale) and prefill formatting.

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/sky-map-team/stardroid/actions/runs/27158701049) • [Branch](https://github.com/sky-map-team/stardroid/tree/claude/issue-908-20260608-1833