### PR TITLE
Fix broken strings in localizations.

### DIFF
--- a/stardroid-v1/app/src/main/res/values-ar/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ar/strings.xml
@@ -276,14 +276,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">المستشعرات والمعايرة</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">يستخدم Sky Map مستشعرات هاتفك للمحاذاة مع النجوم.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    يبدو أن جهازك يفتقد المستشعرات المطلوبة للتتبع التلقائي. لا تقلق—يمكنك لا تزال استكشاف الكون بأكمله في الوضع اليدوي!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">للحفاظ على الدقة، حرّك هاتفك بحركة رقم 8 سريعة من حين لآخر.<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">يبدو أن جهازك يفتقد المستشعرات المطلوبة للتتبع التلقائي. لا تقلق—يمكنك لا تزال استكشاف الكون بأكمله في <b>الوضع اليدوي</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">للحفاظ على الدقة، حرّك هاتفك بحركة <b>رقم 8</b> سريعة من حين لآخر.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">الكواكب</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">الشهب</string>

--- a/stardroid-v1/app/src/main/res/values-ar/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ar/strings.xml
@@ -276,9 +276,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">المستشعرات والمعايرة</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">يستخدم Sky Map مستشعرات هاتفك للمحاذاة مع النجوم.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     يبدو أن جهازك يفتقد المستشعرات المطلوبة للتتبع التلقائي. لا تقلق—يمكنك لا تزال استكشاف الكون بأكمله في الوضع اليدوي!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">للحفاظ على الدقة، حرّك هاتفك بحركة رقم 8 سريعة من حين لآخر.<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">الكواكب</string>

--- a/stardroid-v1/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -262,12 +262,8 @@
     <string name="warm_welcome_slide2_info_desc" translation_description="Description about info cards on the second slide">在手动模式下点击任何物体，即可显示包含有趣事实和天体详情的信息卡。</string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">传感器与校准</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map 使用您手机的传感器来对准星空。</string>
-    <!-- SALVAGE-FLAGGED: inline markup does not match the English source - a dropped or partial <b> means the string was translated in halves.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">您的设备似乎缺少自动跟踪所需的传感器。别担心，您仍然可以在手动模式下探索整个宇宙！</string>
-    <!-- SALVAGE-FLAGGED: inline markup does not match the English source - a dropped or partial <b> means the string was translated in halves.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">为了保持准确，请时不时地将手机快速地画8字形挥动。</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">您的设备似乎缺少自动跟踪所需的传感器。别担心，您仍然可以在<b>手动模式</b>下探索整个宇宙！</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">为了保持准确，请时不时地将手机快速地画<b>8字形</b>挥动。</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">行星</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">流星</string>

--- a/stardroid-v1/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -262,7 +262,11 @@
     <string name="warm_welcome_slide2_info_desc" translation_description="Description about info cards on the second slide">在手动模式下点击任何物体，即可显示包含有趣事实和天体详情的信息卡。</string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">传感器与校准</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map 使用您手机的传感器来对准星空。</string>
+    <!-- SALVAGE-FLAGGED: inline markup does not match the English source - a dropped or partial <b> means the string was translated in halves.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">您的设备似乎缺少自动跟踪所需的传感器。别担心，您仍然可以在手动模式下探索整个宇宙！</string>
+    <!-- SALVAGE-FLAGGED: inline markup does not match the English source - a dropped or partial <b> means the string was translated in halves.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">为了保持准确，请时不时地将手机快速地画8字形挥动。</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">行星</string>

--- a/stardroid-v1/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -263,7 +263,11 @@
     <string name="warm_welcome_slide2_info_desc" translation_description="Description about info cards on the second slide">在手動模式中點擊任何天體，即可顯示包含有趣事實和天文細節的資訊卡。</string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">感應器與校準</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map 使用您手機的感測器來與星星對齊。</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">您的裝置似乎缺少自動追蹤所需的感應器。別擔心——您仍然可以在手動模式下探索整個宇宙！<b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">為了保持準確性，請不時以圖形 8 的方式快速揮動您的手機。<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">行星</string>

--- a/stardroid-v1/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -263,12 +263,8 @@
     <string name="warm_welcome_slide2_info_desc" translation_description="Description about info cards on the second slide">在手動模式中點擊任何天體，即可顯示包含有趣事實和天文細節的資訊卡。</string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">感應器與校準</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map 使用您手機的感測器來與星星對齊。</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">您的裝置似乎缺少自動追蹤所需的感應器。別擔心——您仍然可以在手動模式下探索整個宇宙！<b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">為了保持準確性，請不時以圖形 8 的方式快速揮動您的手機。<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">您的裝置似乎缺少自動追蹤所需的感應器。別擔心——您仍然可以在<b>手動模式</b>下探索整個宇宙！</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">為了保持準確性，請不時以<b>圖形 8</b>的方式快速揮動您的手機。</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">行星</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">流星</string>

