### PR TITLE
Disable place lookup when geocoder backend is absent

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/dialogs/ManualLocationEntryDialogFragment.kt
@@ -91,6 +91,12 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
             trySetLocation()
         }
 
+        if (!Geocoder.isPresent()) {
+            placeNameEdit.isEnabled = false
+            resolveButton.isEnabled = false
+            showPlaceError(getString(R.string.location_geocoder_unavailable))
+        }
+
         return AlertDialog.Builder(requireContext())
             .setTitle(R.string.location_manual_entry_title)
             .setView(view)
@@ -101,11 +107,6 @@ class ManualLocationEntryDialogFragment : DialogFragment() {
         val name = placeNameEdit.text.toString().trim()
         if (name.isEmpty()) return
         placeErrorText.visibility = View.GONE
-
-        if (!Geocoder.isPresent()) {
-            showPlaceError(getString(R.string.location_geocoder_offline))
-            return
-        }
 
         setResolving(true)
         val appContext = requireContext().applicationContext

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="location_set_button" translation_description="Button that confirms and applies the manually entered location">Set Location</string>
     <string name="location_place_not_found" translation_description="Inline error shown when a place name search returns no results">Place not found — try a more specific name</string>
     <string name="location_geocoder_offline" translation_description="Inline message shown when geocoding fails because there is no internet connection">No internet — enter coordinates directly</string>
+    <string name="location_geocoder_unavailable" translation_description="Inline message shown when place name lookup is disabled because the device has no geocoding backend (e.g. no internet or no Google Play Services)">Place lookup unavailable (no internet or Google Play Services) — enter coordinates directly</string>
     <string name="location_invalid_latitude" translation_description="Validation error for latitude values outside the valid range">Latitude must be between −90 and 90</string>
     <string name="location_invalid_longitude" translation_description="Validation error for longitude values outside the valid range">Longitude must be between −180 and 180</string>
     <string name="location_management_title" translation_description="Title of the location management screen">Your Location</string>

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="location_set_button" translation_description="Button that confirms and applies the manually entered location">Set Location</string>
     <string name="location_place_not_found" translation_description="Inline error shown when a place name search returns no results">Place not found — try a more specific name</string>
     <string name="location_geocoder_offline" translation_description="Inline message shown when geocoding fails because there is no internet connection">No internet — enter coordinates directly</string>
-    <string name="location_geocoder_unavailable" translation_description="Inline message shown when place name lookup is disabled because the device has no geocoding backend (e.g. no internet or no Google Play Services)">Place lookup unavailable (no internet or Google Play Services) — enter coordinates directly</string>
+    <string name="location_geocoder_unavailable" translation_description="Inline message shown when place name lookup is disabled because the device has no geocoding backend, typically due to missing Google Play Services">Place lookup unavailable (no geocoding service on this device) — enter coordinates directly</string>
     <string name="location_invalid_latitude" translation_description="Validation error for latitude values outside the valid range">Latitude must be between −90 and 90</string>
     <string name="location_invalid_longitude" translation_description="Validation error for longitude values outside the valid range">Longitude must be between −180 and 180</string>
     <string name="location_management_title" translation_description="Title of the location management screen">Your Location</string>


### PR DESCRIPTION
## Description

Fixes #937. `Geocoder.isPresent()` was being misread as a connectivity check in `ManualLocationEntryDialogFragment`. On de-Googled/F-Droid devices with no on-device geocoding backend, that check is always `false` regardless of actual network state, so users saw a misleading "No internet" message when trying to resolve a place name — even with a working connection.

This is the quick fix: disable the place-name field and "Resolve" button up front when no geocoding backend is present, and show an accurate message explaining that lookup needs internet or Google Play Services (rather than letting the user type a name and hit a wrong error after the fact). Users can still enter lat/lon coordinates directly.

A real fix (network-based geocoding fallback via the Geoapify API already used for static maps, which works on both GMS and F-Droid) is a bigger change and is planned for v2.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I've read the contributing guidelines
- [x] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [x] Single commit

## Notes for Reviewers

Also removed the now-redundant `isPresent()` re-check inside `resolvePlace()`, since the button is disabled before that code path can be reached.