### PR TITLE
Highlight the ecliptic and add a graduated degree scale

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/EclipticLayer.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/EclipticLayer.kt
@@ -15,7 +15,6 @@ package com.google.android.stardroid.layers
 
 import android.content.SharedPreferences
 import android.content.res.Resources
-import android.graphics.Color
 import com.google.android.stardroid.R
 import com.google.android.stardroid.math.Vector3
 import com.google.android.stardroid.math.getGeocentricCoords
@@ -51,18 +50,6 @@ class EclipticLayer(resources: Resources, preferences: SharedPreferences) : Abst
         companion object {
             private const val EARTHS_ANGULAR_TILT = 23.439281f
 
-            // Star Gold (#FF9F1C), the primary brand color. The ecliptic is the Sun's apparent
-            // path, so gold is both on-brand and thematically apt. The renderer red-shifts this
-            // automatically in night-vision mode. The line is kept fairly faint so it reads as a
-            // reference line rather than competing with the stars; labels are always drawn opaque
-            // by the label renderer regardless of this alpha.
-            //
-            // NOTE: the line renderer (NightVisionColorBuffer) reads the color int as ABGR, while
-            // the label renderer (LabelObjectManager) reads it as ARGB. So the same gold needs the
-            // red and blue channels swapped between the two, or the line renders blue.
-            private val LABEL_COLOR = Color.argb(255, 255, 159, 28)
-            private val LINE_COLOR = Color.argb(64, 28, 159, 255)
-
             // Labels are nudged a few degrees off the ecliptic in ecliptic *latitude* (i.e.
             // perpendicular to the line everywhere), so they sit a uniform small distance from the
             // line rather than striking through it. The ticks below bridge the small gap.
@@ -96,14 +83,23 @@ class EclipticLayer(resources: Resources, preferences: SharedPreferences) : Abst
         }
 
         init {
+            // Star Gold (#FF9F1C), loaded from resources per the style guide. The renderer
+            // red-shifts both automatically in night-vision mode. See colors.xml for why the line
+            // colour's red/blue channels are swapped relative to the label colour.
+            val labelColor = resources.getColor(R.color.ecliptic_label, null)
+            val lineColor = resources.getColor(R.color.ecliptic_line, null)
             val title = resources.getString(R.string.ecliptic)
             // Place the descriptive name off the 30-degree marks (45 & 225) so it doesn't collide
             // with the degree labels.
             labels.add(
-                TextPrimitive(geocentricForEcliptic(45f, LABEL_LATITUDE_OFFSET), title, LABEL_COLOR)
+                TextPrimitive(
+                    geocentricForEcliptic(45f, LABEL_LATITUDE_OFFSET), title, labelColor
+                )
             )
             labels.add(
-                TextPrimitive(geocentricForEcliptic(225f, LABEL_LATITUDE_OFFSET), title, LABEL_COLOR)
+                TextPrimitive(
+                    geocentricForEcliptic(225f, LABEL_LATITUDE_OFFSET), title, labelColor
+                )
             )
 
             // Graduation ticks every 10 degrees of ecliptic longitude, each pointing off the line
@@ -113,11 +109,11 @@ class EclipticLayer(resources: Resources, preferences: SharedPreferences) : Abst
                 val isMajor = longitude % 30 == 0
                 val tickLength = if (isMajor) MAJOR_TICK_LENGTH else MINOR_TICK_LENGTH
                 val tickWidth = if (isMajor) 2.0f else 1.5f
-                val tick = arrayListOf(
+                val tick = listOf(
                     geocentricForEcliptic(longitude.toFloat(), 0f),
                     geocentricForEcliptic(longitude.toFloat(), tickLength)
                 )
-                lines.add(LinePrimitive(LINE_COLOR, tick, tickWidth))
+                lines.add(LinePrimitive(lineColor, tick, tickWidth))
             }
 
             // Degree labels at the 30 degree marks. The vernal equinox (0 deg) coincides exactly
@@ -127,8 +123,8 @@ class EclipticLayer(resources: Resources, preferences: SharedPreferences) : Abst
                 labels.add(
                     TextPrimitive(
                         geocentricForEcliptic(longitude.toFloat(), LABEL_LATITUDE_OFFSET),
-                        String.format("%d°", longitude),
-                        LABEL_COLOR
+                        "$longitude°",
+                        labelColor
                     )
                 )
             }
