### PR TITLE
Fix Moon's geocentric-only position and add true-to-life body sizes

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/ephemeris/SolarSystemBody.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/ephemeris/SolarSystemBody.kt
@@ -36,7 +36,9 @@ enum class SolarSystemBody
     // String ID for the body's name
     val nameResourceId: Int,
     // How frequently to update the body's position
-    val updateFrequencyMs: Long
+    val updateFrequencyMs: Long,
+    // Mean physical radius, in kilometers.
+    val meanRadiusKm: Float
 ) {
     // The order here is the order in which they are drawn.  To ensure that during
     // conjunctions they display "naturally" order them in reverse distance from Earth.
@@ -45,46 +47,59 @@ enum class SolarSystemBody
     Pluto(
         R.drawable.pluto,
         R.string.pluto,
-        TimeConstants.MILLISECONDS_PER_HOUR
+        TimeConstants.MILLISECONDS_PER_HOUR,
+        1188.0f
     ),
-    Neptune(R.drawable.neptune, R.string.neptune, TimeConstants.MILLISECONDS_PER_HOUR),
+    Neptune(
+        R.drawable.neptune,
+        R.string.neptune,
+        TimeConstants.MILLISECONDS_PER_HOUR,
+        24622.0f
+    ),
     Uranus(
         R.drawable.uranus,
         R.string.uranus,
-        TimeConstants.MILLISECONDS_PER_HOUR
+        TimeConstants.MILLISECONDS_PER_HOUR,
+        25362.0f
     ),
     Saturn(
         R.drawable.saturn,
         R.string.saturn,
-        TimeConstants.MILLISECONDS_PER_HOUR
+        TimeConstants.MILLISECONDS_PER_HOUR,
+        58232.0f
     ),
     Jupiter(
         R.drawable.jupiter,
         R.string.jupiter,
-        TimeConstants.MILLISECONDS_PER_HOUR
+        TimeConstants.MILLISECONDS_PER_HOUR,
+        69911.0f
     ),
     Mars(
         R.drawable.mars,
         R.string.mars,
-        TimeConstants.MILLISECONDS_PER_HOUR
+        TimeConstants.MILLISECONDS_PER_HOUR,
+        3390.0f
     ),
     Sun(
         R.drawable.sun,
         R.string.sun,
-        TimeConstants.MILLISECONDS_PER_HOUR
+        TimeConstants.MILLISECONDS_PER_HOUR,
+        696000.0f
     ),
     Mercury(
         R.drawable.mercury,
         R.string.mercury,
-        TimeConstants.MILLISECONDS_PER_HOUR
+        TimeConstants.MILLISECONDS_PER_HOUR,
+        2440.0f
     ),
     Venus(
         R.drawable.venus,
         R.string.venus,
-        TimeConstants.MILLISECONDS_PER_HOUR
+        TimeConstants.MILLISECONDS_PER_HOUR,
+        6052.0f
     ),
-    Moon(R.drawable.moon4, R.string.moon, TimeConstants.MILLISECONDS_PER_MINUTE),
-    Earth(R.drawable.earth, R.string.earth, TimeConstants.MILLISECONDS_PER_HOUR);
+    Moon(R.drawable.moon4, R.string.moon, TimeConstants.MILLISECONDS_PER_MINUTE, 1737.0f),
+    Earth(R.drawable.earth, R.string.earth, TimeConstants.MILLISECONDS_PER_HOUR, 6371.0f);
 
     // Taken from JPL's Planetary Positions page: http://ssd.jpl.nasa.gov/?planet_pos
     // This gives us a good approximation for the years 1800 to 2050 AD.

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/ephemeris/SolarSystemRenderable.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/ephemeris/SolarSystemRenderable.kt
@@ -41,7 +41,6 @@ class SolarSystemRenderable(
     private val solarSystemBody: SolarSystemBody, resources: Resources,
     model: AstronomerModel, prefs: SharedPreferences
 ) : AbstractAstronomicalRenderable() {
-    private val pointPrimitives = ArrayList<PointPrimitive>()
     private val imagePrimitives = ArrayList<ImagePrimitive>()
     private val labelPrimitives = ArrayList<TextPrimitive>()
     private val resources: Resources
@@ -53,6 +52,7 @@ class SolarSystemRenderable(
     private var earthCoords: Vector3
     private var imageId = -1
     private var lastUpdateTimeMs = 0L
+    private var lastImageScale = Float.NaN
     private val universe = Universe()
     override val names: List<String>
         get() = Lists.asList(name)
@@ -62,10 +62,28 @@ class SolarSystemRenderable(
     private fun updateCoords(time: Date) {
         lastUpdateTimeMs = time.time
         earthCoords = heliocentricCoordinatesFromOrbitalElements(SolarSystemBody.Earth.getOrbitalElements(time))
-        currentCoords.updateFromRaDec(universe.getRaDec(solarSystemBody, time))
+        currentCoords.updateFromRaDec(
+            universe.getTopocentricRaDec(solarSystemBody, time, model.location)
+        )
         for (imagePrimitive in imagePrimitives) {
             imagePrimitive.setUpVector(getUpVectorForImage())
         }
+    }
+
+    // Called every frame from update(), independent of the position-update throttle below: this
+    // is cheap enough to run every time, and unlike position, size needs to react on the very
+    // next frame both to the true-size setting being toggled and to the Moon's true size
+    // changing continuously between perigee and apogee - waiting for the (up to hourly, for
+    // planets) position-update interval would leave it visibly stale. Returns true if the scale
+    // actually changed, so the caller knows whether the renderer needs telling.
+    private fun updateScale(time: Date): Boolean {
+        val scale = getImageScale(time)
+        if (scale == lastImageScale) return false
+        lastImageScale = scale
+        for (imagePrimitive in imagePrimitives) {
+            imagePrimitive.setScale(scale)
+        }
+        return true
     }
 
     // For the Moon, convert earthCoords from ecliptic to equatorial coordinates
@@ -79,36 +97,27 @@ class SolarSystemRenderable(
         }
     }
 
+    // Read every call so the Moon's true size (which changes continuously between perigee and
+    // apogee) stays current, and so toggling the setting takes effect on the next frame without
+    // needing a preference-change listener.
+    private fun getImageScale(time: Date): Float {
+        return if (preferences.getBoolean(SHOW_TRUE_SIZE, false)) {
+            solarSystemObject.getTrueAngularRadius(time)
+        } else {
+            solarSystemObject.getPlanetaryImageSize()
+        }
+    }
+
     override fun initialize(): Renderable {
         val time = model.time
         updateCoords(time)
         imageId = solarSystemObject.getImageResourceId(time)
-        if (solarSystemBody === SolarSystemBody.Moon) {
-            imagePrimitives.add(
-                ImagePrimitive(
-                    currentCoords, resources, imageId, getUpVectorForImage(),
-                    solarSystemObject.getPlanetaryImageSize()
-                )
+        lastImageScale = getImageScale(time)
+        imagePrimitives.add(
+            ImagePrimitive(
+                currentCoords, resources, imageId, getUpVectorForImage(), lastImageScale
             )
-        } else {
-            val usePlanetaryImages = preferences.getBoolean(SHOW_PLANETARY_IMAGES, true)
-            if (usePlanetaryImages || solarSystemBody === SolarSystemBody.Sun) {
-                imagePrimitives.add(
-                    ImagePrimitive(
-                        currentCoords, resources, imageId, UP,
-                        solarSystemObject.getPlanetaryImageSize()
-                    )
-                )
-            } else {
-                pointPrimitives.add(
-                    PointPrimitive(
-                        currentCoords,
-                        resources.getColor(R.color.planet_body, null),
-                        PLANET_SIZE
-                    )
-                )
-            }
-        }
+        )
         labelPrimitives.add(
             TextPrimitive(currentCoords, name, resources.getColor(R.color.sky_label, null))
         )
@@ -118,6 +127,9 @@ class SolarSystemRenderable(
     override fun update(): EnumSet<UpdateType> {
         val updates = EnumSet.noneOf(UpdateType::class.java)
         val modelTime = model.time
+        if (updateScale(modelTime)) {
+            updates.add(UpdateType.UpdatePositions)
+        }
         if (Math.abs(modelTime.time - lastUpdateTimeMs) > solarSystemObject.getUpdateFrequencyMs()) {
             updates.add(UpdateType.UpdatePositions)
             // update location
@@ -141,13 +153,9 @@ class SolarSystemRenderable(
         get() = imagePrimitives
     override val labels: List<TextPrimitive>
         get() = labelPrimitives
-    override val points: List<PointPrimitive>
-        get() = pointPrimitives
 
     companion object {
-        private const val PLANET_SIZE = 3
-        private const val SHOW_PLANETARY_IMAGES = "show_planetary_images"
-        private val UP = Vector3(0.0f, 1.0f, 0.0f)
+        private const val SHOW_TRUE_SIZE = "show_true_size"
     }
 
     init {

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderables/ImagePrimitive.java
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/renderables/ImagePrimitive.java
@@ -53,7 +53,8 @@ public class ImagePrimitive extends AbstractPrimitive {
 
   public boolean requiresBlending = false;
 
-  private final float imageScale;
+  private float imageScale;
+  private Vector3 upVec;
   private final Resources resources;
 
 
@@ -130,6 +131,7 @@ public class ImagePrimitive extends AbstractPrimitive {
   }
 
   public void setUpVector(Vector3 upVec) {
+    this.upVec = upVec;
     Vector3 p = this.getLocation();
     Vector3 u = p.times(upVec).normalizedCopy().unaryMinus();
     Vector3 v = u.times(p);
@@ -145,5 +147,16 @@ public class ImagePrimitive extends AbstractPrimitive {
     vx = v.x;
     vy = v.y;
     vz = v.z;
+  }
+
+  /**
+   * Updates the image's angular half-width (see the constructor's {@code imageScale} parameter)
+   * and re-derives the corner vectors from the last up-vector passed to {@link #setUpVector}.
+   * Used to resize a body's image every frame (e.g. for the "true-to-life sizes" setting)
+   * without reconstructing the primitive or reloading its bitmap.
+   */
+  public void setScale(float imageScale) {
+    this.imageScale = imageScale;
+    setUpVector(upVec);
   }
 }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Moon.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Moon.kt
@@ -23,16 +23,47 @@ import java.util.*
  */
 class Moon : EarthOrbitingObject(SolarSystemBody.Moon) {
     override fun getRaDec(date: Date): RaDec {
-        /**
-         * Calculate the geocentric right ascension and declination of the moon using
-         * an approximation as described on page D22 of the 2008 Astronomical Almanac
-         * All of the variables in this method use the same names as those described
-         * in the text: lambda = Ecliptic longitude (degrees) beta = Ecliptic latitude
-         * (degrees) pi = horizontal parallax (degrees) r = distance (Earth radii)
-         *
-         * NOTE: The text does not give a specific time period where the approximation
-         * is valid, but it should be valid through at least 2009.
-         */
+        val (l, m, n) = geocentricDirectionCosines(date)
+        val ra: Float = mod2pi(atan2(m, l)) * RADIANS_TO_DEGREES
+        val dec: Float = asin(n) * RADIANS_TO_DEGREES
+        return RaDec(ra, dec)
+    }
+
+    /**
+     * Right ascension and declination of the moon as seen by an observer at [location],
+     * correcting the geocentric position for diurnal parallax (up to ~1 degree - two lunar
+     * diameters - depending on where on Earth the observer stands and how close the Moon is).
+     * Same Astronomical Almanac (2008, p. D22) page as [getRaDec]; the horizontal-parallax
+     * series (`pi`) puts the Moon at `1 / sin(pi)` Earth radii, and the observer sits one
+     * Earth radius out at `(cos(lat) cos(lst), cos(lat) sin(lst), sin(lat))` in the same
+     * equatorial frame, with local sidereal time from [meanSiderealTime].
+     */
+    fun getTopocentricRaDec(date: Date, location: LatLong): RaDec {
+        val (l, m, n) = geocentricDirectionCosines(date)
+        val t = ((julianDay(date) - 2451545.0f) / 36525.0f).toFloat()
+        val distanceEarthRadii = 1.0f / sin(lunarHorizontalParallax(t) * DEGREES_TO_RADIANS)
+        val lstRad = meanSiderealTime(date, location.longitude) * DEGREES_TO_RADIANS
+        val latRad = location.latitude * DEGREES_TO_RADIANS
+        val observerFromGeocenter = Vector3(
+            cos(latRad) * cos(lstRad), cos(latRad) * sin(lstRad), sin(latRad)
+        )
+        val topocentric = Vector3(l, m, n) * distanceEarthRadii - observerFromGeocenter
+        return RaDec.fromGeocentricCoords(topocentric)
+    }
+
+    /**
+     * Calculate the geocentric right ascension and declination of the moon using
+     * an approximation as described on page D22 of the 2008 Astronomical Almanac
+     * All of the variables in this method use the same names as those described
+     * in the text: lambda = Ecliptic longitude (degrees) beta = Ecliptic latitude
+     * (degrees) pi = horizontal parallax (degrees) r = distance (Earth radii)
+     *
+     * NOTE: The text does not give a specific time period where the approximation
+     * is valid, but it should be valid through at least 2009.
+     *
+     * Returns the equatorial direction cosines (l, m, n) as a [Vector3].
+     */
+    private fun geocentricDirectionCosines(date: Date): Vector3 {
         // First, calculate the number of Julian centuries from J2000.0.
         val t = ((julianDay(date) - 2451545.0f) / 36525.0f).toFloat()
         // Second, calculate the approximate geocentric orbital elements.
@@ -47,23 +78,36 @@ class Moon : EarthOrbitingObject(SolarSystemBody.Moon) {
                 * sin((228.2f + 960400.89f * t) * DEGREES_TO_RADIANS)) - (0.28f
                 * sin((318.3f + 6003.15f * t) * DEGREES_TO_RADIANS)) - (0.17f
                 * sin((217.6f - 407332.21f * t) * DEGREES_TO_RADIANS))
-        //float pi =
-        //    0.9508f + 0.0518f * MathUtil.cos((135.0f + 477198.87f * t) * DEGREES_TO_RADIANS)
-        //        + 0.0095f * MathUtil.cos((259.3f - 413335.36f * t) * DEGREES_TO_RADIANS)
-        //        + 0.0078f * MathUtil.cos((235.7f + 890534.22f * t) * DEGREES_TO_RADIANS)
-        //        + 0.0028f * MathUtil.cos((269.9f + 954397.74f * t) * DEGREES_TO_RADIANS);
-        // float r = 1.0f / MathUtil.sin(pi * DEGREES_TO_RADIANS);
 
-        // Third, convert to RA and Dec.
+        // Third, convert to equatorial direction cosines.
         val l = (cos(beta * DEGREES_TO_RADIANS)
                 * cos(lambda * DEGREES_TO_RADIANS))
         val m = (0.9175f * cos(beta * DEGREES_TO_RADIANS)
                 * sin(lambda * DEGREES_TO_RADIANS)) - 0.3978f * sin(beta * DEGREES_TO_RADIANS)
         val n = (0.3978f * cos(beta * DEGREES_TO_RADIANS)
                 * sin(lambda * DEGREES_TO_RADIANS)) + 0.9175f * sin(beta * DEGREES_TO_RADIANS)
-        val ra: Float = mod2pi(atan2(m, l)) * RADIANS_TO_DEGREES
-        val dec: Float = asin(n) * RADIANS_TO_DEGREES
-        return RaDec(ra, dec)
+        return Vector3(l, m, n)
+    }
+
+    /** Lunar equatorial horizontal parallax in degrees, from the same Almanac page. */
+    private fun lunarHorizontalParallax(t: Float): Float {
+        return 0.9508f + 0.0518f * cos((135.0f + 477198.87f * t) * DEGREES_TO_RADIANS) +
+                0.0095f * cos((259.3f - 413335.36f * t) * DEGREES_TO_RADIANS) +
+                0.0078f * cos((235.7f + 890534.22f * t) * DEGREES_TO_RADIANS) +
+                0.0028f * cos((269.9f + 954397.74f * t) * DEGREES_TO_RADIANS)
+    }
+
+    /**
+     * The Moon's true angular radius, in radians. The Moon doesn't orbit the Sun, so it can't
+     * use [SolarSystemObject.getTrueAngularRadius]'s heliocentric distance calculation; instead,
+     * reuse the horizontal-parallax series already computed for [getTopocentricRaDec], since
+     * `1 / sin(parallax)` is the Earth-Moon distance in Earth radii.
+     */
+    override fun getTrueAngularRadius(time: Date): Float {
+        val t = ((julianDay(time) - 2451545.0f) / 36525.0f).toFloat()
+        val distanceEarthRadii = 1.0f / sin(lunarHorizontalParallax(t) * DEGREES_TO_RADIANS)
+        val distanceKm = distanceEarthRadii * SolarSystemBody.Earth.meanRadiusKm
+        return asin((SolarSystemBody.Moon.meanRadiusKm / distanceKm).coerceIn(-1f, 1f))
     }
 
     /** Returns the resource id for the planet's image.  */

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/SolarSystemObject.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/SolarSystemObject.kt
@@ -20,6 +20,8 @@ import kotlin.math.cos
 import com.google.android.stardroid.math.Vector3
 import kotlin.math.log10
 
+// Kilometers per astronomical unit.
+private const val KM_PER_AU = 149597870.7f
 
 /**
  * A celestial object that lives in our solar system.
@@ -103,6 +105,21 @@ abstract class SolarSystemObject(protected val solarSystemBody : SolarSystemBody
             SolarSystemBody.Saturn -> 0.035f
             else -> throw RuntimeException("Unknown image size for Solar System Object: $this")
         }
+    }
+
+    /**
+     * Calculates the true angular radius of the body as seen from Earth, in radians, from its
+     * real physical radius ([SolarSystemBody.meanRadiusKm]) and distance from Earth. Unlike
+     * [getPlanetaryImageSize]'s fixed, exaggerated-for-visibility constants, this reflects the
+     * body's actual apparent size in the sky (e.g. for rendering eclipses to scale).
+     */
+    open fun getTrueAngularRadius(time: Date): Float {
+        val planetCoords =
+            heliocentricCoordinatesFromOrbitalElements(solarSystemBody.getOrbitalElements(time))
+        val earthCoords =
+            heliocentricCoordinatesFromOrbitalElements(SolarSystemBody.Earth.getOrbitalElements(time))
+        val earthDistanceKm = planetCoords.distanceFrom(earthCoords) * KM_PER_AU
+        return MathUtils.asin((solarSystemBody.meanRadiusKm / earthDistanceKm).coerceIn(-1f, 1f))
     }
 
     /**

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Sun.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Sun.kt
@@ -11,7 +11,12 @@ package com.google.android.stardroid.space
 
 import com.google.android.stardroid.ephemeris.SolarSystemBody
 import com.google.android.stardroid.math.Vector3
+import com.google.android.stardroid.math.MathUtils
+import com.google.android.stardroid.math.heliocentricCoordinatesFromOrbitalElements
 import java.util.*
+
+// Kilometers per astronomical unit.
+private const val KM_PER_AU = 149597870.7f
 
 /**
  * The Sun is special as it's at the center of the solar system.
@@ -28,4 +33,13 @@ class Sun : SunOrbitingObject(SolarSystemBody.Sun) {
     // Moon. We shouldn't call this method for those bodies, but we want to do
     // something sane if we do.
     override fun getMagnitude(time: Date) = -27.0f
+
+    // The Sun has no orbital elements of its own (it's the heliocentric origin), so it can't use
+    // the base SolarSystemObject calculation; use Earth's distance from the Sun instead.
+    override fun getTrueAngularRadius(time: Date): Float {
+        val earthCoords =
+            heliocentricCoordinatesFromOrbitalElements(SolarSystemBody.Earth.getOrbitalElements(time))
+        val earthDistanceKm = earthCoords.length * KM_PER_AU
+        return MathUtils.asin((SolarSystemBody.Sun.meanRadiusKm / earthDistanceKm).coerceIn(-1f, 1f))
+    }
 }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Universe.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Universe.kt
@@ -10,6 +10,7 @@
 package com.google.android.stardroid.space
 
 import com.google.android.stardroid.ephemeris.SolarSystemBody
+import com.google.android.stardroid.math.LatLong
 import com.google.android.stardroid.math.RaDec
 import java.util.*
 
@@ -50,5 +51,21 @@ class Universe {
      */
     fun getRaDec(solarSystemBody: SolarSystemBody, datetime: Date): RaDec {
         return solarSystemObjectMap.get(solarSystemBody)!!.getRaDec(datetime)
+    }
+
+    /**
+     * Gets the location of a planet at a particular date, as seen by an observer at [location].
+     * Only the Moon's position depends meaningfully on the observer's location on Earth (diurnal
+     * parallax); every other body falls back to the geocentric [getRaDec], as their own parallax
+     * is far below this model's accuracy (e.g. the Sun's is at most ~0.002 degrees).
+     */
+    fun getTopocentricRaDec(
+        solarSystemBody: SolarSystemBody, datetime: Date, location: LatLong
+    ): RaDec {
+        return if (solarSystemBody == SolarSystemBody.Moon) {
+            moon.getTopocentricRaDec(datetime, location)
+        } else {
+            getRaDec(solarSystemBody, datetime)
+        }
     }
 }

--- a/stardroid-v1/app/src/main/res/values/strings.xml
+++ b/stardroid-v1/app/src/main/res/values/strings.xml
@@ -81,6 +81,10 @@
         translation_description="Setting toggle title: whether to show the blue sky gradient during the day">Show sky gradient</string>
     <string name="show_sky_gradient_preference_summary"
         translation_description="Setting toggle summary for sky gradient: explains what the feature does">Shades the sky blue near the Sun and dark on the opposite side</string>
+    <string name="show_true_size_preference_title"
+        translation_description="Setting toggle title: whether to render the Sun, Moon, and planets at their true size">Show true-to-life sizes</string>
+    <string name="show_true_size_preference_summary"
+        translation_description="Setting toggle summary: explains what the true size feature does, and why you might want it (e.g. eclipses)">Draws the Sun, Moon, and planets at their actual size in the sky, instead of enlarged for visibility. Useful for seeing eclipses to scale.</string>
     <string name="ecliptic" translation_description="Label for the ecliptic layer — the apparent annual path of the Sun across the sky">Ecliptic</string>
     <string name="dialog_accept" translation_description="accepting the licence agreement">Accept</string>
     <string name="dialog_decline" translation_description="declining the licence agreement">No Thanks</string>

--- a/stardroid-v1/app/src/main/res/xml/preference_screen.xml
+++ b/stardroid-v1/app/src/main/res/xml/preference_screen.xml
@@ -42,6 +42,11 @@
         android:key="show_sky_gradient"
         android:summary="@string/show_sky_gradient_preference_summary"
         android:title="@string/show_sky_gradient_preference_title" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="show_true_size"
+        android:summary="@string/show_true_size_preference_summary"
+        android:title="@string/show_true_size_preference_title" />
 
   </PreferenceCategory>
 

--- a/stardroid-v1/app/src/test/java/com/google/android/stardroid/space/MoonTest.kt
+++ b/stardroid-v1/app/src/test/java/com/google/android/stardroid/space/MoonTest.kt
@@ -10,12 +10,32 @@
 package com.google.android.stardroid.space
 
 import com.google.android.stardroid.math.HOURS_TO_DEGREES
+import com.google.android.stardroid.math.LatLong
+import com.google.android.stardroid.math.MathUtils
+import com.google.android.stardroid.math.RADIANS_TO_DEGREES
+import com.google.android.stardroid.math.RaDec
+import com.google.android.stardroid.math.getGeocentricCoords
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import java.util.*
 
 // Accuracy of our position calculations, in degrees.
 private const val POS_TOL = 0.2f
+
+// The topocentric correction itself is geometry - its error is dominated by the underlying
+// series' own small direction and parallax-term truncations, a couple of arcminutes at most.
+private const val PARALLAX_TOL = 0.05f
+
+// The horizontal parallax series peaks at ~1.03 degrees (perigee); the topocentric shift is
+// pi * sin(zenith distance), so no observer anywhere can see a larger offset.
+private const val MAX_LUNAR_PARALLAX = 1.03f
+
+private fun utc(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0): Date {
+    val cal = GregorianCalendar()
+    cal.timeZone = TimeZone.getTimeZone("GMT")
+    cal.set(year, month, day, hour, minute, 0)
+    return cal.time
+}
 
 class MoonTest {
     // Verify that we are calculating a valid lunar RA/Dec.
@@ -42,5 +62,71 @@ class MoonTest {
         lunarPos = moon.getRaDec(testCal.getTime())
         assertThat(lunarPos.ra).isWithin(POS_TOL).of(9.915f * HOURS_TO_DEGREES)
         assertThat(lunarPos.dec).isWithin(POS_TOL).of(8.056f)
+    }
+
+    // Pins the topocentric-geocentric differential against JPL Horizons apparent positions.
+    // The differential isolates the parallax correction from the low-precision series' own
+    // ~1 degree baseline error, so it can use a far tighter tolerance than the absolute
+    // position tests above.
+    @Test
+    fun testTopocentricLunarParallaxMatchesJplHorizonsDifferentials() {
+        val moon = Moon()
+
+        // Horizons geocentric vs topocentric (airless apparent, ANG_FORMAT=DEG), sites at 0 m:
+        // 2020-10-12 00:00 UT, Greenwich (51.48N, 0E):  dRA +0.57927, dDec -0.80086
+        assertParallaxShift(moon, utc(2020, 9, 12), LatLong(51.48f, 0.0f), 0.57927f, -0.80086f)
+        // 2020-10-12 00:00 UT, Sydney (33.87S, 151.21E): dRA -0.50493, dDec +0.73933
+        assertParallaxShift(
+            moon, utc(2020, 9, 12), LatLong(-33.87f, 151.21f), -0.50493f, 0.73933f
+        )
+        // 2009-02-11 00:00 UT, Quito (0.2S, 78.5W): dRA +0.97883, dDec -0.01000
+        assertParallaxShift(moon, utc(2009, 1, 11), LatLong(-0.2f, -78.5f), 0.97883f, -0.01000f)
+    }
+
+    private fun assertParallaxShift(
+        moon: Moon, time: Date, location: LatLong, expectedRaShiftDeg: Float,
+        expectedDecShiftDeg: Float
+    ) {
+        val geo = moon.getRaDec(time)
+        val topo = moon.getTopocentricRaDec(time, location)
+        assertThat(topo.ra - geo.ra).isWithin(PARALLAX_TOL).of(expectedRaShiftDeg)
+        assertThat(topo.dec - geo.dec).isWithin(PARALLAX_TOL).of(expectedDecShiftDeg)
+    }
+
+    @Test
+    fun testTopocentricPositionNeverExceedsTheMaximumLunarParallax() {
+        val moon = Moon()
+        for (day in listOf(1, 8, 15, 22)) {
+            val time = utc(2020, 9, day)
+            val geo = moon.getRaDec(time)
+            var lat = -80
+            while (lat <= 80) {
+                var lon = -180
+                while (lon <= 180) {
+                    val topo = moon.getTopocentricRaDec(time, LatLong(lat.toFloat(), lon.toFloat()))
+                    assertThat(angularSeparation(geo, topo)).isLessThan(MAX_LUNAR_PARALLAX)
+                    lon += 60
+                }
+                lat += 40
+            }
+        }
+    }
+
+    private fun angularSeparation(a: RaDec, b: RaDec): Float {
+        val pointA = getGeocentricCoords(a)
+        val pointB = getGeocentricCoords(b)
+        return MathUtils.acos(pointA.cosineSimilarity(pointB)) * RADIANS_TO_DEGREES
+    }
+
+    @Test
+    fun testTrueAngularRadius() {
+        // Mean apparent angular diameter of the Moon as seen from Earth is about 0.518 degrees,
+        // i.e. an angular radius of about 0.259 degrees - close to the Sun's, which is why total
+        // solar eclipses happen at all. This is a small fraction of the fixed,
+        // exaggerated-for-visibility 0.02 radians (about 1.15 degrees) getPlanetaryImageSize()
+        // returns.
+        val moon = Moon()
+        val angularRadiusDeg = moon.getTrueAngularRadius(utc(2020, 9, 12)) * RADIANS_TO_DEGREES
+        assertThat(angularRadiusDeg).isWithin(0.05f).of(0.259f)
     }
 }

--- a/stardroid-v1/app/src/test/java/com/google/android/stardroid/space/SolarSystemObjectTest.kt
+++ b/stardroid-v1/app/src/test/java/com/google/android/stardroid/space/SolarSystemObjectTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Penterakt LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.google.android.stardroid.space
+
+import com.google.android.stardroid.math.RADIANS_TO_DEGREES
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.*
+
+// True angular radii are only good to a percent or so: distances vary through the year/orbit
+// (e.g. Earth's own orbital eccentricity), and this checks against the well known mean values.
+private const val ANGULAR_RADIUS_TOL_DEG = 0.05f
+
+class SolarSystemObjectTest {
+    @Test
+    fun testSunTrueAngularRadius() {
+        // Mean apparent angular diameter of the Sun as seen from Earth is about 0.533 degrees,
+        // i.e. an angular radius of about 0.267 degrees - a small fraction of the fixed,
+        // exaggerated-for-visibility 0.02 radians (about 1.15 degrees) getPlanetaryImageSize()
+        // returns.
+        val sun = Sun()
+        val angularRadiusDeg = sun.getTrueAngularRadius(Date()) * RADIANS_TO_DEGREES
+        assertThat(angularRadiusDeg).isWithin(ANGULAR_RADIUS_TOL_DEG).of(0.267f)
+    }
+
+    @Test
+    fun testJupiterTrueAngularRadiusIsFarSmallerThanTheFixedImageSize() {
+        val jupiter = SunOrbitingObject(com.google.android.stardroid.ephemeris.SolarSystemBody.Jupiter)
+        val angularRadiusDeg = jupiter.getTrueAngularRadius(Date()) * RADIANS_TO_DEGREES
+        val fixedSizeDeg = jupiter.getPlanetaryImageSize() * RADIANS_TO_DEGREES
+        // Jupiter's true angular radius is at most ~0.012 degrees (opposition); its fixed,
+        // exaggerated-for-visibility image size is ~1.43 degrees - roughly two orders of
+        // magnitude larger.
+        assertThat(angularRadiusDeg).isLessThan(0.02f)
+        assertThat(angularRadiusDeg).isLessThan(fixedSizeDeg)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes the Moon's position calculation, which used only geocentric coordinates and ignored the observer's location on Earth (diurnal parallax), causing errors of up to ~1 degree (two lunar diameters). Adds `Universe`/`Moon.getTopocentricRaDec` and switches the renderer to use it.
- Adds a "Show true-to-life sizes" setting (Settings > Appearance) that renders the Sun, Moon, and planets at their real computed angular size instead of the fixed, exaggerated-for-visibility constants, so eclipses render to scale. Off by default.
- Size is recomputed every frame, decoupled from the per-body position-update throttle, so toggling the setting takes effect immediately and the Moon's true size tracks its continuously changing distance (perigee/apogee) rather than the old behavior of position/size only updating on the throttled interval (up to an hour for planets).
- Removes the dead `show_planetary_images` preference and its point-primitive fallback rendering path — it had no settings UI ever wired to it, so all bodies always rendered as images in practice anyway.

## Test plan
- [x] `./gradlew :app:testGmsDebugUnitTest` passes, including new/extended tests:
  - `MoonTest`: topocentric parallax differentials pinned against JPL Horizons (Greenwich/Sydney/Quito), max-parallax bound check, true angular radius (~0.259°)
  - `SolarSystemObjectTest`: Sun true angular radius (~0.267°), Jupiter true size far smaller than its fixed image size
- [x] Manually verified on a physical device: toggled the new setting and confirmed it takes effect on the next frame (not after a time tick), and confirmed the Moon/Sun render at accurate relative sizes around the 2026-08-12 eclipse date

🤖 Generated with [Claude Code](https://claude.com/claude-code)