### PR TITLE
Add troubleshooting link; fix compass accuracy grace-period bug

### DIFF
--- a/stardroid-v1/Gemfile.lock
+++ b/stardroid-v1/Gemfile.lock
@@ -8,8 +8,8 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1258.0)
-    aws-sdk-core (3.251.0)
+    aws-partitions (1.1261.0)
+    aws-sdk-core (3.252.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -20,7 +20,7 @@ GEM
     aws-sdk-kms (1.129.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.225.0)
+    aws-sdk-s3 (1.226.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -72,7 +72,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.1)
-    fastlane (2.236.0)
+    fastlane (2.236.1)
       CFPropertyList (>= 2.3, < 5.0.0)
       abbrev (~> 0.1)
       addressable (>= 2.8, < 3.0.0)
@@ -142,14 +142,14 @@ GEM
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.63.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-core (1.8.0)
+    google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
     google-cloud-env (2.2.2)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.6.0)
-    google-cloud-storage (1.60.0)
+    google-cloud-storage (1.61.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-core (>= 0.18, < 2)
@@ -159,7 +159,7 @@ GEM
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
     google-logging-utils (0.2.0)
-    googleauth (1.17.0)
+    googleauth (1.17.1)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.2)
       google-logging-utils (~> 0.1)
@@ -173,7 +173,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.19.8)
+    json (2.19.9)
     jwt (3.2.0)
       base64
     logger (1.7.0)
@@ -184,7 +184,7 @@ GEM
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     naturally (2.3.0)
-    nkf (0.2.0)
+    nkf (0.3.0)
     optparse (0.8.1)
     os (1.1.4)
     ostruct (0.6.3)
@@ -249,10 +249,10 @@ CHECKSUMS
   artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
-  aws-partitions (1.1258.0) sha256=3fee017570594ecf5e7f4c845b115fef8000530e57bdaf2b927357e5bf08967f
-  aws-sdk-core (3.251.0) sha256=ef8186cb5509147e590310da58fab4c5b0901eba0e85a72955abdf772e425c87
+  aws-partitions (1.1261.0) sha256=89eda89781c1ea4e1be2a2dcdc72318c62c6171a01cdaeaa0cbecf3cea6f9fdc
+  aws-sdk-core (3.252.0) sha256=09c042cbfc2acf2239441cc9b982ebab2a999bed2ef6bdc51849e7b3d6e48a1c
   aws-sdk-kms (1.129.0) sha256=363f548df321f4a4fcfd05523384e591060b400f8e65133ed7ef0793155a3343
-  aws-sdk-s3 (1.225.0) sha256=734752cc77e369c645ff5285b70ff5af207b0dcd3388346de2f727cd4e943924
+  aws-sdk-s3 (1.226.0) sha256=e599f431e006ec9b92c61ee0f14d3f658a1f6c8a1d623d2160be927ac958e2bf
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
@@ -283,7 +283,7 @@ CHECKSUMS
   faraday-retry (1.0.4) sha256=dc659233777fabf96c69c2ffe56c0a5d2c102af90321a42cc6c90157bcd716aa
   faraday_middleware (1.2.1) sha256=d45b78c8ee864c4783fbc276f845243d4a7918a67301c052647bacabec0529e9
   fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
-  fastlane (2.236.0) sha256=a496b8235ebce61c6311ca4cc1fd274b599e497f65d3035d7cb409d5591150d8
+  fastlane (2.236.1) sha256=fb89e618e0f38636e487743622cf710ad722723f5d33a63f19e367f84d3770bc
   fastlane-plugin-versioning_android (0.1.1) sha256=92cb9388dea0af4df8bf24091356239558cc39657bc791a4d8717308411b742a
   fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
@@ -292,17 +292,17 @@ CHECKSUMS
   google-apis-iamcredentials_v1 (0.27.0) sha256=9289f29968610754ef11d98b9ec627f0153f3e2616fef839aef096de529f6d1e
   google-apis-playcustomapp_v1 (0.17.0) sha256=d5bc90b705f3f862bab4998086449b0abe704ee1685a84821daa90ca7fa95a78
   google-apis-storage_v1 (0.63.0) sha256=7063a6c19c40f5ef96d5894df33c4f9ac915e3107e632b1870ba5247e3bb633f
