### PR TITLE
Fix Vega constellation in Simplified Chinese

### DIFF
--- a/stardroid-v1/app/src/main/res/values-b+zh+Hans/celestial_objects.xml
+++ b/stardroid-v1/app/src/main/res/values-b+zh+Hans/celestial_objects.xml
@@ -175,7 +175,7 @@
     <string name="arcturus" translation_description="Name of the Star Arcturus">大角星（牧夫座 α）</string>
     <string name="rigel_kentaurus_a" translation_description="Name of the Star Rigel Kentaurus A">南門二（半人马座 α）</string>
     <string name="rigil_kentaurus_a" translation_description="Name of the Star Rigil Kentaurus A">南門二（半人马座 α）</string>
-    <string name="vega" translation_description="Name of the Star Vega">织女一（天鹰座 α）</string>
+    <string name="vega" translation_description="Name of the Star Vega">织女一（天琴座 α）</string>
     <string name="rigel" translation_description="Name of the Star Rigel">参宿七（猎户座 β）</string>
     <string name="procyon" translation_description="Name of the Star Procyon">南河三（小犬座 α）</string>
     <string name="betelgeuse" translation_description="Name of the Star Betelgeuse">参宿四（猎户座 α）</string>


### PR DESCRIPTION
### Motivation

Vega is Alpha Lyrae, but its Simplified Chinese label incorrectly identified it as
Alpha Aquilae (`天鹰座 α`).

### Changes

- Correct Vega’s Simplified Chinese label from `织女一（天鹰座 α）` to
  `织女一（天琴座 α）`.

### Testing

- Parsed the modified XML resource successfully.
- Asserted that the `vega` resource equals `织女一（天琴座 α）`.
- Ran `git diff --check`.