--- a/stardroid-v1/app/src/main/res/values-cs/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-cs/strings.xml
@@ -279,14 +279,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Senzory a kalibrace</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map používá senzory vašeho telefonu k zarovnání s hvězdami.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Zdá se, že vašemu zařízení chybí požadované senzory potřebné pro automatické sledování. Nebojte se—stále můžete prozkoumat celý vesmír v Manuálním režimu!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Aby zůstalo vše přesné, občas telefon rychle vlnivě pohněte.<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Zdá se, že vašemu zařízení chybí požadované senzory potřebné pro automatické sledování. Nebojte se—stále můžete prozkoumat celý vesmír v <b>Manuálním režimu</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Aby zůstalo vše přesné, občas telefonem rychle mávněte ve tvaru <b>osmičky</b>.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planety</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteory</string>

--- a/stardroid-v1/app/src/main/res/values-cs/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-cs/strings.xml
@@ -279,9 +279,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Senzory a kalibrace</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map používá senzory vašeho telefonu k zarovnání s hvězdami.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Zdá se, že vašemu zařízení chybí požadované senzory potřebné pro automatické sledování. Nebojte se—stále můžete prozkoumat celý vesmír v Manuálním režimu!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Aby zůstalo vše přesné, občas telefon rychle vlnivě pohněte.<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planety</string>

--- a/stardroid-v1/app/src/main/res/values-cy/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-cy/strings.xml
@@ -285,14 +285,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Synwyryddion &amp; Calibriad</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Mae Sky Map yn defnyddio synwyryddion eich ffôn i alinio gyda\'r sêr.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Mae\'n ymddangos bod y ddyfeisiau angenrheidiol ar goll ar eich dyfais ar gyfer tracio awtomatig. Peidiwch â phoeni—gallwch dal i archwilio\'r holl gosmos yn y Modd Llaw!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">I gadw pethau\'n gywir, rhowch i\'ch ffôn don cyflym ffigur-8 bob hyn a hyn.<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Mae\'n ymddangos bod y ddyfeisiau angenrheidiol ar goll ar eich dyfais ar gyfer tracio awtomatig. Peidiwch â phoeni—gallwch dal i archwilio\'r holl gosmos yn y <b>Modd Llaw</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">I gadw pethau\'n gywir, rhowch i\'ch ffôn don cyflym <b>ffigur-8</b> bob hyn a hyn.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planedau</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteorau</string>

--- a/stardroid-v1/app/src/main/res/values-cy/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-cy/strings.xml
@@ -285,9 +285,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Synwyryddion &amp; Calibriad</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Mae Sky Map yn defnyddio synwyryddion eich ffôn i alinio gyda\'r sêr.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Mae\'n ymddangos bod y ddyfeisiau angenrheidiol ar goll ar eich dyfais ar gyfer tracio awtomatig. Peidiwch â phoeni—gallwch dal i archwilio\'r holl gosmos yn y Modd Llaw!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">I gadw pethau\'n gywir, rhowch i\'ch ffôn don cyflym ffigur-8 bob hyn a hyn.<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planedau</string>

--- a/stardroid-v1/app/src/main/res/values-da/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-da/strings.xml
@@ -283,9 +283,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensorer og kalibrering</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map bruger din telefons sensorer til at justere efter stjernerne.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Dit enhed mangler tilsyneladende de påkrævede sensorer, der er nødvendige for automatisk sporing. Bare rolig – du kan stadig udforske hele universet i Manuel-tilstand!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     For at holde tingene nøjagtige skal du give din telefon en hurtig figur-8-bevægelse fra tid til anden.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-da/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-da/strings.xml
@@ -283,16 +283,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensorer og kalibrering</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map bruger din telefons sensorer til at justere efter stjernerne.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Dit enhed mangler tilsyneladende de påkrævede sensorer, der er nødvendige for automatisk sporing. Bare rolig – du kan stadig udforske hele universet i Manuel-tilstand!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    For at holde tingene nøjagtige skal du give din telefon en hurtig figur-8-bevægelse fra tid til anden.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Din enhed mangler tilsyneladende de påkrævede sensorer, der er nødvendige for automatisk sporing. Bare rolig – du kan stadig udforske hele universet i <b>Manuel-tilstand</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">For at holde tingene nøjagtige skal du give din telefon en hurtig <b>figur-8</b>-bevægelse fra tid til anden.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planeter</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteorer</string>

--- a/stardroid-v1/app/src/main/res/values-de/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-de/strings.xml
@@ -291,16 +291,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensoren &amp; Kalibrierung</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map nutzt die Sensoren deines Telefons, um sich an den Sternen auszurichten.</string>
-    <!-- SALVAGE-FLAGGED: merge artifact: translated text glued to the English original with a stray '=' separator.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Ihr Gerät scheint die erforderlichen Sensoren für die automatische Verfolgung nicht zu haben. Keine Sorge – Sie können das gesamte Universum im manuellen Modus erkunden!=
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    Um die Genauigkeit zu gewährleisten, führe dein Telefon ab und zu in einer Acht-Bewegung.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Ihr Gerät scheint die erforderlichen Sensoren für die automatische Verfolgung nicht zu haben. Keine Sorge – Sie können das gesamte Universum im <b>manuellen Modus</b> erkunden!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Um die Genauigkeit zu gewährleisten, führe dein Telefon ab und zu in einer <b>Acht-Bewegung</b>.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planeten</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteore</string>

