### PR TITLE
Fix NPE crash when GPS enabled on devices without resolvable Play Services

### DIFF
--- a/stardroid-v1/app/src/gms/java/com/google/android/stardroid/activities/util/GooglePlayServicesChecker.java
+++ b/stardroid-v1/app/src/gms/java/com/google/android/stardroid/activities/util/GooglePlayServicesChecker.java
@@ -1,6 +1,7 @@
 package com.google.android.stardroid.activities.util;
 
 import android.app.Activity;
+import android.app.Dialog;
 import android.content.SharedPreferences;
 import android.util.Log;
 import android.widget.Toast;
@@ -44,10 +45,13 @@ public class GooglePlayServicesChecker extends AbstractGooglePlayServicesChecker
       Log.d(TAG, "Google Play Services is available and up to date");
     } else {
       Log.d(TAG, "Google Play Status availability: " + googlePlayServicesAvailability);
-      if (apiAvailability.isUserResolvableError(googlePlayServicesAvailability)) {
+      Dialog errorDialog = apiAvailability.isUserResolvableError(googlePlayServicesAvailability)
+          ? apiAvailability.getErrorDialog(parent, googlePlayServicesAvailability,
+              DynamicStarMapActivity.GOOGLE_PLAY_SERVICES_REQUEST_CODE)
+          : null;
+      if (errorDialog != null) {
         Log.d(TAG, "...but we can fix it");
-        apiAvailability.getErrorDialog(parent, googlePlayServicesAvailability,
-            DynamicStarMapActivity.GOOGLE_PLAY_SERVICES_REQUEST_CODE).show();
+        errorDialog.show();
       } else {
         Log.d(TAG, "...and we can't fix it");
         // For now just warn the user, though we may need to do something like disable


### PR DESCRIPTION
## Summary
- Fixes a crash-on-startup NPE in the gms flavor when auto-locate (GPS) is enabled on a device where Google Play Services is unavailable and unresolvable (e.g. de-googled devices with no Play Store).
- `GoogleApiAvailability.getErrorDialog()` is documented as nullable and can return null even when `isUserResolvableError()` is true; the code called `.show()` on it unconditionally. Now null-checked, falling back to the existing toast message.

Fixes #938

## Test plan
- [ ] Verify the app no longer crashes on startup with GPS enabled and Play Services unavailable/unresolvable
- [ ] Verify normal startup still works when Play Services is present and up to date

Generated with [Claude Code](https://claude.ai/code)