-  google-cloud-core (1.8.0) sha256=e572edcbf189cfcab16590628a516cec3f4f63454b730e59f0b36575120281cf
+  google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.2.2) sha256=94bed40e05a67e9468ce1cb38389fba9a90aa8fc62fc9e173204c1dca59e21e7
   google-cloud-errors (1.6.0) sha256=1da8476dd706ad04b9d32e3c4b90d07d3463b37d6407cb56d41342ea7647d0a1
-  google-cloud-storage (1.60.0) sha256=b21b752d37945d678a4533be5ef4303f15d33a964d8bc709c7c41c3600f650db
+  google-cloud-storage (1.61.0) sha256=a77f10f4a603289948b09e81c3e23d762a18733fd69d70a4c1399663fbd96002
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
-  googleauth (1.17.0) sha256=dbddcaa3b78469fa9392c0e784ab6d8f3f760a1e5f6c6dbbbaa44a612c4198b0
+  googleauth (1.17.1) sha256=0f7e6fc70e204cee1b2d71f1e1de2d3b349d432404197fe68ebf7fa23d0821b9
   highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
   http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
@@ -312,7 +312,7 @@ CHECKSUMS
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   nanaimo (0.4.0) sha256=faf069551bab17f15169c1f74a1c73c220657e71b6e900919897a10d991d0723
   naturally (2.3.0) sha256=459923cf76c2e6613048301742363200c3c7e4904c324097d54a67401e179e01
-  nkf (0.2.0) sha256=fbc151bda025451f627fafdfcb3f4f13d0b22ae11f58c6d3a2939c76c5f5f126
+  nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
   optparse (0.8.1) sha256=42bea10d53907ccff4f080a69991441d611fbf8733b60ed1ce9ee365ce03bd1a
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912