@@ -140,7 +136,7 @@ class EclipticLayer(resources: Resources, preferences: SharedPreferences) : Abst
             for (i in ra.indices) {
                 vertices.add(getGeocentricCoords(ra[i], dec[i]))
             }
-            lines.add(LinePrimitive(LINE_COLOR, vertices, 1.8f))
+            lines.add(LinePrimitive(lineColor, vertices, 1.8f))
         }
     }
 }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/EclipticLayer.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/EclipticLayer.kt
@@ -24,6 +24,8 @@ import com.google.android.stardroid.renderables.AstronomicalRenderable
 import com.google.android.stardroid.renderables.LinePrimitive
 import com.google.android.stardroid.renderables.TextPrimitive
 import java.util.*
+import kotlin.math.cos
+import kotlin.math.sin
 
 /**
  * Creates a Layer for the Ecliptic.
@@ -48,13 +50,88 @@ class EclipticLayer(resources: Resources, preferences: SharedPreferences) : Abst
 
         companion object {
             private const val EARTHS_ANGULAR_TILT = 23.439281f
-            private val LINE_COLOR = Color.argb(20, 248, 239, 188)
+
+            // Star Gold (#FF9F1C), the primary brand color. The ecliptic is the Sun's apparent
+            // path, so gold is both on-brand and thematically apt. The renderer red-shifts this
+            // automatically in night-vision mode. The line is kept fairly faint so it reads as a
+            // reference line rather than competing with the stars; labels are always drawn opaque
+            // by the label renderer regardless of this alpha.
+            //
+            // NOTE: the line renderer (NightVisionColorBuffer) reads the color int as ABGR, while
+            // the label renderer (LabelObjectManager) reads it as ARGB. So the same gold needs the
+            // red and blue channels swapped between the two, or the line renders blue.
+            private val LABEL_COLOR = Color.argb(255, 255, 159, 28)
+            private val LINE_COLOR = Color.argb(64, 28, 159, 255)
+
+            // Labels are nudged a few degrees off the ecliptic in ecliptic *latitude* (i.e.
+            // perpendicular to the line everywhere), so they sit a uniform small distance from the
+            // line rather than striking through it. The ticks below bridge the small gap.
+            private const val LABEL_LATITUDE_OFFSET = 3f
+
+            // Tick lengths, in degrees of ecliptic latitude. Minor ticks every 10 degrees, longer
+            // major ticks at the 30 degree zodiac/constellation boundaries.
+            private const val MINOR_TICK_LENGTH = 1f
+            private const val MAJOR_TICK_LENGTH = 2f
+
+            private val DEGREES_TO_RADIANS = (Math.PI / 180.0).toFloat()
+            private val OBLIQUITY_RADIANS = EARTHS_ANGULAR_TILT * DEGREES_TO_RADIANS
+
+            /**
+             * Geocentric unit vector for the point at the given ecliptic longitude and latitude
+             * (degrees). A non-zero latitude offsets the point perpendicular to the ecliptic.
+             */
+            private fun geocentricForEcliptic(longitude: Float, latitude: Float): Vector3 {
+                val lambda = longitude * DEGREES_TO_RADIANS
+                val beta = latitude * DEGREES_TO_RADIANS
+                val xe = cos(beta) * cos(lambda)
+                val ye = cos(beta) * sin(lambda)
+                val ze = sin(beta)
+                // Rotate about the x-axis by the obliquity to convert ecliptic -> equatorial.
+                return Vector3(
+                    xe,
+                    ye * cos(OBLIQUITY_RADIANS) - ze * sin(OBLIQUITY_RADIANS),
+                    ye * sin(OBLIQUITY_RADIANS) + ze * cos(OBLIQUITY_RADIANS)
+                )
+            }
         }
 
         init {
             val title = resources.getString(R.string.ecliptic)
-            labels.add(TextPrimitive(90.0f, EARTHS_ANGULAR_TILT, title, LINE_COLOR))
-            labels.add(TextPrimitive(270f, -EARTHS_ANGULAR_TILT, title, LINE_COLOR))
+            // Place the descriptive name off the 30-degree marks (45 & 225) so it doesn't collide
+            // with the degree labels.
+            labels.add(
+                TextPrimitive(geocentricForEcliptic(45f, LABEL_LATITUDE_OFFSET), title, LABEL_COLOR)
+            )
+            labels.add(
+                TextPrimitive(geocentricForEcliptic(225f, LABEL_LATITUDE_OFFSET), title, LABEL_COLOR)
+            )
+
+            // Graduation ticks every 10 degrees of ecliptic longitude, each pointing off the line
+            // toward its label. The 30 degree marks (zodiac/constellation boundaries) get longer,
+            // slightly heavier ticks.
+            for (longitude in 0 until 360 step 10) {
+                val isMajor = longitude % 30 == 0
+                val tickLength = if (isMajor) MAJOR_TICK_LENGTH else MINOR_TICK_LENGTH
+                val tickWidth = if (isMajor) 2.0f else 1.5f
+                val tick = arrayListOf(
+                    geocentricForEcliptic(longitude.toFloat(), 0f),
+                    geocentricForEcliptic(longitude.toFloat(), tickLength)
+                )
+                lines.add(LinePrimitive(LINE_COLOR, tick, tickWidth))
+            }
+
+            // Degree labels at the 30 degree marks. The vernal equinox (0 deg) coincides exactly
+            // with 0h RA / 0 deg dec, so it is labelled once by the grid layer (as "0") instead of
+            // here, to avoid two labels stacking at the same point.
+            for (longitude in 30 until 360 step 30) {
+                labels.add(
+                    TextPrimitive(
+                        geocentricForEcliptic(longitude.toFloat(), LABEL_LATITUDE_OFFSET),
+                        String.format("%d°", longitude),
+                        LABEL_COLOR
+                    )
+                )
+            }
 
             // Create line source.
             val ra = floatArrayOf(0f, 90f, 180f, 270f, 0f)
@@ -63,7 +140,7 @@ class EclipticLayer(resources: Resources, preferences: SharedPreferences) : Abst
             for (i in ra.indices) {
                 vertices.add(getGeocentricCoords(ra[i], dec[i]))
             }
-            lines.add(LinePrimitive(LINE_COLOR, vertices, 1.5f))
+            lines.add(LinePrimitive(LINE_COLOR, vertices, 1.8f))
         }
     }
 }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/EclipticLayer.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/EclipticLayer.kt
