### PR TITLE
Add Matariki as a searchable alias for the Pleiades (M45)

### DIFF
--- a/stardroid-v2/.claude/skills/skymap.add-object/SKILL.md
+++ b/stardroid-v2/.claude/skills/skymap.add-object/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skymap.add-object
-description: Add a new deep-sky object or virtual object to Sky Map v2's catalog from a Wikipedia URL or user-supplied data. Handles source-data CSV/JSON files (no protobuf/XML — v2 uses a Room-backed catalog generated from source-data/). Trigger on "add object to v2", "add nebula/galaxy/cluster to v2", "add <object name> to stardroid-v2", etc. ARGUMENTS — "[wikipedia_url_or_object_name]"
+description: Add a new deep-sky object or virtual object to Sky Map v2's catalog from a Wikipedia URL or user-supplied data, or add a new searchable alias/name to an existing object. Handles source-data CSV/JSON files (no protobuf/XML — v2 uses a Room-backed catalog generated from source-data/). Trigger on "add object to v2", "add nebula/galaxy/cluster to v2", "add <object name> to stardroid-v2", "add <name> as an alias for <object>", etc. ARGUMENTS — "[wikipedia_url_or_object_name]"
 ---
 
 # Sky Map v2: Add Catalog Object
@@ -133,6 +133,37 @@ of the positional catalog — only add fields you actually have:
 Add `image_ref` once Step 8 (image) has deployed the asset. `see_also` (array of related object
 ids, reciprocal both ways) is optional — add it if there's an obvious related object (parent
 planet for a moon, sibling galaxies, etc.).
+
+## Adding an Alias to an Existing Object
+
+Sometimes the ask isn't a new object at all — it's an additional searchable name for one that
+already exists (e.g. a culturally significant name, a colloquial nickname). This is much
+lighter than the full flow above: no `dso.csv`/`stars.csv` row, no info card, no `objects.json`
+change, no image.
+
+1. Find the object's existing id — grep `source-data/names/en.csv` or `dso.csv`/`stars.csv` for
+   its current display name.
+2. Add one row to `source-data/names/en.csv` (or `names/universal.csv` if the name is a catalog
+   designation that should match in every locale, e.g. an NGC number): `<object_id>,<Name>,0`.
+   Use `is_primary=0` — you're adding a search alias, not replacing the map label. Group it next
+   to the object's other existing rows for diff-friendliness.
+3. Don't invent translations for other locales — that's a separate task. Per `LocaleSpec`'s
+   fallback chain (exact tag → language → English → universal), an English-only alias is still
+   searchable from any locale that doesn't override that object's names.
+4. Sanity-build and confirm the row landed: `./gradlew :data:generateCatalogDb`, then inspect
+   the generated db (`data/build/generated/assets/generateCatalogDb/skymap.db`) — e.g.
+   `sqlite3 <path> "SELECT * FROM object_name WHERE object_id='<object_id>';"`.
+5. Run `./gradlew :data:test :data:generator:test ktlintCheck` before committing.
+
+Example: adding "Matariki" (the Māori name for the Pleiades, and NZ's official holiday marking
+the Māori new year) as a search alias for `dso/m45`:
+
+```
+dso/m45,Matariki,0
+```
+
+added next to the existing `dso/m45,Pleiades,1` / `dso/m45,Seven Sisters,0` rows in
+`names/en.csv`.
 
 ## Adding a Virtual (Map-less) Object
 

--- a/stardroid-v2/source-data/names/en.csv
+++ b/stardroid-v2/source-data/names/en.csv
@@ -131,6 +131,7 @@ dso/m44,Beehive Cluster,1
 dso/m44,Praesepe,0
 dso/m45,Pleiades,1
 dso/m45,Seven Sisters,0
+dso/m45,Matariki,0
 dso/m51,Whirlpool Galaxy,1
 dso/m57,Ring Nebula,1
 dso/m6,Butterfly Cluster,1


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Description

Matariki is the Māori name for the Pleiades cluster (M45) and the name of Aotearoa New Zealand's official public holiday marking the Māori new year. This adds it as a secondary searchable name for the cluster in stardroid-v2's catalog source data, alongside the existing "Pleiades"/"Seven Sisters" aliases, so it's easy to find by that name (particularly relevant in the NZ region, per the issue).

Also documents this "add an alias to an existing object" workflow in the v2 `skymap.add-object` skill, which previously only covered the full new-object flow.

Fixes #470

## Type of Change

- [x] New feature (Sky Map team only)
- [x] Documentation

## Checklist

- [x] I've read the contributing guidelines
- [x] I've run the unit tests (`./gradlew :data:test :data:generator:test ktlintCheck` from `stardroid-v2/`)
- [ ] I've tested on a device/emulator if applicable (data-only change; verified via `:data:generateCatalogDb` output and querying the generated `skymap.db`)
- [x] If I have multiple commits, I've squashed them into one

## Notes for Reviewers

Implemented in `stardroid-v2` only — v1 is deprecated. No translations added for other locales; per the data layer's locale fallback chain (exact tag → language → English → universal), the English-only alias is still searchable from locales that don't override this object's names.


___

### **PR Type**
Documentation


___

### **Description**
- Document alias addition in `skymap.add-object` skill.

- Detail step-by-step instructions for aliases.

- Include Pleiades Matariki alias example.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SkillDoc["skymap.add-object SKILL.md"] -- "Adds instructions" --> AliasWorkflow["Alias Addition Guide"]
  AliasWorkflow -- "Illustrates with" --> MatarikiExample["Matariki / M45 Example"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Add workflow instructions for existing object aliases</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/.claude/skills/skymap.add-object/SKILL.md

<ul><li>Updated the skill description to include adding searchable aliases to <br>existing objects.<br> <li> Added a new guide section detailing the step-by-step workflow for <br>adding search aliases in <code>names/en.csv</code>.<br> <li> Included an example demonstrating adding "Matariki" as an alias for <br>the Pleiades cluster (<code>dso/m45</code>).</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/975/files#diff-4d5f5d168754b6b6cd9c70ca7f2306da51eb6a7b3aaf33eb9e303dd147a8492b">+32/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