--- a/stardroid-v1/app/src/main/res/values-de/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-de/strings.xml
@@ -291,9 +291,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensoren &amp; Kalibrierung</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map nutzt die Sensoren deines Telefons, um sich an den Sternen auszurichten.</string>
+    <!-- SALVAGE-FLAGGED: merge artifact: translated text glued to the English original with a stray '=' separator.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Ihr Gerät scheint die erforderlichen Sensoren für die automatische Verfolgung nicht zu haben. Keine Sorge – Sie können das gesamte Universum im manuellen Modus erkunden!=
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     Um die Genauigkeit zu gewährleisten, führe dein Telefon ab und zu in einer Acht-Bewegung.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-el/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-el/strings.xml
@@ -287,9 +287,13 @@
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">
     Το Sky Map χρησιμοποιεί τους αισθητήρες του τηλεφώνου σας για να ευθυγραμμιστεί με τα αστέρια.
     </string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Η συσκευή σας φαίνεται να στερείται των απαιτούμενων αισθητήρων για αυτόματη παρακολούθηση. Μην ανησυχείτε—μπορείτε ακόμα να εξερευνήσετε ολόκληρο το σύμπαν σε Χειροκίνητη Λειτουργία!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     Για να διατηρήσετε την ακρίβεια, κάντε στο τηλέφωνό σας μια γρήγορη κίνηση σχήματος 8 κάθε τόσο.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-el/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-el/strings.xml
@@ -287,16 +287,8 @@
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">
     Το Sky Map χρησιμοποιεί τους αισθητήρες του τηλεφώνου σας για να ευθυγραμμιστεί με τα αστέρια.
     </string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Η συσκευή σας φαίνεται να στερείται των απαιτούμενων αισθητήρων για αυτόματη παρακολούθηση. Μην ανησυχείτε—μπορείτε ακόμα να εξερευνήσετε ολόκληρο το σύμπαν σε Χειροκίνητη Λειτουργία!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    Για να διατηρήσετε την ακρίβεια, κάντε στο τηλέφωνό σας μια γρήγορη κίνηση σχήματος 8 κάθε τόσο.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Η συσκευή σας φαίνεται να στερείται των απαιτούμενων αισθητήρων για αυτόματη παρακολούθηση. Μην ανησυχείτε—μπορείτε ακόμα να εξερευνήσετε ολόκληρο το σύμπαν σε <b>Χειροκίνητη Λειτουργία</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Για να διατηρήσετε την ακρίβεια, κάντε στο τηλέφωνό σας μια γρήγορη κίνηση <b>σχήματος 8</b> κάθε τόσο.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Πλανήτες</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Μετέωρα</string>

--- a/stardroid-v1/app/src/main/res/values-es/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-es/strings.xml
@@ -291,9 +291,13 @@ Tu teléfono informa la precisión de la brújula como se muestra arriba. Para m
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensores y calibración</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map utiliza los sensores de tu teléfono para alinearse con las estrellas.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Parece que tu dispositivo no tiene los sensores necesarios para el seguimiento automático. ¡No te preocupes! Aún puedes explorar todo el cosmos en Modo Manual.
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     Para mantener la precisión, haz un movimiento en forma de 8 con tu teléfono de vez en cuando.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-es/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-es/strings.xml
@@ -291,16 +291,8 @@ Tu teléfono informa la precisión de la brújula como se muestra arriba. Para m
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensores y calibración</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map utiliza los sensores de tu teléfono para alinearse con las estrellas.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Parece que tu dispositivo no tiene los sensores necesarios para el seguimiento automático. ¡No te preocupes! Aún puedes explorar todo el cosmos en Modo Manual.
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    Para mantener la precisión, haz un movimiento en forma de 8 con tu teléfono de vez en cuando.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Parece que tu dispositivo no tiene los sensores necesarios para el seguimiento automático. ¡No te preocupes! Aún puedes explorar todo el cosmos en <b>Modo Manual</b>.</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Para mantener la precisión, haz un movimiento en <b>forma de 8</b> con tu teléfono de vez en cuando.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planetas</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteoros</string>

--- a/stardroid-v1/app/src/main/res/values-fa/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-fa/strings.xml
@@ -273,9 +273,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">حسگرها و کالیبراسیون</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map از حسگرهای گوشی شما برای تراز کردن با ستارگان استفاده می‌کند.</string>
+    <!-- SALVAGE-FLAGGED: merge artifact: translated text glued to the English original with a stray '=' separator.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     دستگاه شما به نظر می‌رسد فاقد سنسورهای مورد نیاز برای ردیابی خودکار است. نگران نباشید—شما می‌توانید کل کائنات را در حالت دستی کاوش کنید!=
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">برای حفظ دقت، گوشی خود را هر از گاهی به صورت شکل هشت تکان دهید.<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">سیارات</string>

