### PR TITLE
Fix welcome screen buttons hidden by system navigation bar on Android 15+

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
@@ -21,6 +21,8 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
@@ -73,6 +75,15 @@ class WarmWelcomeActivity : AppCompatActivity(), WhatsNewDialogFragment.CloseLis
         btnSkip = findViewById(R.id.btn_skip)
         btnNextFinish = findViewById(R.id.btn_next_finish)
         indicatorsContainer = findViewById(R.id.indicators_container)
+
+        val bottomContainer = findViewById<LinearLayout>(R.id.bottom_container)
+        val initialBottomPadding = bottomContainer.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(bottomContainer) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(view.paddingLeft, view.paddingTop, view.paddingRight,
+                initialBottomPadding + systemBars.bottom)
+            insets
+        }
 
         val adapter = WelcomePagerAdapter(this)
         viewPager.adapter = adapter

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/WarmWelcomeActivity.kt
@@ -77,11 +77,20 @@ class WarmWelcomeActivity : AppCompatActivity(), WhatsNewDialogFragment.CloseLis
         indicatorsContainer = findViewById(R.id.indicators_container)
 
         val bottomContainer = findViewById<LinearLayout>(R.id.bottom_container)
+        val initialLeftPadding = bottomContainer.paddingLeft
+        val initialTopPadding = bottomContainer.paddingTop
+        val initialRightPadding = bottomContainer.paddingRight
         val initialBottomPadding = bottomContainer.paddingBottom
         ViewCompat.setOnApplyWindowInsetsListener(bottomContainer) { view, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(view.paddingLeft, view.paddingTop, view.paddingRight,
-                initialBottomPadding + systemBars.bottom)
+            val systemBars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            view.setPadding(
+                initialLeftPadding + systemBars.left,
+                initialTopPadding,
+                initialRightPadding + systemBars.right,
+                initialBottomPadding + systemBars.bottom
+            )
             insets
         }
 


### PR DESCRIPTION
Apply WindowInsetsCompat listener to bottom_container in WarmWelcomeActivity so the Skip/Next/Finish buttons are correctly positioned above the system navigation bar.

On Android 15+ (targetSdk 35+), edge-to-edge rendering is enforced and the system navigation bar overlays the bottom of the app. Without inset handling, taps on the buttons landed on the gesture navigation surface, making it appear as if the welcome screen "dead ended to nothing".

Fixes #915

Generated with [Claude Code](https://claude.ai/code)