### PR TITLE
Fix build break: remove dangling grace-period check in SensorAccuracy…

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/util/SensorAccuracyMonitor.kt
@@ -84,10 +84,6 @@ class SensorAccuracyMonitor @Inject internal constructor(
     Log.d(TAG, "Compass accuracy insufficient")
     hasReading = true
     val nowMillis = System.currentTimeMillis()
-    if (nowMillis - startedAtMillis < STARTUP_GRACE_PERIOD_MILLIS) {
-      Log.d(TAG, "...but still within startup grace period, letting the user settle in first")
-      return
-    }
     val lastWarnedMillis = sharedPreferences.getLong(LAST_CALIBRATION_WARNING_PREF_KEY, 0)
     if (nowMillis - lastWarnedMillis < MIN_INTERVAL_BETWEEN_WARNINGS) {
       Log.d(TAG, "...but too soon to warn again")


### PR DESCRIPTION
…Monitor

Merge 17f8c073 combined two independent fixes for the same startup grace-period bug — a local wall-clock version (startedAtMillis) and an upstream elapsed-realtime version (startedAtElapsedMillis) preferred for not being affected by clock/NTP adjustments. The merge kept the dangling wall-clock check without its field, breaking compilation. The elapsed-realtime check at the top of onAccuracyChanged already covers the grace period, so the leftover block is removed.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