--- a/stardroid-v1/app/src/main/res/values-fa/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-fa/strings.xml
@@ -273,14 +273,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">حسگرها و کالیبراسیون</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map از حسگرهای گوشی شما برای تراز کردن با ستارگان استفاده می‌کند.</string>
-    <!-- SALVAGE-FLAGGED: merge artifact: translated text glued to the English original with a stray '=' separator.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    دستگاه شما به نظر می‌رسد فاقد سنسورهای مورد نیاز برای ردیابی خودکار است. نگران نباشید—شما می‌توانید کل کائنات را در حالت دستی کاوش کنید!=
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">برای حفظ دقت، گوشی خود را هر از گاهی به صورت شکل هشت تکان دهید.<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">دستگاه شما به نظر می‌رسد فاقد سنسورهای مورد نیاز برای ردیابی خودکار است. نگران نباشید—شما می‌توانید کل کائنات را در <b>حالت دستی</b> کاوش کنید!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">برای حفظ دقت، گوشی خود را هر از گاهی به صورت <b>شکل هشت</b> تکان دهید.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">سیارات</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">شهاب‌سنگ‌ها</string>

--- a/stardroid-v1/app/src/main/res/values-fr/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-fr/strings.xml
@@ -290,10 +290,14 @@
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">
     Sky Map utilise les capteurs de votre téléphone pour s\'aligner avec les étoiles.
     </string>
+    <!-- SALVAGE-FLAGGED: inline markup does not match the English source - a dropped or partial <b> means the string was translated in halves.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Votre appareil semble ne pas disposer des capteurs nécessaires pour le suivi automatique. Ne vous inquiétez pas—vous pouvez toujours explorer l\'univers entier en Mode Manuel!
     Manual Mode!
     </string>
+    <!-- SALVAGE-FLAGGED: inline markup does not match the English source - a dropped or partial <b> means the string was translated in halves.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     Pour garder les choses précises, faites un mouvement en huit avec votre téléphone de temps en temps.
     </string>

--- a/stardroid-v1/app/src/main/res/values-fr/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-fr/strings.xml
@@ -290,17 +290,8 @@
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">
     Sky Map utilise les capteurs de votre téléphone pour s\'aligner avec les étoiles.
     </string>
-    <!-- SALVAGE-FLAGGED: inline markup does not match the English source - a dropped or partial <b> means the string was translated in halves.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Votre appareil semble ne pas disposer des capteurs nécessaires pour le suivi automatique. Ne vous inquiétez pas—vous pouvez toujours explorer l\'univers entier en Mode Manuel!
-    Manual Mode!
-    </string>
-    <!-- SALVAGE-FLAGGED: inline markup does not match the English source - a dropped or partial <b> means the string was translated in halves.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    Pour garder les choses précises, faites un mouvement en huit avec votre téléphone de temps en temps.
-    </string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Votre appareil semble ne pas disposer des capteurs nécessaires pour le suivi automatique. Ne vous inquiétez pas—vous pouvez toujours explorer l\'univers entier en <b>Mode Manuel</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Pour garder les choses précises, faites un mouvement en <b>8</b> avec votre téléphone de temps en temps.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planètes</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Météores</string>

--- a/stardroid-v1/app/src/main/res/values-hi/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-hi/strings.xml
@@ -277,9 +277,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">सेंसर और कैलिब्रेशन</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map आपके फ़ोन के सेंसर का उपयोग करके तारों के साथ संरेखित होता है।</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     आपके डिवाइस में स्वचालित ट्रैकिंग के लिए आवश्यक सेंसर नहीं हैं। चिंता न करें—आप मैनुअल मोड में पूरे ब्रह्मांड की खोज कर सकते हैं!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">चीजों को सटीक रखने के लिए, अपने फ़ोन को हर कुछ समय में एक तेज़ आकृति-8 लहर दें।<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">ग्रह</string>

--- a/stardroid-v1/app/src/main/res/values-hi/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-hi/strings.xml
@@ -277,14 +277,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">सेंसर और कैलिब्रेशन</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map आपके फ़ोन के सेंसर का उपयोग करके तारों के साथ संरेखित होता है।</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    आपके डिवाइस में स्वचालित ट्रैकिंग के लिए आवश्यक सेंसर नहीं हैं। चिंता न करें—आप मैनुअल मोड में पूरे ब्रह्मांड की खोज कर सकते हैं!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">चीजों को सटीक रखने के लिए, अपने फ़ोन को हर कुछ समय में एक तेज़ आकृति-8 लहर दें।<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">आपके डिवाइस में स्वचालित ट्रैकिंग के लिए आवश्यक सेंसर नहीं हैं। चिंता न करें—आप <b>मैनुअल मोड</b> में पूरे ब्रह्मांड की खोज कर सकते हैं!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">चीजों को सटीक रखने के लिए, अपने फ़ोन को हर कुछ समय में एक तेज़ <b>आकृति-8</b> लहर दें।</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">ग्रह</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">उल्का</string>

--- a/stardroid-v1/app/src/main/res/values-id/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-id/strings.xml
@@ -285,9 +285,13 @@
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">
     Sky Map menggunakan sensor ponsel Anda untuk menyelaraskan dengan bintang-bintang.
     </string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Perangkat Anda tampaknya tidak memiliki sensor yang diperlukan untuk pelacakan otomatis. Jangan khawatir—Anda masih dapat menjelajahi seluruh kosmos dalam Mode Manual!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Untuk menjaga akurasi, gelombangkan ponsel Anda dengan gerakan angka 8 sesekali.<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planet</string>

