### PR TITLE
Force consistent 24dp menu icon size to fix Pixel 5 misalignment

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DynamicStarMapActivity.java
@@ -496,6 +496,7 @@ public class DynamicStarMapActivity extends androidx.fragment.app.FragmentActivi
   public boolean onPrepareOptionsMenu(Menu menu) {
     boolean result = super.onPrepareOptionsMenu(menu);
     MenuUtils.showOptionalIcons(menu);
+    MenuUtils.normalizeIconSizes(menu, this);
     NightModeHelper.tintMenuIcons(menu, nightMode, this);
     MenuItem tutorialItem = menu.findItem(R.id.menu_item_tutorial);
     if (tutorialItem != null) {

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/MenuUtils.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/MenuUtils.kt
@@ -1,9 +1,8 @@
 package com.google.android.stardroid.activities.util
 
 import android.content.Context
-import android.graphics.Canvas
-import android.graphics.ColorFilter
 import android.graphics.drawable.Drawable
+import android.graphics.drawable.DrawableWrapper
 import android.util.Log
 import android.view.Menu
 
@@ -66,28 +65,12 @@ object MenuUtils {
 
     /** A [Drawable] wrapper that always reports [sizePx] as its intrinsic width/height. */
     private class FixedSizeDrawable(
-        private val wrapped: Drawable,
+        wrapped: Drawable,
         private val sizePx: Int
-    ) : Drawable() {
+    ) : DrawableWrapper(wrapped) {
         init {
             wrapped.setBounds(0, 0, sizePx, sizePx)
         }
-
-        override fun draw(canvas: Canvas) {
-            wrapped.bounds = bounds
-            wrapped.draw(canvas)
-        }
-
-        override fun setAlpha(alpha: Int) {
-            wrapped.alpha = alpha
-        }
-
-        override fun setColorFilter(colorFilter: ColorFilter?) {
-            wrapped.colorFilter = colorFilter
-        }
-
-        @Deprecated("Deprecated in Java")
-        override fun getOpacity(): Int = wrapped.opacity
 
         override fun getIntrinsicWidth(): Int = sizePx
 

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/MenuUtils.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/MenuUtils.kt
@@ -1,19 +1,23 @@
 package com.google.android.stardroid.activities.util
 
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.drawable.Drawable
 import android.util.Log
 import android.view.Menu
-import java.lang.reflect.InvocationTargetException
 
 /**
  * Utility methods for working with Android Menus.
  */
 object MenuUtils {
     private const val TAG = "MenuUtils"
+    private const val MENU_ICON_SIZE_DP = 24
 
     /**
      * Forces icons to be visible in the overflow menu via reflection on MenuBuilder.
-     * 
-     * 
+     *
+     *
      * This relies on the internal `setOptionalIconsVisible` method of `MenuBuilder`,
      * which is not part of the public API and may change in future Android versions or on
      * non-standard OEM builds. There is currently no public API equivalent. Monitor
@@ -30,5 +34,63 @@ object MenuUtils {
                 Log.w(TAG, "Could not invoke setOptionalIconsVisible on menu", e)
             }
         }
+    }
+
+    /**
+     * Forces every menu item's icon to report a consistent 24dp intrinsic size.
+     *
+     *
+     * The overflow menu is rendered by the platform's own (non-AppCompat) `MenuBuilder`,
+     * whose popup row layout varies across Android versions and OEM skins. Some
+     * implementations size the icon `ImageView` from `wrap_content`, honouring whatever
+     * intrinsic size the `Drawable` reports, while others constrain it to a fixed size
+     * regardless. A raster icon that only ships a single density-bucket asset can resolve
+     * to a slightly different intrinsic size depending on the device's exact screen
+     * density and the platform's bitmap-scaling implementation, which is how an icon can
+     * look correctly sized on one device/OS version but oversized on another even though
+     * the underlying resource never changed. Wrapping every icon so it always reports
+     * exactly 24dp removes that platform-version dependency entirely.
+     */
+    @JvmStatic
+    fun normalizeIconSizes(menu: Menu?, context: Context) {
+        if (menu == null) return
+        val sizePx = (MENU_ICON_SIZE_DP * context.resources.displayMetrics.density).toInt()
+        for (i in 0 until menu.size()) {
+            val item = menu.getItem(i)
+            val icon = item.icon ?: continue
+            if (icon is FixedSizeDrawable) continue
+            if (icon.intrinsicWidth == sizePx && icon.intrinsicHeight == sizePx) continue
+            item.icon = FixedSizeDrawable(icon.mutate(), sizePx)
+        }
+    }
+
+    /** A [Drawable] wrapper that always reports [sizePx] as its intrinsic width/height. */
+    private class FixedSizeDrawable(
+        private val wrapped: Drawable,
+        private val sizePx: Int
+    ) : Drawable() {
+        init {
+            wrapped.setBounds(0, 0, sizePx, sizePx)
+        }
+
+        override fun draw(canvas: Canvas) {
+            wrapped.bounds = bounds
+            wrapped.draw(canvas)
+        }
+
+        override fun setAlpha(alpha: Int) {
+            wrapped.alpha = alpha
+        }
+
+        override fun setColorFilter(colorFilter: ColorFilter?) {
+            wrapped.colorFilter = colorFilter
+        }
+
+        @Deprecated("Deprecated in Java")
+        override fun getOpacity(): Int = wrapped.opacity
+
+        override fun getIntrinsicWidth(): Int = sizePx
+
+        override fun getIntrinsicHeight(): Int = sizePx
     }
 }


### PR DESCRIPTION
The overflow menu is rendered by the platform's own MenuBuilder/popup layout, which varies across Android OS versions and OEM skins. Some implementations size the icon ImageView from wrap_content, honouring whatever intrinsic size a Drawable reports, while others constrain it to a fixed size regardless. The Time Travel icon (a raster webp that only ships a single density-bucket asset) resolved to a slightly different intrinsic size depending on the device's exact density and the platform's bitmap-scaling implementation -- correct on Pixel 9 Pro but oversized on Pixel 5, even though the resource itself was already "fixed" in a prior pass.

Add MenuUtils.normalizeIconSizes(), which wraps any menu icon whose intrinsic size doesn't already resolve to 24dp in a small Drawable wrapper that forces exactly that size, and call it from onPrepareOptionsMenu. This sidesteps density-bucket/platform-version differences entirely instead of relying on resource tricks, and future-proofs the menu against any other icon resource that is mis-sized on some devices but not others.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