--- a/stardroid-v1/app/build.gradle
+++ b/stardroid-v1/app/build.gradle
@@ -60,7 +60,7 @@ android {
         applicationId 'com.google.android.stardroid'
         minSdk 26
         targetSdk 36
-        versionCode 1684
+        versionCode 1686
         versionName "1.16.0:Caelus"
         testInstrumentationRunner "com.google.android.stardroid.test.HiltTestRunner"
         resourceConfigurations += ['en', 'b+en+GB', 'ar', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'es', 'fa', 'fr', 'hi', 'hu', 'id', 'it', 'ja', 'ko', 'ms', 'nb', 'nl', 'pl', 'pt', 'ru', 'sk', 'sl', 'sv', 'th', 'tr', 'uk', 'b+zh+Hans', 'b+zh+Hant']

--- a/stardroid-v1/app/build.gradle
+++ b/stardroid-v1/app/build.gradle
@@ -60,7 +60,7 @@ android {
         applicationId 'com.google.android.stardroid'
         minSdk 26
         targetSdk 36
-        versionCode 1681
+        versionCode 1684
         versionName "1.16.0:Caelus"
         testInstrumentationRunner "com.google.android.stardroid.test.HiltTestRunner"
         resourceConfigurations += ['en', 'b+en+GB', 'ar', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'es', 'fa', 'fr', 'hi', 'hu', 'id', 'it', 'ja', 'ko', 'ms', 'nb', 'nl', 'pl', 'pt', 'ru', 'sk', 'sl', 'sv', 'th', 'tr', 'uk', 'b+zh+Hans', 'b+zh+Hant']

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
@@ -32,6 +32,7 @@ class SensorAccuracyMonitor @Inject internal constructor(
   private val toaster: Toaster
   private var started = false
   private var hasReading = false
+  private var startedAtMillis = 0L
 
   /**
    * Starts monitoring.
@@ -41,6 +42,7 @@ class SensorAccuracyMonitor @Inject internal constructor(
       return
     }
     Log.d(TAG, "Starting monitoring compass accuracy")
+    startedAtMillis = System.currentTimeMillis()
     if (compassSensor != null) {
       (sensorManager ?: return).registerListener(this, compassSensor, SensorManager.SENSOR_DELAY_UI)
     }
@@ -73,6 +75,10 @@ class SensorAccuracyMonitor @Inject internal constructor(
     }
     Log.d(TAG, "Compass accuracy insufficient")
     val nowMillis = System.currentTimeMillis()
+    if (nowMillis - startedAtMillis < STARTUP_GRACE_PERIOD_MILLIS) {
+      Log.d(TAG, "...but still within startup grace period, letting the user settle in first")
+      return
+    }
     val lastWarnedMillis = sharedPreferences.getLong(LAST_CALIBRATION_WARNING_PREF_KEY, 0)
     if (nowMillis - lastWarnedMillis < MIN_INTERVAL_BETWEEN_WARNINGS) {
       Log.d(TAG, "...but too soon to warn again")
@@ -99,6 +105,7 @@ class SensorAccuracyMonitor @Inject internal constructor(
     private val TAG = getTag(SensorAccuracyMonitor::class.java)
     private const val LAST_CALIBRATION_WARNING_PREF_KEY = "Last calibration warning time"
     private const val MIN_INTERVAL_BETWEEN_WARNINGS = 180 * TimeConstants.MILLISECONDS_PER_SECOND
+    private const val STARTUP_GRACE_PERIOD_MILLIS = 15 * TimeConstants.MILLISECONDS_PER_SECOND
   }
 
   init {

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
@@ -68,6 +68,13 @@ class SensorAccuracyMonitor @Inject internal constructor(
   }
 
   override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {
+    if (SystemClock.elapsedRealtime() - startedAtElapsedMillis < STARTUP_GRACE_PERIOD_MILLIS) {
+      // Keep hasReading false so onSensorChanged keeps re-checking once the grace period
+      // passes, even if accuracy was briefly HIGH/MEDIUM in the meantime or the system never
+      // sends a fresh accuracy-changed callback.
+      hasReading = false
+      return
+    }
     if (accuracy == SensorManager.SENSOR_STATUS_ACCURACY_HIGH
       || accuracy == SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM
     ) {
@@ -75,12 +82,6 @@ class SensorAccuracyMonitor @Inject internal constructor(
       return  // OK
     }
     Log.d(TAG, "Compass accuracy insufficient")
-    if (SystemClock.elapsedRealtime() - startedAtElapsedMillis < STARTUP_GRACE_PERIOD_MILLIS) {
-      Log.d(TAG, "...but still within startup grace period, letting the user settle in first")
-      // Deliberately leave hasReading unset so onSensorChanged keeps re-checking until the
-      // grace period passes, even if the system never sends a fresh accuracy-changed callback.
-      return
-    }
     hasReading = true
     val nowMillis = System.currentTimeMillis()
     val lastWarnedMillis = sharedPreferences.getLong(LAST_CALIBRATION_WARNING_PREF_KEY, 0)

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
@@ -7,6 +7,7 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import android.os.SystemClock
 import android.util.Log
 import com.google.android.stardroid.R
 import com.google.android.stardroid.activities.CompassCalibrationActivity
@@ -32,7 +33,7 @@ class SensorAccuracyMonitor @Inject internal constructor(
   private val toaster: Toaster
   private var started = false
   private var hasReading = false
-  private var startedAtMillis = 0L
+  private var startedAtElapsedMillis = 0L
 
   /**
    * Starts monitoring.
@@ -42,7 +43,7 @@ class SensorAccuracyMonitor @Inject internal constructor(
       return
     }
     Log.d(TAG, "Starting monitoring compass accuracy")
-    startedAtMillis = System.currentTimeMillis()
+    startedAtElapsedMillis = SystemClock.elapsedRealtime()
     if (compassSensor != null) {
       (sensorManager ?: return).registerListener(this, compassSensor, SensorManager.SENSOR_DELAY_UI)
     }
@@ -67,18 +68,21 @@ class SensorAccuracyMonitor @Inject internal constructor(
   }
 
   override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {
-    hasReading = true
     if (accuracy == SensorManager.SENSOR_STATUS_ACCURACY_HIGH
       || accuracy == SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM
     ) {
+      hasReading = true
       return  // OK
     }
     Log.d(TAG, "Compass accuracy insufficient")
-    val nowMillis = System.currentTimeMillis()
-    if (nowMillis - startedAtMillis < STARTUP_GRACE_PERIOD_MILLIS) {
+    if (SystemClock.elapsedRealtime() - startedAtElapsedMillis < STARTUP_GRACE_PERIOD_MILLIS) {
       Log.d(TAG, "...but still within startup grace period, letting the user settle in first")
+      // Deliberately leave hasReading unset so onSensorChanged keeps re-checking until the
+      // grace period passes, even if the system never sends a fresh accuracy-changed callback.
       return
     }
+    hasReading = true
+    val nowMillis = System.currentTimeMillis()
     val lastWarnedMillis = sharedPreferences.getLong(LAST_CALIBRATION_WARNING_PREF_KEY, 0)
     if (nowMillis - lastWarnedMillis < MIN_INTERVAL_BETWEEN_WARNINGS) {
       Log.d(TAG, "...but too soon to warn again")

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -230,13 +230,13 @@
         translation_description="Information for the user on how to calibrate the compass when the dialog auto-opens. Placeholder is the video URL"><![CDATA[
 Your phone\'s compass sensor is reporting poor calibration. The figure-8 motion (%s) prompts your phone to recalibrate its hardware sensor — Sky Map has no control over this process.<br/><br/>
 <b>Calibrated does not mean accurate.</b> The figure-8 gesture helps the sensor normalize itself internally, but it cannot remove interference from nearby metal objects, car dashboards, or magnetic phone cases. If the map is still off after calibrating, those external sources are the most likely cause — not Sky Map.<br/><br/>
-Move to an open area away from metal and try again. See <i>Troubleshooting</i> in <i>Help</i> for more steps, or visit http://troubleshooting.stardroid.app
+Move to an open area away from metal and try again. See <i>Troubleshooting</i> in <i>Help</i> for more steps, or visit https://troubleshooting.stardroid.app
     ]]></string>
     <string name="compass_calib_what_to_do_user"
         translation_description="Information for the user on how to calibrate the compass when they invoke the calibration dialog. Placeholder is the video URL"><![CDATA[
 Your phone is reporting its compass calibration status as shown above. The figure-8 motion (%s) prompts your phone\'s hardware to recalibrate its compass sensor.<br/><br/>
 <b>Important:</b> calibration helps the sensor normalize itself internally. A calibrated compass is not necessarily an accurate one — local magnetic interference (metal objects, car dashboards, magnetic phone cases) can still cause the map to point the wrong way. Sky Map reads exactly what your phone\'s sensor reports; it has no way to correct for your environment or bad hardware.<br/><br/>
-See <i>Troubleshooting</i> in <i>Help</i> for other steps, including the manual compass offset for phones with a consistent directional error, or visit http://troubleshooting.stardroid.app
+See <i>Troubleshooting</i> in <i>Help</i> for other steps, including the manual compass offset for phones with a consistent directional error, or visit https://troubleshooting.stardroid.app
     ]]></string>
     <string name="compass_low_accuracy_toast" translation_description="Brief toast shown when compass accuracy is low and the user has disabled the calibration dialog">Your phone\'s compass is reporting poor calibration</string>
     <string name="sensor_reverse_preference_title" translation_description="Preference title for reversing the magnetic Z-axis sensor reading, a fix for certain phones with incorrectly implemented sensors">Reverse Magnetic Z</string>

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -230,13 +230,13 @@
         translation_description="Information for the user on how to calibrate the compass when the dialog auto-opens. Placeholder is the video URL"><![CDATA[
 Your phone\'s compass sensor is reporting poor calibration. The figure-8 motion (%s) prompts your phone to recalibrate its hardware sensor — Sky Map has no control over this process.<br/><br/>
 <b>Calibrated does not mean accurate.</b> The figure-8 gesture helps the sensor normalize itself internally, but it cannot remove interference from nearby metal objects, car dashboards, or magnetic phone cases. If the map is still off after calibrating, those external sources are the most likely cause — not Sky Map.<br/><br/>
-Move to an open area away from metal and try again. See <i>Troubleshooting</i> in <i>Help</i> for more steps.
+Move to an open area away from metal and try again. See <i>Troubleshooting</i> in <i>Help</i> for more steps, or visit http://troubleshooting.stardroid.app
     ]]></string>
     <string name="compass_calib_what_to_do_user"
         translation_description="Information for the user on how to calibrate the compass when they invoke the calibration dialog. Placeholder is the video URL"><![CDATA[
 Your phone is reporting its compass calibration status as shown above. The figure-8 motion (%s) prompts your phone\'s hardware to recalibrate its compass sensor.<br/><br/>
 <b>Important:</b> calibration helps the sensor normalize itself internally. A calibrated compass is not necessarily an accurate one — local magnetic interference (metal objects, car dashboards, magnetic phone cases) can still cause the map to point the wrong way. Sky Map reads exactly what your phone\'s sensor reports; it has no way to correct for your environment or bad hardware.<br/><br/>
-See <i>Troubleshooting</i> in <i>Help</i> for other steps, including the manual compass offset for phones with a consistent directional error.
+See <i>Troubleshooting</i> in <i>Help</i> for other steps, including the manual compass offset for phones with a consistent directional error, or visit http://troubleshooting.stardroid.app
     ]]></string>
     <string name="compass_low_accuracy_toast" translation_description="Brief toast shown when compass accuracy is low and the user has disabled the calibration dialog">Your phone\'s compass is reporting poor calibration</string>
     <string name="sensor_reverse_preference_title" translation_description="Preference title for reversing the magnetic Z-axis sensor reading, a fix for certain phones with incorrectly implemented sensors">Reverse Magnetic Z</string>

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="sensor_accuracy_unknown" translation_description="Sensor calibration level shown in the diagnostics screen and calibration dialog">Calibration: Unknown</string>
     <string name="sensor_accuracy_unreliable" translation_description="Sensor calibration level shown in the diagnostics screen and calibration dialog">Calibration: Uncalibrated</string>
     <string name="sensor_accuracy_low" translation_description="Sensor calibration level shown in the diagnostics screen and calibration dialog">Calibration: Poor</string>
-    <string name="sensor_accuracy_medium" translation_description="Sensor calibration level shown in the diagnostics screen and calibration dialog">Calibration: OK</string>
+    <string name="sensor_accuracy_medium" translation_description="Sensor calibration level shown in the diagnostics screen and calibration dialog">Calibration: So-so</string>
     <string name="sensor_accuracy_high" translation_description="Sensor calibration level shown in the diagnostics screen and calibration dialog">Calibration: Good</string>
     <string name="sensor_accuracy_nocontact" translation_description="Sensor calibration level shown when the sensor has no contact (e.g. heart-rate sensor lifted from skin) — unlikely to appear in Sky Map but included for completeness">Calibration: No contact</string>
     <string name="diagnostics_activity_general_heading" translation_description="Section heading in the Diagnostics screen for general device information">General</string>
@@ -222,23 +222,23 @@
     <string name="wifi" translation_description="Network type suffix appended to the connection status (e.g. \'Connected (wifi)\'). Note the leading space.">" (wifi)"</string>
     <string name="cell_network" translation_description="Network type suffix appended to the connection status (e.g. \'Connected (cell)\'). Note the leading space.">" (cell)"</string>
     <string name="menu_calibrate" translation_description="Menu item label to open the compass calibration screen">Calibrate</string>
-    <string name="compass_calibration_activity_heading_compass" translation_description="Static label in the compass calibration screen placed inline to the left of the live compass accuracy value (e.g. displayed as \'Compass - Accuracy: High\')">Compass -</string>
+    <string name="compass_calibration_activity_heading_compass" translation_description="Static label in the compass calibration screen placed inline to the left of the live compass accuracy value (e.g. displayed as \'Compass - Calibration: Poor\')">Compass -</string>
     <string name="compass_calibration_activity_do_not_show_this_again" translation_description="Checkbox label in the compass calibration dialog to suppress future automatic appearances">Do not show this again</string>
     <string name="compass_calibration_activity_warning" translation_description="Heading/reason text shown in the compass calibration dialog when it opens automatically due to low accuracy">Your Phone\'s Compass Needs Attention</string>
     <string name="compass_calibration_activity_user_heading" translation_description="Heading shown in the compass calibration dialog when the user opens it manually from the menu">Your Phone\'s Compass</string>
     <string name="compass_calib_what_to_do"
         translation_description="Information for the user on how to calibrate the compass when the dialog auto-opens. Placeholder is the video URL"><![CDATA[
-Your phone\'s compass sensor is reporting low accuracy. The figure-8 motion (%s) prompts your phone to recalibrate its hardware sensor — Sky Map has no control over this process.<br/><br/>
+Your phone\'s compass sensor is reporting poor calibration. The figure-8 motion (%s) prompts your phone to recalibrate its hardware sensor — Sky Map has no control over this process.<br/><br/>
 <b>Calibrated does not mean accurate.</b> The figure-8 gesture helps the sensor normalize itself internally, but it cannot remove interference from nearby metal objects, car dashboards, or magnetic phone cases. If the map is still off after calibrating, those external sources are the most likely cause — not Sky Map.<br/><br/>
 Move to an open area away from metal and try again. See <i>Troubleshooting</i> in <i>Help</i> for more steps.
     ]]></string>
     <string name="compass_calib_what_to_do_user"
         translation_description="Information for the user on how to calibrate the compass when they invoke the calibration dialog. Placeholder is the video URL"><![CDATA[
 Your phone is reporting its compass calibration status as shown above. The figure-8 motion (%s) prompts your phone\'s hardware to recalibrate its compass sensor.<br/><br/>
-<b>Important distinction:</b> calibration helps the sensor normalize itself internally. A calibrated compass is not necessarily an accurate one — local magnetic interference (metal objects, car dashboards, magnetic phone cases) can still cause the map to point the wrong way. Sky Map reads exactly what your phone\'s sensor reports; it has no way to correct for your environment.<br/><br/>
+<b>Important:</b> calibration helps the sensor normalize itself internally. A calibrated compass is not necessarily an accurate one — local magnetic interference (metal objects, car dashboards, magnetic phone cases) can still cause the map to point the wrong way. Sky Map reads exactly what your phone\'s sensor reports; it has no way to correct for your environment or bad hardware.<br/><br/>
 See <i>Troubleshooting</i> in <i>Help</i> for other steps, including the manual compass offset for phones with a consistent directional error.
     ]]></string>
-    <string name="compass_low_accuracy_toast" translation_description="Brief toast shown when compass accuracy is low and the user has disabled the calibration dialog">Your phone\'s compass is reporting low accuracy</string>
+    <string name="compass_low_accuracy_toast" translation_description="Brief toast shown when compass accuracy is low and the user has disabled the calibration dialog">Your phone\'s compass is reporting poor calibration</string>
     <string name="sensor_reverse_preference_title" translation_description="Preference title for reversing the magnetic Z-axis sensor reading, a fix for certain phones with incorrectly implemented sensors">Reverse Magnetic Z</string>
     <string name="sensor_reverse_preference_summary" translation_description="Summary for the Reverse Magnetic Z preference">Fix for phones with incorrectly implemented sensors - requires restart</string>
     <string name="whats_new_dialog_title" translation_description="Title of the dialog shown on first launch after an update, listing new features">What\'s new</string>

--- a/stardroid-v1/app/src/main/res/values/whatsnew_content.xml
+++ b/stardroid-v1/app/src/main/res/values/whatsnew_content.xml
@@ -4,6 +4,6 @@
     <string name="whats_new_content" translation_description="HTML content listing new features in this release, shown in the What's new dialog and appended to the Help screen. Please do not change the &lt; and &gt; markup."><![CDATA[<h2>Watch this space</h2>
 ]]></string>
     <string name="beta_user_help_text" translation_description="HTML content shown to beta testers asking for feedback. Please do not change the &lt; and &gt; markup.">
-      Can you send me feedback on the new color scheme to skymapdevs@gmail.com ? I feel like the horizon ought to be green, which then clashes with the DSOs, so I've made those blue.  The ecliptic is now more visible and, by popular demand, has degree marks.  It's a lot more bold than it used to be. Should I dial it back?
+      Beta users! Can you send me feedback on the new color scheme to skymapdevs@gmail.com? I feel like the horizon ought to be green, which then clashes with the DSOs, so I\'ve made those blue.  The ecliptic is now more visible and, by popular demand, has degree marks.  It\'s a lot more bold than it used to be. Should I dial it back?
     </string>
 </resources>

--- a/stardroid-v1/app/src/main/res/values/whatsnew_content.xml
+++ b/stardroid-v1/app/src/main/res/values/whatsnew_content.xml
@@ -4,5 +4,6 @@
     <string name="whats_new_content" translation_description="HTML content listing new features in this release, shown in the What's new dialog and appended to the Help screen. Please do not change the &lt; and &gt; markup."><![CDATA[<h2>Watch this space</h2>
 ]]></string>
     <string name="beta_user_help_text" translation_description="HTML content shown to beta testers asking for feedback. Please do not change the &lt; and &gt; markup.">
+      Can you send me feedback on the new color scheme to skymapdevs@gmail.com ? I feel like the horizon ought to be green, which then clashes with the DSOs, so I've made those blue.  The ecliptic is now more visible and, by popular demand, has degree marks.  It's a lot more bold than it used to be. Should I dial it back?
     </string>
 </resources>

--- a/troubleshooting-llm.md
+++ b/troubleshooting-llm.md
@@ -140,6 +140,24 @@ a known side-effect. This is not a Sky Map change.
 
 ---
 
+### CAT-INFO-CARD · Info card won't close
+
+**What users say:** "the pop-up card doesn't close", "can't dismiss the info card", "card stays
+on screen", "stuck on the info panel"
+
+**Real cause:** User doesn't realize tapping outside the card or using back dismisses it. Most
+commonly affects users on the older "classic" 3-button Android navigation: Sky Map runs full
+screen, so the on-screen nav bar (and therefore the Back button) isn't rendered until the user
+swipes up from the bottom edge.
+
+**Steps to suggest:**
+1. Tap anywhere outside the card to dismiss it
+2. Use the back gesture/button
+3. If using classic 3-button navigation, swipe up from the very bottom of the screen to bring the
+   navigation bar into view, then tap Back
+
+---
+
 ### CAT-5 · Map is jittery / shaky
 
 **What users say:** "the map jumps around", "it's shaky", "very unstable"

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -136,6 +136,17 @@ sensor.
 
 ---
 
+## The info card won't close
+
+Tap anywhere outside the card, or use the back gesture/button, to dismiss it.
+
+If you're using the older "classic" 3-button Android navigation (rather than gesture navigation),
+Sky Map runs full screen, so the on-screen Back/Home/Recents buttons aren't rendered at all. Swipe
+up from the very bottom of the screen to bring the navigation bar into view, then tap Back to
+close the card.
+
+---
+
 ## The map doesn't move
 
 - Make sure you haven't switched to Manual Mode — tap the sensor icon to return to Automatic Mode.


### PR DESCRIPTION
## Description

- Add a link to http://troubleshooting.stardroid.app in the compass calibration help text, alongside the existing "See Troubleshooting in Help" pointer.
- Tweak the calibration dialog wording.
- Add a 15s startup grace period to `SensorAccuracyMonitor` before it warns about poor compass accuracy, so it doesn't nag the user immediately on launch while sensors settle.
- Document how to close the info card (including the classic 3-button nav case where the nav bar is hidden) in `troubleshooting.md` and `troubleshooting-llm.md`.
- Ask beta testers for feedback on the new color scheme via the What's New screen.
- Bump build/version numbers and update `Gemfile.lock`.

## Type of Change

- [x] Bug fix
- [x] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [x] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

This branch picked up several unrelated commits (grace period fix, beta tester ask, info-card-close docs, build bump) along the way - listed above for visibility.