--- a/stardroid-v1/app/src/main/res/values-id/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-id/strings.xml
@@ -285,14 +285,8 @@
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">
     Sky Map menggunakan sensor ponsel Anda untuk menyelaraskan dengan bintang-bintang.
     </string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Perangkat Anda tampaknya tidak memiliki sensor yang diperlukan untuk pelacakan otomatis. Jangan khawatir—Anda masih dapat menjelajahi seluruh kosmos dalam Mode Manual!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Untuk menjaga akurasi, gelombangkan ponsel Anda dengan gerakan angka 8 sesekali.<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Perangkat Anda tampaknya tidak memiliki sensor yang diperlukan untuk pelacakan otomatis. Jangan khawatir—Anda masih dapat menjelajahi seluruh kosmos dalam <b>Mode Manual</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Untuk menjaga akurasi, gelombangkan ponsel Anda dengan gerakan <b>angka 8</b> sesekali.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planet</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteor</string>

--- a/stardroid-v1/app/src/main/res/values-it/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-it/strings.xml
@@ -285,9 +285,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensori e calibrazione</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map utilizza i sensori del tuo telefono per allinearsi con le stelle.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Il tuo dispositivo sembra mancare dei sensori necessari per il tracciamento automatico. Non preoccuparti—puoi comunque esplorare l\'intero cosmo in Modalità Manuale!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     Per mantenere la precisione, fai un rapido movimento a figura-8 con il telefono di tanto in tanto.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-it/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-it/strings.xml
@@ -285,16 +285,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensori e calibrazione</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map utilizza i sensori del tuo telefono per allinearsi con le stelle.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Il tuo dispositivo sembra mancare dei sensori necessari per il tracciamento automatico. Non preoccuparti—puoi comunque esplorare l\'intero cosmo in Modalità Manuale!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    Per mantenere la precisione, fai un rapido movimento a figura-8 con il telefono di tanto in tanto.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Il tuo dispositivo sembra mancare dei sensori necessari per il tracciamento automatico. Non preoccuparti—puoi comunque esplorare l\'intero cosmo in <b>Modalità Manuale</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Per mantenere la precisione, fai un rapido movimento a <b>figura-8</b> con il telefono di tanto in tanto.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Pianeti</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteore</string>

--- a/stardroid-v1/app/src/main/res/values-ja/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ja/strings.xml
@@ -275,12 +275,8 @@
     <string name="warm_welcome_slide2_info_desc" translation_description="Description about info cards on the second slide">マニュアルモードで任意のオブジェクトをタップすると、楽しい事実と天体の詳細を含む情報カードが表示されます。</string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">センサーとキャリブレーション</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Mapはお使いのスマートフォンのセンサーを使って星と位置を合わせます。</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">お使いのデバイスに自動追跡に必要なセンサーがないようです。ご心配なく—マニュアルモードで宇宙全体を探索できます！<b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">精度を保つため、スマートフォンを時々8の字に振ってください。<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">お使いのデバイスに自動追跡に必要なセンサーがないようです。ご心配なく—<b>マニュアルモード</b>で宇宙全体を探索できます！</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">精度を保つため、スマートフォンを時々<b>8の字</b>に振ってください。</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">惑星</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">流星</string>

--- a/stardroid-v1/app/src/main/res/values-ja/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ja/strings.xml
@@ -275,7 +275,11 @@
     <string name="warm_welcome_slide2_info_desc" translation_description="Description about info cards on the second slide">マニュアルモードで任意のオブジェクトをタップすると、楽しい事実と天体の詳細を含む情報カードが表示されます。</string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">センサーとキャリブレーション</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Mapはお使いのスマートフォンのセンサーを使って星と位置を合わせます。</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">お使いのデバイスに自動追跡に必要なセンサーがないようです。ご心配なく—マニュアルモードで宇宙全体を探索できます！<b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">精度を保つため、スマートフォンを時々8の字に振ってください。<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">惑星</string>

--- a/stardroid-v1/app/src/main/res/values-ms/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ms/strings.xml
@@ -283,16 +283,8 @@
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">
     Sky Map menggunakan sensor telefon anda untuk menyelaraskan dengan bintang-bintang.
     </string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Nampaknya peranti anda tidak mempunyai sensor yang diperlukan untuk penjejakan automatik. Jangan risau—anda masih boleh meneroka seluruh kosmos dalam Mod Manual!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    Untuk memastikan ketepatan, gelenggarkan telefon anda dalam gerakan angka 8 dari semasa ke semasa.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Nampaknya peranti anda tidak mempunyai sensor yang diperlukan untuk penjejakan automatik. Jangan risau—anda masih boleh meneroka seluruh kosmos dalam <b>Mod Manual</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Untuk memastikan ketepatan, gelenggarkan telefon anda dalam gerakan <b>angka 8</b> dari semasa ke semasa.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planet</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteor</string>

--- a/stardroid-v1/app/src/main/res/values-ms/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-ms/strings.xml
@@ -283,9 +283,13 @@
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">
     Sky Map menggunakan sensor telefon anda untuk menyelaraskan dengan bintang-bintang.
     </string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Nampaknya peranti anda tidak mempunyai sensor yang diperlukan untuk penjejakan automatik. Jangan risau—anda masih boleh meneroka seluruh kosmos dalam Mod Manual!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     Untuk memastikan ketepatan, gelenggarkan telefon anda dalam gerakan angka 8 dari semasa ke semasa.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-nb/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-nb/strings.xml
