### PR TITLE
Improve Sun and Moon accuracy for correct eclipse timing

### DIFF
--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/math/TimeUtils.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/math/TimeUtils.kt
@@ -65,6 +65,27 @@ fun julianDay(date: Date): Double {
 }
 
 /**
+ * Delta-T (TT - UT) in seconds: the gap between the device's UT clock and the uniform Terrestrial
+ * Time in which the ephemeris series are expressed. Uses the Espenak-Meeus polynomial for
+ * 2005-2050 (about 69 s in the app's era). It is only ~1 minute of clock time, but at the Moon's
+ * ~0.5'/minute motion it is visible in eclipse timing.
+ */
+fun deltaTSeconds(date: Date): Double {
+    val year = 2000.0 + (julianDay(date) - 2451545.0) / 365.25
+    val u = year - 2000.0
+    return 62.92 + 0.32217 * u + 0.005589 * u * u
+}
+
+/**
+ * Julian centuries of Terrestrial Time (TT) from J2000.0 - the time argument the Meeus/ELP series
+ * for the Sun and Moon expect. See [deltaTSeconds].
+ */
+fun julianCenturiesTerrestrial(date: Date): Double {
+    val jdTt = julianDay(date) + deltaTSeconds(date) / 86400.0
+    return (jdTt - 2451545.0) / 36525.0
+}
+
+/**
  * Converts the given Julian Day to Gregorian Date (in UT time zone).
  * Based on the formula given in the Explanatory Supplement to the
  * Astronomical Almanac, pg 604.

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Moon.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Moon.kt
@@ -33,81 +33,147 @@ class Moon : EarthOrbitingObject(SolarSystemBody.Moon) {
      * Right ascension and declination of the moon as seen by an observer at [location],
      * correcting the geocentric position for diurnal parallax (up to ~1 degree - two lunar
      * diameters - depending on where on Earth the observer stands and how close the Moon is).
-     * Same Astronomical Almanac (2008, p. D22) page as [getRaDec]; the horizontal-parallax
-     * series (`pi`) puts the Moon at `1 / sin(pi)` Earth radii, and the observer sits one
-     * Earth radius out at `(cos(lat) cos(lst), cos(lat) sin(lst), sin(lat))` in the same
-     * equatorial frame, with local sidereal time from [meanSiderealTime].
+     *
+     * The geocentric position and Earth-Moon distance both come from [geocentricEclipticPosition]
+     * (Meeus, *Astronomical Algorithms*, 2nd ed., ch. 47); the observer sits one Earth radius out
+     * at `(cos(lat) cos(lst), cos(lat) sin(lst), sin(lat))` in the same equatorial frame, with
+     * local sidereal time from [meanSiderealTime].
      */
     fun getTopocentricRaDec(date: Date, location: LatLong): RaDec {
-        val (l, m, n) = geocentricDirectionCosines(date)
-        val t = ((julianDay(date) - 2451545.0f) / 36525.0f).toFloat()
-        val distanceEarthRadii = 1.0f / sin(lunarHorizontalParallax(t) * DEGREES_TO_RADIANS)
+        val position = geocentricEclipticPosition(date)
+        val geocentric = eclipticToEquatorialCosines(position)
+        val distanceEarthRadii = (position.distanceKm / EARTH_EQUATORIAL_RADIUS_KM).toFloat()
         val lstRad = meanSiderealTime(date, location.longitude) * DEGREES_TO_RADIANS
         val latRad = location.latitude * DEGREES_TO_RADIANS
         val observerFromGeocenter = Vector3(
             cos(latRad) * cos(lstRad), cos(latRad) * sin(lstRad), sin(latRad)
         )
-        val topocentric = Vector3(l, m, n) * distanceEarthRadii - observerFromGeocenter
+        val topocentric = geocentric * distanceEarthRadii - observerFromGeocenter
         return RaDec.fromGeocentricCoords(topocentric)
     }
 
     /**
-     * Calculate the geocentric right ascension and declination of the moon using
-     * an approximation as described on page D22 of the 2008 Astronomical Almanac
-     * All of the variables in this method use the same names as those described
-     * in the text: lambda = Ecliptic longitude (degrees) beta = Ecliptic latitude
-     * (degrees) pi = horizontal parallax (degrees) r = distance (Earth radii)
-     *
-     * NOTE: The text does not give a specific time period where the approximation
-     * is valid, but it should be valid through at least 2009.
-     *
-     * Returns the equatorial direction cosines (l, m, n) as a [Vector3].
+     * The geocentric equatorial direction cosines (l, m, n) as a [Vector3], derived from the
+     * apparent ecliptic longitude/latitude of [geocentricEclipticPosition].
      */
