### PR TITLE
Add close button to info card for classic 3-button nav users

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ObjectInfoDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ObjectInfoDialogFragment.kt
@@ -28,6 +28,7 @@ import android.widget.TextView
 import com.google.android.stardroid.R
 import com.google.android.stardroid.activities.dialogs.ObjectInfoDialogFragment.Companion.newInstance
 import com.google.android.stardroid.activities.util.ActivityLightLevelManager
+import com.google.android.stardroid.activities.util.NavigationModeUtil
 import com.google.android.stardroid.activities.util.NightModeHelper
 import com.google.android.stardroid.education.ObjectInfo
 import com.google.android.stardroid.education.ObjectInfoRegistry
@@ -215,6 +216,11 @@ class ObjectInfoDialogFragment : DialogFragment() {
                 (activity as? OnFindClickedListener)?.onFindClicked(info)
                 dialog.dismiss()
             }
+        }
+        // Users on classic 2/3-button navigation have no visible Back button to dismiss the
+        // card with, since the app runs full screen. Give them an explicit close button.
+        if (!NavigationModeUtil.isGestureNavigationEnabled(parentActivity)) {
+            builder.setNegativeButton(android.R.string.ok) { dialog, _ -> dialog.dismiss() }
         }
         val alertDialog = builder.create()
         alertDialog.setOnShowListener { NightModeHelper.applyAlertDialogNightMode(alertDialog, isNight) }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/NavigationModeUtil.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/NavigationModeUtil.kt
@@ -1,0 +1,30 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.android.stardroid.activities.util
+
+import android.content.Context
+import android.provider.Settings
+
+/** Utility for detecting whether the device is using gesture or classic on-screen navigation. */
+object NavigationModeUtil {
+    /**
+     * Returns true if gesture navigation is enabled, false if the user is on the classic
+     * 2-button or 3-button on-screen navigation bar.
+     *
+     * Reads the same "navigation_mode" setting Android itself uses internally
+     * (0 = 3-button, 1 = 2-button [deprecated], 2 = gesture). The key isn't a publicly
+     * documented constant, but it has been stable since Android 10 (Q).
+     */
+    fun isGestureNavigationEnabled(context: Context): Boolean {
+        return Settings.Secure.getInt(context.contentResolver, "navigation_mode", 0) == 2
+    }
+}

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/NavigationModeUtil.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/util/NavigationModeUtil.kt
@@ -23,8 +23,16 @@ object NavigationModeUtil {
      * Reads the same "navigation_mode" setting Android itself uses internally
      * (0 = 3-button, 1 = 2-button [deprecated], 2 = gesture). The key isn't a publicly
      * documented constant, but it has been stable since Android 10 (Q).
+     *
+     * Falls back to false (classic navigation) if the read fails, e.g. due to a
+     * SecurityException on a restricted profile or customized ROM. That's a safe default:
+     * it just means an extra close button is shown, never a crash.
      */
     fun isGestureNavigationEnabled(context: Context): Boolean {
-        return Settings.Secure.getInt(context.contentResolver, "navigation_mode", 0) == 2
+        return try {
+            Settings.Secure.getInt(context.contentResolver, "navigation_mode", 0) == 2
+        } catch (e: Exception) {
+            false
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Users on classic 2/3-button on-screen navigation have no visible Back button to dismiss the info card, since Sky Map runs full screen — they previously had to swipe up to reveal the hidden nav bar.
- Adds `NavigationModeUtil.isGestureNavigationEnabled()`, which reads the `navigation_mode` system setting to detect classic vs. gesture navigation.
- `ObjectInfoDialogFragment` now adds a negative "OK" button to the info card's `AlertDialog` only when classic navigation is detected. Gesture-nav users see no change.

## Test plan
- [x] `./gradlew :app:compileGmsDebugKotlin` passes
- [ ] Manually verify on a device/emulator set to 3-button nav: info card shows an OK button that dismisses it
- [ ] Manually verify on a device/emulator set to gesture nav: info card looks unchanged (no extra button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)