### PR TITLE
Don't show What's New dialog on fresh installs, only on upgrades

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/StartupRouter.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/StartupRouter.kt
@@ -30,6 +30,9 @@ class StartupRouter @Inject constructor(
         sharedPreferences.edit {
             putLong(ApplicationConstants.READ_WARM_WELCOME_PREF_VERSION, app.version)
             putBoolean(ApplicationConstants.NO_WARN_ABOUT_MISSING_SENSORS, true)
+            // Mark what's new seen so fresh installs skip the dialog; upgrades still see it
+            // because this method is only called after the warm welcome (fresh install path).
+            putLong(ApplicationConstants.READ_WHATS_NEW_PREF_VERSION, app.version)
         }
     }
 


### PR DESCRIPTION
On a fresh install, the warm welcome already introduces the app's features, so showing the What's New dialog immediately after is redundant and confusing. This change marks the What's New preference as seen when the warm welcome completes, suppressing the dialog for fresh installs. On upgrades, the warm welcome is skipped (already seen), so the What's New dialog still appears as expected.

Fixes #915

Generated with [Claude Code](https://claude.ai/code)