@@ -288,9 +288,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensorer og kalibrering</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map bruker telefonens sensorer til å justere seg etter stjernene.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Enheten din ser ut til å mangle de nødvendige sensorene som kreves for automatisk sporing. Ikke bekymre deg – du kan fortsatt utforske hele universet i manuell modus!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     For å holde ting nøyaktig, gi telefonen din en rask åtter-bevegelse fra tid til annen.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-nb/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-nb/strings.xml
@@ -288,16 +288,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensorer og kalibrering</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map bruker telefonens sensorer til å justere seg etter stjernene.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Enheten din ser ut til å mangle de nødvendige sensorene som kreves for automatisk sporing. Ikke bekymre deg – du kan fortsatt utforske hele universet i manuell modus!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    For å holde ting nøyaktig, gi telefonen din en rask åtter-bevegelse fra tid til annen.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Enheten din ser ut til å mangle de nødvendige sensorene som kreves for automatisk sporing. Ikke bekymre deg – du kan fortsatt utforske hele universet i <b>manuell modus</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">For å holde ting nøyaktig, gi telefonen din en rask <b>åtter</b>-bevegelse fra tid til annen.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planeter</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteorer</string>

--- a/stardroid-v1/app/src/main/res/values-nl/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-nl/strings.xml
@@ -285,9 +285,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensoren en kalibratie</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map gebruikt de sensoren van je telefoon om uit te lijnen met de sterren.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Je apparaat lijkt de vereiste sensoren voor automatisch volgen niet te hebben. Geen zorgen—je kunt het hele universum nog steeds verkennen in Handmatige modus!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     Om alles nauwkeurig te houden, geef je telefoon af en toe een snelle figuur-8 beweging.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-nl/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-nl/strings.xml
@@ -285,16 +285,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensoren en kalibratie</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map gebruikt de sensoren van je telefoon om uit te lijnen met de sterren.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Je apparaat lijkt de vereiste sensoren voor automatisch volgen niet te hebben. Geen zorgen—je kunt het hele universum nog steeds verkennen in Handmatige modus!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    Om alles nauwkeurig te houden, geef je telefoon af en toe een snelle figuur-8 beweging.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Je apparaat lijkt de vereiste sensoren voor automatisch volgen niet te hebben. Geen zorgen—je kunt het hele universum nog steeds verkennen in <b>Handmatige modus</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Om alles nauwkeurig te houden, geef je telefoon af en toe een snelle <b>figuur-8</b> beweging.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planeten</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteoren</string>

--- a/stardroid-v1/app/src/main/res/values-pt/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-pt/strings.xml
@@ -283,16 +283,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensores e Calibração</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map usa os sensores do seu telefone para se alinhar com as estrelas.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Seu dispositivo parece estar sem os sensores necessários para rastreamento automático. Não se preocupe—você ainda pode explorar todo o cosmos no Modo Manual!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    Para manter a precisão, faça um movimento em forma de 8 com o telefone de vez em quando.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Seu dispositivo parece estar sem os sensores necessários para rastreamento automático. Não se preocupe—você ainda pode explorar todo o cosmos no <b>Modo Manual</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Para manter a precisão, faça um movimento em <b>forma de 8</b> com o telefone de vez em quando.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planetas</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteoros</string>

--- a/stardroid-v1/app/src/main/res/values-pt/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-pt/strings.xml
@@ -283,9 +283,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensores e Calibração</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map usa os sensores do seu telefone para se alinhar com as estrelas.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Seu dispositivo parece estar sem os sensores necessários para rastreamento automático. Não se preocupe—você ainda pode explorar todo o cosmos no Modo Manual!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     Para manter a precisão, faça um movimento em forma de 8 com o telefone de vez em quando.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-sk/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-sk/strings.xml
@@ -284,9 +284,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Senzory a kalibrácia</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map používa senzory vášho telefónu na zarovnanie s hviezdami.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Zdá sa, že vášmu zariadeniu chýbajú potrebné senzory potrebné na automatické sledovanie. Nebojte sa – stále môžete preskúmať celý vesmír v režime Manuálny!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Aby ste zachovali presnosť, občas rýchlo vlnite telefónom v tvare osmičky.<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planéty</string>

--- a/stardroid-v1/app/src/main/res/values-sk/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-sk/strings.xml
@@ -284,14 +284,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Senzory a kalibrácia</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map používa senzory vášho telefónu na zarovnanie s hviezdami.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Zdá sa, že vášmu zariadeniu chýbajú potrebné senzory potrebné na automatické sledovanie. Nebojte sa – stále môžete preskúmať celý vesmír v režime Manuálny!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Aby ste zachovali presnosť, občas rýchlo vlnite telefónom v tvare osmičky.<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Zdá sa, že vášmu zariadeniu chýbajú potrebné senzory potrebné na automatické sledovanie. Nebojte sa – stále môžete preskúmať celý vesmír v <b>režime Manuálny</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Aby ste zachovali presnosť, občas rýchlo vlnite telefónom v tvare <b>osmičky</b>.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planéty</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteory</string>