@@ -62,6 +62,8 @@ class EclipticLayer(resources: Resources, preferences: SharedPreferences) : Abst
 
             private val DEGREES_TO_RADIANS = (Math.PI / 180.0).toFloat()
             private val OBLIQUITY_RADIANS = EARTHS_ANGULAR_TILT * DEGREES_TO_RADIANS
+            private val COS_OBLIQUITY = cos(OBLIQUITY_RADIANS)
+            private val SIN_OBLIQUITY = sin(OBLIQUITY_RADIANS)
 
             /**
              * Geocentric unit vector for the point at the given ecliptic longitude and latitude
@@ -70,14 +72,15 @@ class EclipticLayer(resources: Resources, preferences: SharedPreferences) : Abst
             private fun geocentricForEcliptic(longitude: Float, latitude: Float): Vector3 {
                 val lambda = longitude * DEGREES_TO_RADIANS
                 val beta = latitude * DEGREES_TO_RADIANS
-                val xe = cos(beta) * cos(lambda)
-                val ye = cos(beta) * sin(lambda)
+                val cosBeta = cos(beta)
+                val xe = cosBeta * cos(lambda)
+                val ye = cosBeta * sin(lambda)
                 val ze = sin(beta)
                 // Rotate about the x-axis by the obliquity to convert ecliptic -> equatorial.
                 return Vector3(
                     xe,
-                    ye * cos(OBLIQUITY_RADIANS) - ze * sin(OBLIQUITY_RADIANS),
-                    ye * sin(OBLIQUITY_RADIANS) + ze * cos(OBLIQUITY_RADIANS)
+                    ye * COS_OBLIQUITY - ze * SIN_OBLIQUITY,
+                    ye * SIN_OBLIQUITY + ze * COS_OBLIQUITY
                 )
             }
         }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/GridLayer.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/layers/GridLayer.kt
@@ -130,7 +130,10 @@ class GridLayer
             )
             for (index in 0..11) {
                 val ra = index * 30.0f
-                val title = String.format("%dh", 2 * index)
+                // RA 0h / dec 0 is also the ecliptic's vernal equinox (ecliptic longitude 0). The
+                // ecliptic layer deliberately omits its "0 deg" label there, so this single "0"
+                // (in the grid/RA color) serves both.
+                val title = if (index == 0) "0" else String.format("%dh", 2 * index)
                 labels.add(TextPrimitive(ra, 0.0f, title, LINE_COLOR))
             }
             lines.add(createDecLine(0f)) // Equator

--- a/stardroid-v1/app/src/main/res/values/colors.xml
+++ b/stardroid-v1/app/src/main/res/values/colors.xml
@@ -28,4 +28,12 @@
     <color name="night_button_on_tint">#FFCC4444</color>
     <!-- Near-black MULTIPLY tint for disabled layer buttons in night mode -->
     <color name="night_button_off_tint">#FF2A0000</color>
+
+    <!-- Ecliptic (Star Gold #FF9F1C). ecliptic_label is the true brand gold used for the text.
+         ecliptic_line has its red and blue channels swapped (with alpha 0x40) because the line
+         renderer reads colours as ABGR while the label renderer reads ARGB; change it back to
+         #40FF9F1C once that renderer mismatch is fixed centrally. The renderer red-shifts both
+         automatically in night-vision mode. -->
+    <color name="ecliptic_label">#FFFF9F1C</color>
+    <color name="ecliptic_line">#401C9FFF</color>
 </resources>


### PR DESCRIPTION
## Summary

Make the ecliptic read as a clear reference line in the brand's **Star Gold** (`#FF9F1C`) instead of the previous near-invisible pale line, and add a graduated degree scale along it.

- **Faint gold great-circle line** — visible but kept subtle so it reads as a reference line rather than competing with the stars.
- **Graduation ticks** every 10° of ecliptic longitude, with longer/heavier ticks at the 30° zodiac/constellation boundaries, each pointing toward its label. Ticks share the line's color and alpha.
- **Degree labels** at the 30° marks, offset perpendicular to the line (in ecliptic *latitude*) so they sit a uniform small distance off it at every longitude.
- **Merged equinox label** — the vernal equinox (ecliptic longitude 0) coincides exactly with RA 0h / dec 0, so the ecliptic omits its "0°" label and the grid labels that shared point once, as **`0`**, in the RA/grid color.

## Notes

- The line renderer reads colors as ABGR while the label renderer reads ARGB, so the line/tick gold has its R and B channels swapped relative to the label gold (documented in a comment in `EclipticLayer`). This is a known codebase quirk; a central root-cause fix is planned on a separate branch.
- The 180°/12h point still shows two labels (only the 0 equinox was merged for now).
- Verified on a physical Pixel 5 (debug GMS build): brightness, label offsets, tick scale, and the merged `0` at the equinox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Partially addresses #126 — the "make the ecliptic stand out from the grid" half. The independent ecliptic/grid on-off toggle requested in that issue is still outstanding (they currently share the `source_provider.4` preference).
