### PR TITLE
Add build flavor label to Diagnostics screen

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DiagnosticActivity.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/activities/DiagnosticActivity.java
@@ -26,6 +26,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import com.google.android.stardroid.BuildConfig;
 import com.google.android.stardroid.R;
 import com.google.android.stardroid.StardroidApplication;
 import com.google.android.stardroid.control.LocationController;
@@ -100,9 +101,20 @@ public class DiagnosticActivity extends androidx.fragment.app.FragmentActivity
     String androidVersion = String.format(Build.VERSION.RELEASE + " (%d)", Build.VERSION.SDK_INT);
     setText(R.id.diagnose_android_version_txt, androidVersion);
 
-    String skyMapVersion = String.format(
-        app.getVersionName() + " (%d)", app.getVersion());
+    String skyMapVersion = getString(R.string.diagnostics_skymap_version_format,
+        app.getVersionName(), app.getVersion(), getFlavorLabel());
     setText(R.id.diagnose_skymap_version_txt, skyMapVersion);
+  }
+
+  private String getFlavorLabel() {
+    switch (BuildConfig.FLAVOR) {
+      case "gms":
+        return getString(R.string.diagnostics_flavor_gms);
+      case "fdroid":
+        return getString(R.string.diagnostics_flavor_fdroid);
+      default:
+        return BuildConfig.FLAVOR;
+    }
   }
 
   private boolean continueUpdates;

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -195,6 +195,9 @@
     <string name="diagnostics_activity_phone" translation_description="Row label in the Diagnostics screen for the device model name">Device</string>
     <string name="diagnostics_activity_android_version" translation_description="Row label in the Diagnostics screen for the Android OS version">Android version</string>
     <string name="diagnostics_activity_sky_map_version" translation_description="Row label in the Diagnostics screen for the Sky Map app version">Sky Map version</string>
+    <string name="diagnostics_skymap_version_format" translation_description="Format for the Sky Map version row in Diagnostics: version name (version code) [build flavor]. %1$s is version name, %2$d is version code, %3$s is the build flavor label (e.g. Gms or F-Droid)" translatable="false">%1$s (%2$d) [%3$s]</string>
+    <string name="diagnostics_flavor_gms" translation_description="Build flavor label shown in Diagnostics for the Google-services build" translatable="false">Gms</string>
+    <string name="diagnostics_flavor_fdroid" translation_description="Build flavor label shown in Diagnostics for the F-Droid (no Google services) build" translatable="false">F-Droid</string>
     <string name="diagnostics_activity_sensors_heading" translation_description="Section heading in the Diagnostics screen for sensor readings">Sensors</string>
     <string name="diagnostics_activity_compass" translation_description="Row label in the Diagnostics screen for the compass (magnetic field) sensor">Compass</string>
     <string name="diagnostics_activity_accelerometer" translation_description="Row label in the Diagnostics screen for the accelerometer sensor">Accelerometer</string>


### PR DESCRIPTION
## Summary
- Adds a build flavor label (`Gms` or `F-Droid`) to the Sky Map version row on the Diagnostics screen, so users and maintainers can quickly confirm which flavor is installed.
- Requested in order to help diagnose #946, where auto-location never completes for a user on an apk downloaded from GitHub Releases — we need to confirm whether that's the gms or fdroid build since they use different location providers.

## Changes
- `DiagnosticActivity.java`: new `getFlavorLabel()` helper switching on `BuildConfig.FLAVOR`; version string now built from a resource format string including the flavor label.
- `strings.xml`: new non-translatable strings for the format and the "Gms"/"F-Droid" labels.

## Test plan
- [ ] Build `assembleGmsDebug` and confirm Diagnostics screen shows `... [Gms]`
- [ ] Build `assembleFdroidDebug` and confirm Diagnostics screen shows `... [F-Droid]`

Refs #946

Generated with [Claude Code](https://claude.ai/code)