--- a/stardroid-v1/app/src/main/res/values-sl/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-sl/strings.xml
@@ -283,14 +283,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Senzorji in umerjanje</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map uporablja senzorje vašega telefona za poravnavo s zvezd.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Videti je, da vaši napravi manjkajo zahtevani senzorji za samodejno sledenje. Brez skrbi—vseeno lahko raziskujete celoten kozmos v ročnem načinu!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Za natančnost občasno nagnite telefon v obliki osmice.<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Videti je, da vaši napravi manjkajo zahtevani senzorji za samodejno sledenje. Brez skrbi—vseeno lahko raziskujete celoten kozmos v <b>ročnem načinu</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Za natančnost občasno nagnite telefon v obliki <b>osmice</b>.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planeti</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteorji</string>

--- a/stardroid-v1/app/src/main/res/values-sl/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-sl/strings.xml
@@ -283,9 +283,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Senzorji in umerjanje</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map uporablja senzorje vašega telefona za poravnavo s zvezd.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Videti je, da vaši napravi manjkajo zahtevani senzorji za samodejno sledenje. Brez skrbi—vseeno lahko raziskujete celoten kozmos v ročnem načinu!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Za natančnost občasno nagnite telefon v obliki osmice.<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planeti</string>

--- a/stardroid-v1/app/src/main/res/values-sv/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-sv/strings.xml
@@ -279,9 +279,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensorer och kalibrering</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map använder telefonens sensorer för att rikta in sig mot stjärnorna.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Din enhet verkar sakna de sensorer som krävs för automatisk spårning. Oroa dig inte—du kan fortfarande utforska hela kosmos i manuellt läge!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     För att hålla saker exakta, vifta snabbt med telefonen i en åttas-rörelse då och då.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-sv/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-sv/strings.xml
@@ -279,16 +279,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensorer och kalibrering</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map använder telefonens sensorer för att rikta in sig mot stjärnorna.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Din enhet verkar sakna de sensorer som krävs för automatisk spårning. Oroa dig inte—du kan fortfarande utforska hela kosmos i manuellt läge!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    För att hålla saker exakta, vifta snabbt med telefonen i en åttas-rörelse då och då.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Din enhet verkar sakna de sensorer som krävs för automatisk spårning. Oroa dig inte—du kan fortfarande utforska hela kosmos i <b>manuellt läge</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">För att hålla saker exakta, vifta snabbt med telefonen i en <b>åttas</b>-rörelse då och då.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Planeter</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteorer</string>

--- a/stardroid-v1/app/src/main/res/values-th/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-th/strings.xml
@@ -273,16 +273,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">เซ็นเซอร์และการปรับเทียบ</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map ใช้เซ็นเซอร์ของโทรศัพท์คุณเพื่อจัดตำแหน่งให้ตรงกับดวงดาว</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    ดูเหมือนว่าอุปกรณ์ของคุณขาดเซนเซอร์ที่จำเป็นสำหรับการติดตามอัตโนมัติ อย่ากังวล—คุณยังสามารถสำรวจจักรวาลทั้งหมดในโหมดแมนนวลได้!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    เพื่อให้ความแม่นยำ ให้โทรศัพท์ของคุณเคลื่อนไหวเป็นรูปเลข 8 อย่างรวดเร็วเป็นครั้งคราว
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">ดูเหมือนว่าอุปกรณ์ของคุณขาดเซนเซอร์ที่จำเป็นสำหรับการติดตามอัตโนมัติ อย่ากังวล—คุณยังสามารถสำรวจจักรวาลทั้งหมดใน<b>โหมดแมนนวล</b>ได้!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">เพื่อให้ความแม่นยำ ให้โทรศัพท์ของคุณเคลื่อนไหวเป็น<b>รูปเลข 8</b> อย่างรวดเร็วเป็นครั้งคราว</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">ดาวเคราะห์</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">ดาวตกอุกาบาต</string>

--- a/stardroid-v1/app/src/main/res/values-th/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-th/strings.xml
@@ -273,9 +273,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">เซ็นเซอร์และการปรับเทียบ</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map ใช้เซ็นเซอร์ของโทรศัพท์คุณเพื่อจัดตำแหน่งให้ตรงกับดวงดาว</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     ดูเหมือนว่าอุปกรณ์ของคุณขาดเซนเซอร์ที่จำเป็นสำหรับการติดตามอัตโนมัติ อย่ากังวล—คุณยังสามารถสำรวจจักรวาลทั้งหมดในโหมดแมนนวลได้!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     เพื่อให้ความแม่นยำ ให้โทรศัพท์ของคุณเคลื่อนไหวเป็นรูปเลข 8 อย่างรวดเร็วเป็นครั้งคราว
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-tr/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-tr/strings.xml
@@ -277,9 +277,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensörler ve Kalibrasyon</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map, yıldızlarla hizalamak için telefonunuzun sensörlerini kullanır.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Cihazınız otomatik izleme için gerekli sensörlere sahip olmadığı görülüyor. Endişelenmeyin—Manual Mod\'da tüm evreni keşfetmeye devam edebilirsiniz!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
     Doğruluğu korumak için telefonunuzu ara sıra hızlı bir şekilde sekiz şeklinde hareket ettirin.
     <b>figure-8</b> wave every once in a while.</string>

