### PR TITLE
Fix oversized location icon in overflow menu

### DIFF
--- a/stardroid-v1/app/src/main/res/drawable/ic_location.xml
+++ b/stardroid-v1/app/src/main/res/drawable/ic_location.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
+    android:width="24dp"
+    android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path


### PR DESCRIPTION
Fixes #26.

The "Your Location" row in the overflow menu rendered with a noticeably larger icon than the other rows, breaking the visual alignment of menu items.

## Root cause
`ic_location.xml` was declared at 48dp intrinsic size while every other menu icon (system bitmaps and other custom vectors like `ic_compass.xml`) is 24dp. The menu icon relies on intrinsic size, so it rendered twice as large as its neighbors.

## Fix
Changed `ic_location.xml` to 24dp x 24dp to match the other menu icons. The two dialogs that also use this drawable (`dialog_location_rationale.xml`, `dialog_location_permanently_denied.xml`) set an explicit 48dp size on their ImageView, so they are unaffected.

Generated with [Claude Code](https://claude.ai/code)