-    private fun geocentricDirectionCosines(date: Date): Vector3 {
-        // First, calculate the number of Julian centuries from J2000.0.
-        val t = ((julianDay(date) - 2451545.0f) / 36525.0f).toFloat()
-        // Second, calculate the approximate geocentric orbital elements.
-        val lambda = (218.32f + 481267.881f * t + (6.29f
-                * sin((135.0f + 477198.87f * t) * DEGREES_TO_RADIANS)) - 1.27f
-                * sin((259.3f - 413335.36f * t) * DEGREES_TO_RADIANS)) + (0.66f
-                * sin((235.7f + 890534.22f * t) * DEGREES_TO_RADIANS)) + (0.21f
-                * sin((269.9f + 954397.74f * t) * DEGREES_TO_RADIANS)) - (0.19f
-                * sin((357.5f + 35999.05f * t) * DEGREES_TO_RADIANS)) - (0.11f
-                * sin((186.5f + 966404.03f * t) * DEGREES_TO_RADIANS))
-        val beta = (5.13f * sin((93.3f + 483202.02f * t) * DEGREES_TO_RADIANS) + 0.28f
-                * sin((228.2f + 960400.89f * t) * DEGREES_TO_RADIANS)) - (0.28f
-                * sin((318.3f + 6003.15f * t) * DEGREES_TO_RADIANS)) - (0.17f
-                * sin((217.6f - 407332.21f * t) * DEGREES_TO_RADIANS))
+    private fun geocentricDirectionCosines(date: Date): Vector3 =
+        eclipticToEquatorialCosines(geocentricEclipticPosition(date))
 
-        // Third, convert to equatorial direction cosines.
-        val l = (cos(beta * DEGREES_TO_RADIANS)
-                * cos(lambda * DEGREES_TO_RADIANS))
-        val m = (0.9175f * cos(beta * DEGREES_TO_RADIANS)
-                * sin(lambda * DEGREES_TO_RADIANS)) - 0.3978f * sin(beta * DEGREES_TO_RADIANS)
-        val n = (0.3978f * cos(beta * DEGREES_TO_RADIANS)
-                * sin(lambda * DEGREES_TO_RADIANS)) + 0.9175f * sin(beta * DEGREES_TO_RADIANS)
-        return Vector3(l, m, n)
-    }
+    /**
+     * Geocentric apparent ecliptic longitude, latitude and Earth-Moon distance of the Moon,
+     * computed from the ELP-2000/82 truncated series published in Meeus,
+     * *Astronomical Algorithms* (2nd ed., 1998), ch. 47. Retaining the full 60-term longitude,
+     * 60-term latitude and 60-term distance tables gives roughly 10" accuracy in longitude and
+     * 4" in latitude - about two orders of magnitude better than the previous six-term Almanac
+     * approximation, which is what eclipse timing (extremely sensitive to lunar position) needs.
+     *
+     * The time argument is Terrestrial Time (see [julianCenturiesTerrestrial]); longitude carries
+     * the leading nutation term so it is the *apparent* longitude of date.
+     */
+    private fun geocentricEclipticPosition(date: Date): EclipticPosition {
+        val t = julianCenturiesTerrestrial(date)
+        val t2 = t * t
+        val t3 = t2 * t
+        val t4 = t3 * t
 
-    /** Lunar equatorial horizontal parallax in degrees, from the same Almanac page. */
-    private fun lunarHorizontalParallax(t: Float): Float {
-        return 0.9508f + 0.0518f * cos((135.0f + 477198.87f * t) * DEGREES_TO_RADIANS) +
-                0.0095f * cos((259.3f - 413335.36f * t) * DEGREES_TO_RADIANS) +
-                0.0078f * cos((235.7f + 890534.22f * t) * DEGREES_TO_RADIANS) +
-                0.0028f * cos((269.9f + 954397.74f * t) * DEGREES_TO_RADIANS)
+        // Fundamental arguments in degrees (Meeus 47.1-47.5).
+        val lp = 218.3164477 + 481267.88123421 * t - 0.0015786 * t2 + t3 / 538841.0 -
+                t4 / 65194000.0
+        val d = 297.8501921 + 445267.1114034 * t - 0.0018819 * t2 + t3 / 545868.0 -
+                t4 / 113065000.0
+        val m = 357.5291092 + 35999.0502909 * t - 0.0001536 * t2 + t3 / 24490000.0
+        val mp = 134.9633964 + 477198.8675055 * t + 0.0087414 * t2 + t3 / 69699.0 -
+                t4 / 14712000.0
+        val f = 93.2720950 + 483202.0175233 * t - 0.0036539 * t2 - t3 / 3526000.0 +
+                t4 / 863310000.0
+        val a1 = 119.75 + 131.849 * t
+        val a2 = 53.09 + 479264.290 * t
+        val a3 = 313.45 + 481266.484 * t
+        // Eccentricity correction for terms involving the Sun's anomaly M (Meeus 47.6).
+        val e = 1.0 - 0.002516 * t - 0.0000074 * t2
+
+        var sumL = 0.0 // 1e-6 degrees
+        var sumR = 0.0 // 1e-3 km
+        for (row in TABLE_47A) {
+            val arg = row[0] * d + row[1] * m + row[2] * mp + row[3] * f
+            val eFactor = when (Math.abs(row[1])) {
+                1 -> e
+                2 -> e * e
+                else -> 1.0
+            }
+            sumL += row[4] * eFactor * Math.sin(Math.toRadians(arg))
+            sumR += row[5] * eFactor * Math.cos(Math.toRadians(arg))
+        }
+        var sumB = 0.0 // 1e-6 degrees
+        for (row in TABLE_47B) {
+            val arg = row[0] * d + row[1] * m + row[2] * mp + row[3] * f
+            val eFactor = when (Math.abs(row[1])) {
+                1 -> e
+                2 -> e * e
+                else -> 1.0
+            }
+            sumB += row[4] * eFactor * Math.sin(Math.toRadians(arg))
+        }
+
+        // Additive terms from Venus, Jupiter and the flattening of the Earth (Meeus, p. 342).
+        sumL += 3958.0 * Math.sin(Math.toRadians(a1)) +
+                1962.0 * Math.sin(Math.toRadians(lp - f)) +
+                318.0 * Math.sin(Math.toRadians(a2))
+        sumB += -2235.0 * Math.sin(Math.toRadians(lp)) +
+                382.0 * Math.sin(Math.toRadians(a3)) +
+                175.0 * Math.sin(Math.toRadians(a1 - f)) +
+                175.0 * Math.sin(Math.toRadians(a1 + f)) +
+                127.0 * Math.sin(Math.toRadians(lp - mp)) -
+                115.0 * Math.sin(Math.toRadians(lp + mp))
+
+        var lambda = lp + sumL / 1_000_000.0 // mean longitude of date, degrees
+        val beta = sumB / 1_000_000.0        // ecliptic latitude, degrees
+        val distanceKm = 385000.56 + sumR / 1000.0
+
+        // Leading nutation terms (Meeus ch. 22) to turn mean longitude into apparent longitude
+        // and to build the true obliquity used for the equatorial rotation.
+        val omega = 125.04452 - 1934.136261 * t
+        val lSun = 280.4665 + 36000.7698 * t
+        val lMoon = 218.3165 + 481267.8813 * t
+        val dPsiArcsec = -17.20 * Math.sin(Math.toRadians(omega)) -
+                1.32 * Math.sin(Math.toRadians(2 * lSun)) -
+                0.23 * Math.sin(Math.toRadians(2 * lMoon)) +
+                0.21 * Math.sin(Math.toRadians(2 * omega))
+        val dEpsilonArcsec = 9.20 * Math.cos(Math.toRadians(omega)) +
+                0.57 * Math.cos(Math.toRadians(2 * lSun)) +
+                0.10 * Math.cos(Math.toRadians(2 * lMoon)) -
+                0.09 * Math.cos(Math.toRadians(2 * omega))
+        lambda += dPsiArcsec / 3600.0
+        val epsilon0 = 23.4392911 - 0.0130042 * t - 1.64e-7 * t2 + 5.04e-7 * t3
+        val obliquityRad = Math.toRadians(epsilon0 + dEpsilonArcsec / 3600.0)
+
+        return EclipticPosition(lambda, beta, distanceKm, obliquityRad)
     }
 
     /**
-     * The Moon's true angular radius, in radians. The Moon doesn't orbit the Sun, so it can't
-     * use [SolarSystemObject.getTrueAngularRadius]'s heliocentric distance calculation; instead,
-     * reuse the horizontal-parallax series already computed for [getTopocentricRaDec], since
-     * `1 / sin(parallax)` is the Earth-Moon distance in Earth radii.
+     * Rotates the apparent ecliptic coordinates in [position] into equatorial direction cosines
+     * (Meeus 13.3-13.4), returned as a unit [Vector3] in the same frame the rest of the app uses.
+     */
+    private fun eclipticToEquatorialCosines(position: EclipticPosition): Vector3 {
+        val lambdaRad = Math.toRadians(position.lambda)
+        val betaRad = Math.toRadians(position.beta)
+        val cosEps = Math.cos(position.obliquityRad)
+        val sinEps = Math.sin(position.obliquityRad)
+        val cosBeta = Math.cos(betaRad)
+        val l = cosBeta * Math.cos(lambdaRad)
+        val m = cosEps * cosBeta * Math.sin(lambdaRad) - sinEps * Math.sin(betaRad)
+        val n = sinEps * cosBeta * Math.sin(lambdaRad) + cosEps * Math.sin(betaRad)
+        return Vector3(l.toFloat(), m.toFloat(), n.toFloat())
+    }
+
+    /**
+     * The Moon's true angular radius, in radians, from the Earth-Moon distance of
+     * [geocentricEclipticPosition].
      */
     override fun getTrueAngularRadius(time: Date): Float {
-        val t = ((julianDay(time) - 2451545.0f) / 36525.0f).toFloat()
-        val distanceEarthRadii = 1.0f / sin(lunarHorizontalParallax(t) * DEGREES_TO_RADIANS)
-        val distanceKm = distanceEarthRadii * SolarSystemBody.Earth.meanRadiusKm
-        return asin((SolarSystemBody.Moon.meanRadiusKm / distanceKm).coerceIn(-1f, 1f))
+        val distanceKm = geocentricEclipticPosition(time).distanceKm
+        val ratio = (SolarSystemBody.Moon.meanRadiusKm / distanceKm).toFloat().coerceIn(-1f, 1f)
+        return asin(ratio)
     }
 
     /** Returns the resource id for the planet's image.  */
@@ -155,4 +221,151 @@ class Moon : EarthOrbitingObject(SolarSystemBody.Moon) {
     // Moon. We shouldn't call this method for those bodies, but we want to do
     // something sane if we do.
     override fun getMagnitude(time: Date) = -10.0f
+
+    /** Apparent ecliptic longitude/latitude (degrees), Earth-Moon distance (km), obliquity (rad). */
+    private data class EclipticPosition(
+        val lambda: Double,
+        val beta: Double,
+        val distanceKm: Double,
+        val obliquityRad: Double
+    )
+
+    private companion object {
+        /** Mean equatorial radius of the Earth in km, matching the horizontal-parallax convention. */
+        const val EARTH_EQUATORIAL_RADIUS_KM = 6378.14
+
+        /**
+         * Meeus table 47.A: multiples of (D, M, M', F), then the longitude coefficient
+         * (1e-6 degrees) and the distance coefficient (1e-3 km).
+         */
+        val TABLE_47A = arrayOf(
+            intArrayOf(0, 0, 1, 0, 6288774, -20905355),
+            intArrayOf(2, 0, -1, 0, 1274027, -3699111),
+            intArrayOf(2, 0, 0, 0, 658314, -2955968),
+            intArrayOf(0, 0, 2, 0, 213618, -569925),
+            intArrayOf(0, 1, 0, 0, -185116, 48888),
+            intArrayOf(0, 0, 0, 2, -114332, -3149),
+            intArrayOf(2, 0, -2, 0, 58793, 246158),
+            intArrayOf(2, -1, -1, 0, 57066, -152138),
+            intArrayOf(2, 0, 1, 0, 53322, -170733),
+            intArrayOf(2, -1, 0, 0, 45758, -204586),
+            intArrayOf(0, 1, -1, 0, -40923, -129620),
+            intArrayOf(1, 0, 0, 0, -34720, 108743),
+            intArrayOf(0, 1, 1, 0, -30383, 104755),
+            intArrayOf(2, 0, 0, -2, 15327, 10321),
+            intArrayOf(0, 0, 1, 2, -12528, 0),
+            intArrayOf(0, 0, 1, -2, 10980, 79661),
+            intArrayOf(4, 0, -1, 0, 10675, -34782),
+            intArrayOf(0, 0, 3, 0, 10034, -23210),
+            intArrayOf(4, 0, -2, 0, 8548, -21636),
+            intArrayOf(2, 1, -1, 0, -7888, 24208),
+            intArrayOf(2, 1, 0, 0, -6766, 30824),
+            intArrayOf(1, 0, -1, 0, -5163, -8379),
+            intArrayOf(1, 1, 0, 0, 4987, -16675),
+            intArrayOf(2, -1, 1, 0, 4036, -12831),
+            intArrayOf(2, 0, 2, 0, 3994, -10445),
+            intArrayOf(4, 0, 0, 0, 3861, -11650),
+            intArrayOf(2, 0, -3, 0, 3665, 14403),
+            intArrayOf(0, 1, -2, 0, -2689, -7003),
+            intArrayOf(2, 0, -1, 2, -2602, 0),
+            intArrayOf(2, -1, -2, 0, 2390, 10056),
+            intArrayOf(1, 0, 1, 0, -2348, 6322),
+            intArrayOf(2, -2, 0, 0, 2236, -9884),
+            intArrayOf(0, 1, 2, 0, -2120, 5751),
+            intArrayOf(0, 2, 0, 0, -2069, 0),
+            intArrayOf(2, -2, -1, 0, 2048, -4950),
+            intArrayOf(2, 0, 1, -2, -1773, 4130),
+            intArrayOf(2, 0, 0, 2, -1595, 0),
+            intArrayOf(4, -1, -1, 0, 1215, -3958),
+            intArrayOf(0, 0, 2, 2, -1110, 0),
+            intArrayOf(3, 0, -1, 0, -892, 3258),
+            intArrayOf(2, 1, 1, 0, -810, 2616),
+            intArrayOf(4, -1, -2, 0, 759, -1897),
+            intArrayOf(0, 2, -1, 0, -713, -2117),
+            intArrayOf(2, 2, -1, 0, -700, 2354),
+            intArrayOf(2, 1, -2, 0, 691, 0),
+            intArrayOf(2, -1, 0, -2, 596, 0),
+            intArrayOf(4, 0, 1, 0, 549, -1423),
+            intArrayOf(0, 0, 4, 0, 537, -1117),
+            intArrayOf(4, -1, 0, 0, 520, -1571),
+            intArrayOf(1, 0, -2, 0, -487, -1739),
+            intArrayOf(2, 1, 0, -2, -399, 0),
+            intArrayOf(0, 0, 2, -2, -381, -4421),
+            intArrayOf(1, 1, 1, 0, 351, 0),
+            intArrayOf(3, 0, -2, 0, -340, 0),
+            intArrayOf(4, 0, -3, 0, 330, 0),
+            intArrayOf(2, -1, 2, 0, 327, 0),
+            intArrayOf(0, 2, 1, 0, -323, 1165),
+            intArrayOf(1, 1, -1, 0, 299, 0),
+            intArrayOf(2, 0, 3, 0, 294, 0),
+            intArrayOf(2, 0, -1, -2, 0, 8752)
+        )
+
+        /**
+         * Meeus table 47.B: multiples of (D, M, M', F), then the latitude coefficient
+         * (1e-6 degrees).
+         */
+        val TABLE_47B = arrayOf(
+            intArrayOf(0, 0, 0, 1, 5128122),
+            intArrayOf(0, 0, 1, 1, 280602),
+            intArrayOf(0, 0, 1, -1, 277693),
+            intArrayOf(2, 0, 0, -1, 173237),
+            intArrayOf(2, 0, -1, 1, 55413),
+            intArrayOf(2, 0, -1, -1, 46271),
+            intArrayOf(2, 0, 0, 1, 32573),
+            intArrayOf(0, 0, 2, 1, 17198),
+            intArrayOf(2, 0, 1, -1, 9266),
+            intArrayOf(0, 0, 2, -1, 8822),
+            intArrayOf(2, -1, 0, -1, 8216),
+            intArrayOf(2, 0, -2, -1, 4324),
+            intArrayOf(2, 0, 1, 1, 4200),
+            intArrayOf(2, 1, 0, -1, -3359),
+            intArrayOf(2, -1, -1, 1, 2463),
+            intArrayOf(2, -1, 0, 1, 2211),
+            intArrayOf(2, -1, -1, -1, 2065),
+            intArrayOf(0, 1, -1, -1, -1870),
+            intArrayOf(4, 0, -1, -1, 1828),
+            intArrayOf(0, 1, 0, 1, -1794),
+            intArrayOf(0, 0, 0, 3, -1749),
+            intArrayOf(0, 1, -1, 1, -1565),
+            intArrayOf(1, 0, 0, 1, -1491),
+            intArrayOf(0, 1, 1, 1, -1475),
+            intArrayOf(0, 1, 1, -1, -1410),
+            intArrayOf(0, 1, 0, -1, -1344),
+            intArrayOf(1, 0, 0, -1, -1335),
+            intArrayOf(0, 0, 3, 1, 1107),
+            intArrayOf(4, 0, 0, -1, 1021),
+            intArrayOf(4, 0, -1, 1, 833),
+            intArrayOf(0, 0, 1, -3, 777),
+            intArrayOf(4, 0, -2, 1, 671),
+            intArrayOf(2, 0, 0, -3, 607),
+            intArrayOf(2, 0, 2, -1, 596),
+            intArrayOf(2, -1, 1, -1, 491),
+            intArrayOf(2, 0, -2, 1, -451),
+            intArrayOf(0, 0, 3, -1, 439),
+            intArrayOf(2, 0, 2, 1, 422),
+            intArrayOf(2, 0, -3, -1, 421),
+            intArrayOf(2, 1, -1, 1, -366),
+            intArrayOf(2, 1, 0, 1, -351),
+            intArrayOf(4, 0, 0, 1, 331),
+            intArrayOf(2, -1, 1, 1, 315),
+            intArrayOf(2, -2, 0, -1, 302),
+            intArrayOf(0, 0, 1, 3, -283),
+            intArrayOf(2, 1, 1, -1, -229),
+            intArrayOf(1, 1, 0, -1, 223),
+            intArrayOf(1, 1, 0, 1, 223),
+            intArrayOf(0, 1, -2, -1, -220),
+            intArrayOf(2, 1, -1, -1, -220),
+            intArrayOf(1, 0, 1, 1, -185),
+            intArrayOf(2, -1, -2, -1, 181),
+            intArrayOf(0, 1, 2, 1, -177),
+            intArrayOf(4, 0, -2, -1, 176),
+            intArrayOf(4, -1, -1, -1, 166),
+            intArrayOf(1, 0, 1, -1, -164),
+            intArrayOf(4, 0, 1, -1, 132),
+            intArrayOf(1, 0, -1, -1, -119),
+            intArrayOf(4, -1, 0, -1, 115),
+            intArrayOf(2, -2, 0, 1, 107)
+        )
+    }
 }

--- a/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Sun.kt
+++ b/stardroid-v1/app/src/main/java/com/google/android/stardroid/space/Sun.kt
@@ -10,9 +10,11 @@
 package com.google.android.stardroid.space
 
 import com.google.android.stardroid.ephemeris.SolarSystemBody
+import com.google.android.stardroid.math.RaDec
 import com.google.android.stardroid.math.Vector3
 import com.google.android.stardroid.math.MathUtils
 import com.google.android.stardroid.math.heliocentricCoordinatesFromOrbitalElements
+import com.google.android.stardroid.math.julianCenturiesTerrestrial
 import java.util.*
 
 // Kilometers per astronomical unit.
@@ -25,6 +27,35 @@ private const val KM_PER_AU = 149597870.7f
  */
 class Sun : SunOrbitingObject(SolarSystemBody.Sun) {
     override val bodySize = -0.83f
+
+    /**
+     * Geocentric apparent right ascension and declination of the Sun, from Meeus,
+     * *Astronomical Algorithms* (2nd ed., ch. 25, "lower accuracy" method), which is good to about
+     * 0.01 degrees. This replaces the inherited [SunOrbitingObject.getRaDec], whose position from
+     * the Earth's truncated Keplerian elements is ~0.4 degrees off - enough to throw solar-eclipse
+     * timing (which depends on the Sun-Moon separation) out by half an hour. The result carries
+     * nutation and aberration, so it is the apparent equatorial position of date.
+     */
+    override fun getRaDec(date: Date): RaDec {
+        val t = julianCenturiesTerrestrial(date)
+        // Geometric mean longitude and mean anomaly (degrees).
+        val l0 = 280.46646 + 36000.76983 * t + 0.0003032 * t * t
+        val m = Math.toRadians(357.52911 + 35999.05029 * t - 0.0001537 * t * t)
+        // Equation of the centre.
+        val c = (1.914602 - 0.004817 * t - 0.000014 * t * t) * Math.sin(m) +
+                (0.019993 - 0.000101 * t) * Math.sin(2 * m) +
+                0.000289 * Math.sin(3 * m)
+        val trueLong = l0 + c
+        // Apparent longitude: correct for nutation and aberration.
+        val omega = Math.toRadians(125.04 - 1934.136 * t)
+        val lambda = Math.toRadians(trueLong - 0.00569 - 0.00478 * Math.sin(omega))
+        val epsilon = Math.toRadians(23.439291 - 0.0130042 * t + 0.00256 * Math.cos(omega))
+        val ra = Math.toDegrees(
+            Math.atan2(Math.cos(epsilon) * Math.sin(lambda), Math.cos(lambda))
+        )
+        val dec = Math.toDegrees(Math.asin(Math.sin(epsilon) * Math.sin(lambda)))
+        return RaDec(((ra + 360.0) % 360.0).toFloat(), dec.toFloat())
+    }
 
     override fun getMyHeliocentricCoordinates(date: Date) =
         Vector3(0.0f, 0.0f, 0.0f)

--- a/stardroid-v1/app/src/test/java/com/google/android/stardroid/space/SolarEclipseTimingTest.kt
+++ b/stardroid-v1/app/src/test/java/com/google/android/stardroid/space/SolarEclipseTimingTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Penterakt LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.google.android.stardroid.space
+
+import com.google.android.stardroid.math.LatLong
+import com.google.android.stardroid.math.MathUtils
+import com.google.android.stardroid.math.RADIANS_TO_DEGREES
+import com.google.android.stardroid.math.RaDec
+import com.google.android.stardroid.math.getGeocentricCoords
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.*
+
+/**
+ * Guards the end-to-end timing of a solar eclipse - the combined accuracy of the Sun's apparent
+ * position ([Sun.getRaDec]) and the Moon's topocentric position ([Moon.getTopocentricRaDec]).
+ *
+ * Maximum eclipse is when the topocentric Sun-Moon separation is least, and its timing is very
+ * sensitive to position errors: at the ~0.5 degrees/hour rate the Moon closes on the Sun, every
+ * 0.1 degrees of error in either body moves the moment by ~13 minutes. Earlier, low-precision Sun
+ * and Moon models put this eclipse's maximum ~30 minutes early; the Meeus/ELP series bring it back
+ * in line with published local circumstances.
+ */
+class SolarEclipseTimingTest {
+    private fun separationDegrees(a: RaDec, b: RaDec): Double {
+        val cosSimilarity =
+            getGeocentricCoords(a).cosineSimilarity(getGeocentricCoords(b)).coerceIn(-1f, 1f)
+        return (MathUtils.acos(cosSimilarity) * RADIANS_TO_DEGREES).toDouble()
+    }
+
+    @Test
+    fun maximumOfAug2026PartialEclipseMatchesPublishedLocalCircumstances() {
+        val sun = Sun()
+        val moon = Moon()
+        // Grassington, North Yorkshire, at sea level.
+        val grassington = LatLong(54.070f, -1.990f)
+
+        var minSeparation = Double.MAX_VALUE
+        var maximumEclipseSecondsUt = -1
+        // Scan 17:00-20:00 UT on 2026-08-12 at one-second resolution.
+        val start = GregorianCalendar(TimeZone.getTimeZone("GMT"))
+        start.set(2026, GregorianCalendar.AUGUST, 12, 17, 0, 0)
+        for (second in 0..(3 * 3600)) {
+            val time = Date(start.time.time + second * 1000L)
+            val separation =
+                separationDegrees(sun.getRaDec(time), moon.getTopocentricRaDec(time, grassington))
+            if (separation < minSeparation) {
+                minSeparation = separation
+                maximumEclipseSecondsUt = second
+            }
+        }
+
+        // Published local maximum for Grassington is 18:07 UT (19:07 BST); allow a few minutes for
+        // our ~arcminute Sun/Moon models, sea-level assumption and neglected refraction.
+        val expectedSecondsUt = 67 * 60 // 18:07 UT relative to the 17:00 UT scan start.
+        assertThat(maximumEclipseSecondsUt.toDouble()).isWithin(3.0 * 60).of(expectedSecondsUt.toDouble())
+        // It is a deep partial from here, not a central eclipse: the disks never fully coincide.
+        assertThat(minSeparation).isGreaterThan(0.02)
+        assertThat(minSeparation).isLessThan(0.10)
+    }
+}

--- a/stardroid-v1/app/src/test/java/com/google/android/stardroid/space/UniverseSmokeTest.kt
+++ b/stardroid-v1/app/src/test/java/com/google/android/stardroid/space/UniverseSmokeTest.kt
@@ -299,7 +299,7 @@ class UniverseSmokeTest {
         testCal[2010, GregorianCalendar.DECEMBER, 25, 12, 0] = 0
         assertThat(
             universe.solarSystemObjectFor(SolarSystemBody.Moon).calculatePercentIlluminated(testCal.time)
-        ).isWithin(REG_TOL).of(21.741992950439453f)
+        ).isWithin(REG_TOL).of(21.813465118408203f)
         assertThat(
             universe.solarSystemObjectFor(SolarSystemBody.Mercury).calculatePercentIlluminated(testCal.time)
         ).isWithin(REG_TOL).of(12.131664276123047f)
@@ -313,7 +313,7 @@ class UniverseSmokeTest {
         // Don't trust these numbers
         assertThat(
             universe.solarSystemObjectFor(SolarSystemBody.Moon).calculatePhaseAngle(testCal.time)
-        ).isWithin(REG_TOL).of(124.41341400146484f)
+        ).isWithin(REG_TOL).of(124.31419372558594f)
         assertThat(
             universe.solarSystemObjectFor(SolarSystemBody.Mercury).calculatePhaseAngle(testCal.time)
         ).isWithin(REG_TOL).of(139.23260498046875f)


### PR DESCRIPTION
## Summary

Solar-eclipse maximum is when the topocentric Sun–Moon separation is least, and its timing is acutely sensitive to position error: at the ~0.5°/hr rate the Moon closes on the Sun, **0.1° of error in either body shifts the moment by ~13 minutes**. The 12 Aug 2026 partial eclipse peaked ~30 min early in Sky Map as a result (18:39 vs the real 19:08 BST from Grassington).

Two low-precision models were to blame — and, notably, the **Sun** was the larger culprit:

- **Moon** used the 6-term Astronomical Almanac D22 series (~0.3°). Replaced with the full Meeus ch. 47 (ELP2000-82 truncated): 60-term longitude/distance and 60-term latitude tables, plus leading nutation and true obliquity (~10″ longitude, ~4″ latitude). Distance now comes from the series and feeds both parallax and angular radius.
- **Sun**'s RA/Dec came from Earth's truncated Keplerian elements with no aberration/nutation (~0.37° off). Given its own apparent position from Meeus ch. 25 (~0.01°).

Both series now run on **Terrestrial Time** via a shared `TimeUtils.julianCenturiesTerrestrial` (Espenak–Meeus ΔT), and the computation is **double precision** throughout instead of leaking the Julian Day's precision through a `Float` cast.

## Result

Eclipse maximum from Grassington now computes to **19:06:43 BST**, within a minute of the published 19:08 (residual is approximate coordinates + sea-level/refraction).

## Changes

- `Moon.kt` — Meeus ch. 47 series (replaces D22)
- `Sun.kt` — apparent position from Meeus ch. 25
- `TimeUtils.kt` — shared `julianCenturiesTerrestrial` / `deltaTSeconds`
- `SolarEclipseTimingTest.kt` — new end-to-end guard
- `UniverseSmokeTest.kt` — re-pinned the two Moon values in the explicit "don't trust these numbers" change-detector snapshot (physical-accuracy checks untouched)

## Notes

- The Sun change is global: it nudges the rendered Sun, sky gradient, and sunrise/sunset by up to ~0.4°. Strictly more correct; rise/set tests still pass.
- Full `testGmsDebugUnitTest` suite passes, including the existing JPL-Horizons lunar-parallax differentials (now over more accurate absolute positions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)