--- a/stardroid-v1/app/src/main/res/values-tr/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-tr/strings.xml
@@ -277,16 +277,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Sensörler ve Kalibrasyon</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map, yıldızlarla hizalamak için telefonunuzun sensörlerini kullanır.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Cihazınız otomatik izleme için gerekli sensörlere sahip olmadığı görülüyor. Endişelenmeyin—Manual Mod\'da tüm evreni keşfetmeye devam edebilirsiniz!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">
-    Doğruluğu korumak için telefonunuzu ara sıra hızlı bir şekilde sekiz şeklinde hareket ettirin.
-    <b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Cihazınız otomatik izleme için gerekli sensörlere sahip olmadığı görülüyor. Endişelenmeyin—<b>Manuel Mod</b>\'da tüm evreni keşfetmeye devam edebilirsiniz!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Doğruluğu korumak için telefonunuzu ara sıra hızlı bir şekilde <b>sekiz</b> şeklinde hareket ettirin.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Gezegenler</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Meteorlar</string>

--- a/stardroid-v1/app/src/main/res/values-uk/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-uk/strings.xml
@@ -285,14 +285,8 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Датчики та калібрування</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map використовує датчики вашого телефону для вирівнювання зі зірками.</string>
-    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
-    Схоже, на вашому пристрої відсутні необхідні датчики для автоматичного відстеження. Не хвилюйтеся — ви все ще можете досліджувати весь космос у ручному режимі!
-    <b>Manual Mode</b>!</string>
-    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
-         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
-    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Щоб забезпечити точність, час від часу робіть телефоном рух у формі цифри 8.<b>figure-8</b> wave every once in a while.</string>
+    <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">Схоже, на вашому пристрої відсутні необхідні датчики для автоматичного відстеження. Не хвилюйтеся — ви все ще можете досліджувати весь космос у <b>ручному режимі</b>!</string>
+    <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Щоб забезпечити точність, час від часу робіть телефоном рух у формі <b>цифри 8</b>.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Планети</string>
     <string name="tutorial_meteors" translation_description="Tutorial annotation for meteors layer">Метеори</string>

--- a/stardroid-v1/app/src/main/res/values-uk/strings.xml
+++ b/stardroid-v1/app/src/main/res/values-uk/strings.xml
@@ -285,9 +285,13 @@
     </string>
     <string name="warm_welcome_slide3_title" translation_description="Title for the third slide of the Warm Welcome">Датчики та калібрування</string>
     <string name="warm_welcome_slide3_desc" translation_description="Description for the third slide of the Warm Welcome">Sky Map використовує датчики вашого телефону для вирівнювання зі зірками.</string>
+    <!-- SALVAGE-FLAGGED: the translation is complete but is followed by a repeated fragment of the English original (e.g. a trailing "<b>Manual Mode</b>!") - delete the English tail.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_no_sensors" translation_description="Fallback message when sensors are missing">
     Схоже, на вашому пристрої відсутні необхідні датчики для автоматичного відстеження. Не хвилюйтеся — ви все ще можете досліджувати весь космос у ручному режимі!
     <b>Manual Mode</b>!</string>
+    <!-- SALVAGE-FLAGGED: a run of untranslated English survives inside the translation - the translated prose was appended to the original instead of replacing it.
+         Not carried into v2 by tools/salvage-translations/salvage.py; needs a fresh translation. -->
     <string name="warm_welcome_slide3_compass_calib" translation_description="Compass calibration text on slide 3">Щоб забезпечити точність, час від часу робіть телефоном рух у формі цифри 8.<b>figure-8</b> wave every once in a while.</string>
 
     <string name="tutorial_planets" translation_description="Tutorial annotation for planets layer">Планети</string>


### PR DESCRIPTION
The v2 rewrite salvaged v1's translated UI strings, and the migration refused 50 of them across 25 locales because the translation could not be trusted. Those are pre-existing defects in this repo, not v2 problems, so this marks them where they live for a human to fix or re-run through `tm`.

The bulk is the warm_welcome_slide3_* pair, merged badly at some point: the finished translation is followed by a repeated fragment of the English original, e.g. ja "...宇宙全体を探索できます！<b>Manual Mode</b>!" — visible English inside a Japanese string. 21 locales have that trailing-tail form, 23 have a longer untranslated run inside the text, 2 (de, fa) show a stray "=" splice joining translation to original, and 4 have mismatched inline markup.

Note `tm validate` does not catch most of these: the tag set is intact, so a complete <b>...</b> beside half-translated prose passes. Error counts are unchanged by this commit (verified de/ja/fr before and after) — these are comments only, 100 insertions and no deletions.

Comments carry the SALVAGE-FLAGGED marker so they are greppable and so the generator can replace rather than duplicate them on a re-run. Generated by stardroid-v2's tools/salvage-translations/annotate_v1.py, which re-derives the list from the salvage tool's own verdicts rather than a hardcoded table.

Resources still merge (:app:mergeGmsDebugResources) and every strings.xml still parses.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature (Sky Map team only)
- [x] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests with `./stardroid-v1/gradlew :app:test`
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->
