### PR TITLE
fix: migrate shouldOverrideUrlLoading to WebResourceRequest in dialog fragments

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/CreditsDialogFragment.java
@@ -5,11 +5,11 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -61,12 +61,12 @@ public class CreditsDialogFragment extends DialogFragment {
     WebView webView = view.findViewById(R.id.webview);
     webView.setWebViewClient(new WebViewClient() {
       @Override
-      public boolean shouldOverrideUrlLoading(WebView view, String url) {
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+      public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, request.getUrl());
         try {
           parentActivity.startActivity(intent);
         } catch (android.content.ActivityNotFoundException e) {
-          Log.w(TAG, "No handler for " + url, e);
+          Log.w(TAG, "No handler for " + request.getUrl(), e);
         }
         return true;
       }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/EulaDialogFragment.java
@@ -7,11 +7,11 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -123,13 +123,13 @@ public class EulaDialogFragment extends DialogFragment {
       WebView webView = view.findViewById(R.id.eula_webview);
       webView.setWebViewClient(new WebViewClient() {
         @Override
-        public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
           // Open links in external browser
-          Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+          Intent intent = new Intent(Intent.ACTION_VIEW, request.getUrl());
           try {
             parentActivity.startActivity(intent);
           } catch (android.content.ActivityNotFoundException e) {
-            Log.w(TAG, "No handler for " + url, e);
+            Log.w(TAG, "No handler for " + request.getUrl(), e);
           }
           return true;
         }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/HelpDialogFragment.java
@@ -6,11 +6,11 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -71,13 +71,13 @@ public class HelpDialogFragment extends DialogFragment {
     WebView webView = view.findViewById(R.id.webview);
     webView.setWebViewClient(new WebViewClient() {
       @Override
-      public boolean shouldOverrideUrlLoading(WebView view, String url) {
+      public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
         // Open links in external browser
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        Intent intent = new Intent(Intent.ACTION_VIEW, request.getUrl());
         try {
           activity.startActivity(intent);
         } catch (android.content.ActivityNotFoundException e) {
-          Log.w(TAG, "No handler for " + url, e);
+          Log.w(TAG, "No handler for " + request.getUrl(), e);
         }
         return true;
       }


### PR DESCRIPTION
## Summary

Replace the deprecated `shouldOverrideUrlLoading(WebView, String)` override with the modern `shouldOverrideUrlLoading(WebView, WebResourceRequest)` form in three dialog fragments: `CreditsDialogFragment`, `EulaDialogFragment`, and `HelpDialogFragment`.

- Switch method signature to accept `WebResourceRequest request` instead of `String url`
- Use `request.getUrl()` directly (returns a `Uri`) instead of the redundant `Uri.parse(url)` call
- Remove the now-unused `android.net.Uri` import from each file

## Why this matters

Closes #879. The two-argument `shouldOverrideUrlLoading(WebView, String)` was deprecated in API level 24. Since `minSdkVersion` is 26, there are no compatibility concerns — the modern form is both correct and available on every device the app supports.

## Testing

- Tap a hyperlink in the Credits screen and confirm it opens in the device browser
- Tap a hyperlink in the EULA dialog and confirm it opens in the device browser
- Tap a hyperlink in the Help dialog and confirm it opens in the device browser
- Verify no `ActivityNotFoundException` is swallowed silently on a device with no browser app installed
- Run `./gradlew :app:test` to confirm no regressions

Fixes #879