### PR TITLE
Fix: startup crash from requesting GPS_PROVIDER without FINE permission

### DIFF
--- a/stardroid-v1/app/src/fdroid/java/com/google/android/stardroid/control/PlatformLocationProvider.kt
+++ b/stardroid-v1/app/src/fdroid/java/com/google/android/stardroid/control/PlatformLocationProvider.kt
@@ -14,6 +14,7 @@ import android.content.Context
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import com.google.android.stardroid.math.LatLong
@@ -34,7 +35,7 @@ class PlatformLocationProvider @Inject constructor(
         stopUpdates()
         updateCallback = onUpdate
 
-        for (provider in listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)) {
+        for (provider in coarseProviders()) {
             if (!locationManager.isProviderEnabled(provider)) continue
             val listener = createListener(onUpdate)
             try {
@@ -43,6 +44,10 @@ class PlatformLocationProvider @Inject constructor(
             } catch (_: IllegalArgumentException) {
                 // Provider not supported on this device
                 Log.w(TAG, "Provider $provider not supported on this device")
+            } catch (_: SecurityException) {
+                // App only holds ACCESS_COARSE_LOCATION; should not happen for the providers
+                // in coarseProviders(), but guard against it regardless.
+                Log.w(TAG, "Not permitted to request updates from provider $provider")
             }
         }
     }
@@ -66,8 +71,20 @@ class PlatformLocationProvider @Inject constructor(
     }
 
     override fun isAvailable(): Boolean {
-        return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) ||
-            locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+        return coarseProviders().any { locationManager.isProviderEnabled(it) }
+    }
+
+    /**
+     * GPS_PROVIDER always requires ACCESS_FINE_LOCATION, which this app never requests, so it
+     * must not be used. FUSED_PROVIDER (API 31+) blends every available source, including GPS,
+     * and the platform automatically coarsens its output to match the app's granted permission.
+     */
+    private fun coarseProviders(): List<String> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            listOf(LocationManager.FUSED_PROVIDER)
+        } else {
+            listOf(LocationManager.NETWORK_PROVIDER)
+        }
     }
 
     companion object {

--- a/stardroid-v1/specs/002-modern-location/contracts/location-provider.md
+++ b/stardroid-v1/specs/002-modern-location/contracts/location-provider.md
@@ -58,11 +58,16 @@ interface LocationProvider {
 
 ## fdroid Implementation (`fdroid/control/PlatformLocationProvider.kt`)
 
-- Registers `LocationListener` on `GPS_PROVIDER` and `NETWORK_PROVIDER` independently.
-- `isAvailable()`: Returns `LocationManager.isProviderEnabled(GPS_PROVIDER) ||
-  LocationManager.isProviderEnabled(NETWORK_PROVIDER)`.
-- On update: accepts the first arrival; ignores subsequent arrivals from the same event window
-  unless they come from a provider with better stated accuracy.
+- The app only ever holds `ACCESS_COARSE_LOCATION`. `GPS_PROVIDER` unconditionally requires
+  `ACCESS_FINE_LOCATION` at the OS level, so it MUST NOT be used — registering a listener on it
+  without FINE throws an uncaught `SecurityException` at request time.
+- Registers a `LocationListener` on a single OS-version-guarded provider: `FUSED_PROVIDER` on API
+  31+ (blends all available sources, including GPS, and the platform auto-coarsens the output to
+  match the app's granted permission), or `NETWORK_PROVIDER` below API 31 (no coarse-safe
+  GPS-derived fix exists pre-31).
+- `isAvailable()`: Returns `true` if that same provider is enabled.
+- Requests to `requestLocationUpdates` also catch `SecurityException` defensively, in addition to
+  `IllegalArgumentException`, so a future provider/permission mismatch can't crash the app.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes a systematic startup crash on the fdroid build reported in #947.

The app only declares `ACCESS_COARSE_LOCATION`, but `PlatformLocationProvider.startUpdates` was requesting updates from `LocationManager.GPS_PROVIDER`, which unconditionally requires `ACCESS_FINE_LOCATION` at the OS level. This throws an uncaught `SecurityException` as soon as GPS is enabled as a provider, crashing the app immediately after the user grants location permission.

**Changes:**
- Drop `GPS_PROVIDER` entirely; it can never work with coarse-only permission.
- On API 31+, use `LocationManager.FUSED_PROVIDER`, which blends all available sources (including GPS) and is auto-coarsened by the platform to match the app's granted permission.
- Below API 31, fall back to `NETWORK_PROVIDER`, the only coarse-safe option on those versions.
- `isAvailable()` updated to match the new provider set.
- Added a defensive `SecurityException` catch around `requestLocationUpdates`.
- Updated the `002-modern-location` spec contract doc to match.

Fixes #947

Generated with [Claude Code](https://claude.ai/code)