### PR TITLE
Freeze text angle near zenith to prevent label flickering

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -148,8 +148,14 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
    * @author John Taylor
    */
   private static final class RendererModelUpdateClosure implements Runnable {
+    // Freeze text orientation when pointing within 20° of zenith; thaw above 30°.
+    private static final float ZENITH_FREEZE_COS = (float) Math.cos(Math.toRadians(20));
+    private static final float ZENITH_UNFREEZE_COS = (float) Math.cos(Math.toRadians(30));
+
     private final RendererController rendererController;
     private final AstronomerModel model;
+    private float frozenTextAngle = 0f;
+    private boolean textAngleFrozen = false;
 
     public RendererModelUpdateClosure(AstronomerModel model,
         RendererController rendererController,
@@ -173,11 +179,24 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
 
       rendererController.queueSetViewOrientation(directionX, directionY, directionZ, upX, upY, upZ);
 
+      Vector3 zenith = model.getZenith();
+      float dotWithZenith = directionX * zenith.x + directionY * zenith.y + directionZ * zenith.z;
+
       Vector3 up = model.getPhoneUpDirection();
       //noinspection SuspiciousNameCombination swapping x and y here is actually correct
       float angleVertClockwiseFromYaxisInRadians = MathUtils.atan2(up.x, up.y);
-      rendererController.queueTextAngle(angleVertClockwiseFromYaxisInRadians);
-      rendererController.queueViewerUpDirection(model.getZenith().copyForJ());
+      if (textAngleFrozen) {
+        if (dotWithZenith < ZENITH_UNFREEZE_COS) {
+          textAngleFrozen = false;
+        }
+      } else {
+        if (dotWithZenith >= ZENITH_FREEZE_COS) {
+          textAngleFrozen = true;
+          frozenTextAngle = angleVertClockwiseFromYaxisInRadians;
+        }
+      }
+      rendererController.queueTextAngle(textAngleFrozen ? frozenTextAngle : angleVertClockwiseFromYaxisInRadians);
+      rendererController.queueViewerUpDirection(zenith.copyForJ());
 
       float fieldOfView = model.getFieldOfView();
       rendererController.queueFieldOfView(fieldOfView);

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -195,7 +195,8 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
           frozenTextAngle = angleVertClockwiseFromYaxisInRadians;
         }
       }
-      rendererController.queueTextAngle(textAngleFrozen ? frozenTextAngle : angleVertClockwiseFromYaxisInRadians);
+      rendererController.queueTextAngle(
+          textAngleFrozen ? frozenTextAngle : angleVertClockwiseFromYaxisInRadians);
       rendererController.queueViewerUpDirection(zenith.copyForJ());
 
       float fieldOfView = model.getFieldOfView();


### PR DESCRIPTION
When the phone is tilted close to vertical (pointing at zenith), the phone-up vector loses a reliable "down" reference, causing text label orientation to flutter. This change freezes the text angle once the phone's line-of-sight comes within 20° of zenith, and releases the freeze with hysteresis at 30° to avoid repeated triggering at the boundary.

Fixes #912

Generated with [Claude Code](https://claude.ai/code)