### PR TITLE
Follow the app's language in catalog text, not just resources

### DIFF
--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/CatalogAccess.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/CatalogAccess.kt
@@ -12,11 +12,11 @@ package com.google.android.stardroid
 import android.app.Application
 import com.google.android.stardroid.astronomy.MeeusEphemeris
 import com.google.android.stardroid.catalog.CatalogRepository
-import com.google.android.stardroid.catalog.LocaleSpec
 import com.google.android.stardroid.data.RoomCatalogRepository
 import com.google.android.stardroid.data.SkyMapDatabaseFactory
 import com.google.android.stardroid.layers.LayerRegistry
 import com.google.android.stardroid.layers.ResourceLayerStrings
+import com.google.android.stardroid.locale.LocaleSource
 import com.google.android.stardroid.location.LocationController
 import com.google.android.stardroid.satellites.satelliteElementsFlow
 import com.google.android.stardroid.satellites.satelliteEntryPoint
@@ -25,7 +25,7 @@ import com.google.android.stardroid.startup.Experiment
 import com.google.android.stardroid.startup.ExperimentConfig
 import com.google.android.stardroid.time.TimeController
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -45,7 +45,7 @@ class CatalogAccess
         private val application: Application,
         private val timeController: TimeController,
         private val locationController: LocationController,
-        private val localeSpec: LocaleSpec,
+        private val localeSource: LocaleSource,
         private val settings: Settings,
         private val experimentConfig: ExperimentConfig,
     ) {
@@ -78,8 +78,13 @@ class CatalogAccess
                     registry
                         ?: LayerRegistry.create(
                             catalog = repository,
-                            locale = flowOf(localeSpec),
-                            strings = flowOf(ResourceLayerStrings(application.resources)),
+                            locale = localeSource.specs,
+                            // A new reader per locale, so the computed layers' own labels
+                            // ("Zenith", the planet names) re-resolve with the scene.
+                            strings =
+                                localeSource.specs.map {
+                                    ResourceLayerStrings(application.resources)
+                                },
                             clock = timeController.times,
                             location = locationController.locations,
                             ephemeris = MeeusEphemeris,

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/di/AppModule.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/di/AppModule.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
 import com.google.android.stardroid.FlavorEdges
 import com.google.android.stardroid.analytics.Analytics
-import com.google.android.stardroid.catalog.LocaleSpec
 import com.google.android.stardroid.data.satellites.HttpUrlConnectionCelesTrakClient
 import com.google.android.stardroid.data.satellites.SatelliteElementsRepository
 import com.google.android.stardroid.data.satellites.TleStore
@@ -226,13 +225,4 @@ object AppModule {
     @Singleton
     fun sensorStatusSource(application: Application): SensorStatusSource =
         SensorManagerStatusSource(application.getSystemService(SensorManager::class.java))
-
-    /**
-     * The process's locale, read once — a system locale change shows fresh strings after
-     * process death, as in v1.
-     */
-    @Provides
-    @Singleton
-    fun localeSpec(application: Application): LocaleSpec =
-        LocaleSpec(application.resources.configuration.locales[0].toLanguageTag())
 }

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/locale/LocaleSource.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/locale/LocaleSource.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Penterakt LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.google.android.stardroid.locale
+
+import android.app.Application
+import android.content.ComponentCallbacks
+import android.content.res.Configuration
+import com.google.android.stardroid.catalog.LocaleSpec
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The locale every catalog read is made in, kept current across a language change.
+ *
+ * Switching language — the system per-app picker `android:localeConfig` enables, or the device
+ * language — recreates the activities but leaves the process alive. Resource strings therefore
+ * come back translated while anything captured once at startup does not, and a captured
+ * [LocaleSpec] left every catalog-sourced string — object names, map labels, info-card prose —
+ * in the old language until the process happened to die.
+ *
+ * So nothing captures one: [current] re-reads the live configuration on each call for the
+ * on-demand reads, and [specs] re-emits on a configuration change for the layers, which rebuild
+ * their scenes from a flow. `MutableStateFlow` conflates equal values and [LocaleSpec] compares
+ * by tag, so configuration changes that leave the language alone (a rotation) emit nothing.
+ */
+@Singleton
+class LocaleSource
+    @Inject
+    constructor(
+        private val application: Application,
+    ) {
+        /** The app's locale right now, read from the live configuration — never cached. */
+        val current: LocaleSpec
+            get() = LocaleSpec(application.resources.configuration.locales[0].toLanguageTag())
+
+        private val mutableSpecs = MutableStateFlow(current)
+
+        /** [current], re-emitted whenever the configuration changes. */
+        val specs: StateFlow<LocaleSpec> = mutableSpecs.asStateFlow()
+
+        init {
+            application.registerComponentCallbacks(
+                object : ComponentCallbacks {
+                    override fun onConfigurationChanged(newConfig: Configuration) {
+                        mutableSpecs.value = current
+                    }
+
+                    override fun onLowMemory() = Unit
+                },
+            )
+        }
+    }

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/notifications/NotificationScheduler.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/notifications/NotificationScheduler.kt
@@ -110,7 +110,7 @@ class NotificationPlannerWorker(
             entryPoint
                 .catalogAccess()
                 .repository()
-                .meteorShowers(entryPoint.localeSpec())
+                .meteorShowers(entryPoint.localeSource().current)
                 .first()
         val now = Clock.System.now()
         val sky =
@@ -152,7 +152,7 @@ class NotificationPosterWorker(
             entryPoint
                 .catalogAccess()
                 .repository()
-                .meteorShowers(entryPoint.localeSpec())
+                .meteorShowers(entryPoint.localeSource().current)
                 .first()
         val now = Clock.System.now()
         val sky =

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/MainActivity.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/MainActivity.kt
@@ -50,8 +50,8 @@ import com.google.android.stardroid.analytics.SessionBucket
 import com.google.android.stardroid.astronomy.MeeusEphemeris
 import com.google.android.stardroid.camera.SkyCameraPreview
 import com.google.android.stardroid.catalog.CelestialObjectId
-import com.google.android.stardroid.catalog.LocaleSpec
 import com.google.android.stardroid.data.satellites.RefreshResult
+import com.google.android.stardroid.locale.LocaleSource
 import com.google.android.stardroid.location.AndroidGeocoding
 import com.google.android.stardroid.location.LocationController
 import com.google.android.stardroid.location.LocationSource
@@ -141,7 +141,7 @@ class MainActivity : ComponentActivity() {
 
     @Inject lateinit var startupState: StartupState
 
-    @Inject lateinit var localeSpec: LocaleSpec
+    @Inject lateinit var localeSource: LocaleSource
 
     @Inject lateinit var displayRotation: DisplayRotationBus
 
@@ -215,7 +215,7 @@ class MainActivity : ComponentActivity() {
             initializer {
                 SearchViewModel(
                     catalog = catalogAccess::repository,
-                    locale = localeSpec,
+                    locale = localeSource.specs,
                     ephemeris = MeeusEphemeris,
                     now = timeController::now,
                     settings = settings,
@@ -234,7 +234,7 @@ class MainActivity : ComponentActivity() {
             initializer {
                 ObjectInfoViewModel(
                     catalog = catalogAccess::repository,
-                    locale = localeSpec,
+                    locale = localeSource.specs,
                     ephemeris = MeeusEphemeris,
                     now = timeController::now,
                     settings = settings,
@@ -282,7 +282,7 @@ class MainActivity : ComponentActivity() {
 
     private val galleryViewModel: GalleryViewModel by viewModels {
         viewModelFactory {
-            initializer { GalleryViewModel(catalogAccess::repository, localeSpec) }
+            initializer { GalleryViewModel(catalogAccess::repository, localeSource.specs) }
         }
     }
 
@@ -597,7 +597,7 @@ class MainActivity : ComponentActivity() {
                 AnalyticsEvents.HAS_ROTATION_VECTOR,
                 sensors.hasSensor(SensorKind.ROTATION_VECTOR).toString(),
             )
-            analytics.setUserProperty(AnalyticsEvents.USER_LOCALE, localeSpec.tag)
+            analytics.setUserProperty(AnalyticsEvents.USER_LOCALE, localeSource.current.tag)
             val nightMode = settings.nightMode.first()
             val disableGyro = settings.disableGyro.first()
             val sensorPath =

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/gallery/GalleryViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/gallery/GalleryViewModel.kt
@@ -19,6 +19,7 @@ import com.google.android.stardroid.catalog.LocaleSpec
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 /**
@@ -29,7 +30,7 @@ import kotlinx.coroutines.launch
  */
 class GalleryViewModel(
     private val catalog: suspend () -> CatalogRepository,
-    private val locale: LocaleSpec,
+    private val locale: StateFlow<LocaleSpec>,
 ) : ViewModel() {
     private val _items = MutableStateFlow<List<GalleryItem>>(emptyList())
     val items: StateFlow<List<GalleryItem>> = _items.asStateFlow()
@@ -39,7 +40,11 @@ class GalleryViewModel(
     // scroll-back. ~48 tiles × ~256 KB ≈ 12 MB ceiling.
     val thumbnailCache = LruCache<String, ImageBitmap>(48)
 
+    // Re-listed on a language change: the view model outlives the activity recreation the
+    // switch triggers, so a once-only load would keep showing the old language's names.
     init {
-        viewModelScope.launch { _items.value = catalog().galleryItems(locale) }
+        viewModelScope.launch {
+            locale.collectLatest { _items.value = catalog().galleryItems(it) }
+        }
     }
 }

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/objectinfo/ObjectInfoViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/objectinfo/ObjectInfoViewModel.kt
@@ -410,7 +410,9 @@ class ObjectInfoViewModel(
         viewModelScope.launch {
             locale.drop(1).collect {
                 val open = _card.value ?: return@collect
-                cardFor(open.id)?.let(::openCard)
+                // The re-read suspends, so the user may have dismissed the card or opened a
+                // different one meanwhile; reopening then would resurrect what they closed.
+                cardFor(open.id)?.let { if (_card.value?.id == open.id) openCard(it) }
             }
         }
     }

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/objectinfo/ObjectInfoViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/objectinfo/ObjectInfoViewModel.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -90,7 +91,7 @@ sealed interface RiseSetState {
  */
 class ObjectInfoViewModel(
     private val catalog: suspend () -> CatalogRepository,
-    private val locale: LocaleSpec,
+    private val locale: StateFlow<LocaleSpec>,
     private val ephemeris: Ephemeris,
     private val now: () -> Instant,
     private val settings: Settings,
@@ -195,13 +196,7 @@ class ObjectInfoViewModel(
     /** Opens [id]'s card — a see-also chip tap, v1's `onSeeAlsoClicked`. */
     fun show(id: CelestialObjectId) {
         viewModelScope.launch {
-            // Satellites are not in the bundled catalog — they arrive from the network — so their
-            // card is synthesized rather than looked up. See SatelliteIds.
-            val info =
-                SatelliteIds.noradIdFor(id)?.let { norad ->
-                    satellites().firstOrNull { it.info.id == id }?.info
-                } ?: catalog().objectInfo(id, locale)
-            info?.let {
+            cardFor(id)?.let {
                 analytics.trackEvent(
                     AnalyticsEvents.OBJECT_INFO_VIEWED_EVENT,
                     mapOf(AnalyticsEvents.OBJECT_INFO_ID to id.value),
@@ -258,7 +253,7 @@ class ObjectInfoViewModel(
                         .minByOrNull { (_, separation) -> separation }
                         ?.first
                 } ?: return@launch
-            catalog().objectInfo(hit.id, locale)?.let { openCard(it) }
+            catalog().objectInfo(hit.id, locale.value)?.let { openCard(it) }
         }
     }
 
@@ -352,7 +347,7 @@ class ObjectInfoViewModel(
                         if (!settings.layerEnabled(layerId).first()) {
                             emptyList()
                         } else {
-                            repo.layerObjects(kind, locale).first()
+                            repo.layerObjects(kind, locale.value).first()
                         }
                     }
                 }
@@ -362,7 +357,7 @@ class ObjectInfoViewModel(
                         emptyList()
                     } else {
                         val today = utcMonthDay(now())
-                        repo.meteorShowers(locale).first().filter { it.isActiveOn(today) }
+                        repo.meteorShowers(locale.value).first().filter { it.isActiveOn(today) }
                     }
                 }
             val solarSystemDeferred =
@@ -397,6 +392,28 @@ class ObjectInfoViewModel(
             catalogCandidates + showerCandidates + solarSystemDeferred.await() +
                 satelliteCandidates
         }
+
+    /**
+     * [id]'s card content in the current locale. Satellites are not in the bundled catalog —
+     * they arrive from the network — so their card is synthesized rather than looked up. See
+     * [SatelliteIds].
+     */
+    private suspend fun cardFor(id: CelestialObjectId): ObjectInfo? =
+        SatelliteIds.noradIdFor(id)?.let { norad ->
+            satellites().firstOrNull { it.info.id == id }?.info
+        } ?: catalog().objectInfo(id, locale.value)
+
+    // A language switch recreates the activity but not this view model, so a card left open
+    // across one would keep the language it was opened in: look it up again in the new locale.
+    // Last in the class body so every property it touches is initialized before it runs.
+    init {
+        viewModelScope.launch {
+            locale.drop(1).collect {
+                val open = _card.value ?: return@collect
+                cardFor(open.id)?.let(::openCard)
+            }
+        }
+    }
 
     private companion object {
         val MOON_ID: CelestialObjectId = SolarSystemIds.idFor(SolarSystemBody.MOON)

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
@@ -103,13 +104,17 @@ class SearchViewModel(
      */
     @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
     val suggestions: StateFlow<List<SearchHit>> =
-        _query
-            .debounce { if (it.isBlank()) Duration.ZERO else SEARCH_DEBOUNCE }
-            .mapLatest { q ->
+        combine(
+            _query.debounce { if (it.isBlank()) Duration.ZERO else SEARCH_DEBOUNCE },
+            // A language switch leaves this view model alive, so a list already on screen would
+            // otherwise keep the old language's names until the next keystroke.
+            locale,
+        ) { q, spec -> q to spec }
+            .mapLatest { (q, spec) ->
                 if (q.isBlank()) {
                     emptyList()
                 } else {
-                    catalog().searchByPrefix(q.trim(), locale.value, SUGGESTION_LIMIT)
+                    catalog().searchByPrefix(q.trim(), spec, SUGGESTION_LIMIT)
                 }
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchViewModel.kt
@@ -73,7 +73,7 @@ data class SearchTarget(
  */
 class SearchViewModel(
     private val catalog: suspend () -> CatalogRepository,
-    private val locale: LocaleSpec,
+    private val locale: StateFlow<LocaleSpec>,
     private val ephemeris: Ephemeris,
     private val now: () -> Instant,
     private val settings: Settings,
@@ -109,7 +109,7 @@ class SearchViewModel(
                 if (q.isBlank()) {
                     emptyList()
                 } else {
-                    catalog().searchByPrefix(q.trim(), locale, SUGGESTION_LIMIT)
+                    catalog().searchByPrefix(q.trim(), locale.value, SUGGESTION_LIMIT)
                 }
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
@@ -125,7 +125,7 @@ class SearchViewModel(
      */
     fun selectById(id: CelestialObjectId) {
         viewModelScope.launch {
-            val info = catalog().objectInfo(id, locale) ?: return@launch
+            val info = catalog().objectInfo(id, locale.value) ?: return@launch
             select(
                 SearchHit(
                     id = info.id,
@@ -141,7 +141,7 @@ class SearchViewModel(
     /** The user picked a hit from the list (v1's single-result / "Did you mean?" selection). */
     fun select(hit: SearchHit) {
         viewModelScope.launch {
-            val info = catalog().objectInfo(hit.id, locale)
+            val info = catalog().objectInfo(hit.id, locale.value)
             val direction = resolveDirection(hit, info)
             if (direction != null) {
                 // Search spans hidden layers (D43); re-enable the hit's layer so the arrow
@@ -167,7 +167,7 @@ class SearchViewModel(
             return
         }
         viewModelScope.launch {
-            val hits = catalog().searchByPrefix(q, locale, SUGGESTION_LIMIT)
+            val hits = catalog().searchByPrefix(q, locale.value, SUGGESTION_LIMIT)
             val chosen =
                 hits.firstOrNull { it.name.equals(q, ignoreCase = true) } ?: hits.singleOrNull()
             if (chosen != null) {

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/widget/CountdownWidget.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/widget/CountdownWidget.kt
@@ -70,7 +70,7 @@ class CountdownWidget : GlanceAppWidget() {
                     entryPoint
                         .catalogAccess()
                         .repository()
-                        .meteorShowers(entryPoint.localeSpec())
+                        .meteorShowers(entryPoint.localeSource().current)
                         .first()
                 // Location-free: the countdown is about dates, not local geometry.
                 tonightSky(Clock.System.now(), location = null, showers = showers).countdown

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/widget/TonightWidget.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/widget/TonightWidget.kt
@@ -74,7 +74,7 @@ class TonightWidget : GlanceAppWidget() {
                     entryPoint
                         .catalogAccess()
                         .repository()
-                        .meteorShowers(entryPoint.localeSpec())
+                        .meteorShowers(entryPoint.localeSource().current)
                         .first()
                 tonightSky(
                     Clock.System.now(),

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/widget/WidgetEntryPoint.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/widget/WidgetEntryPoint.kt
@@ -11,7 +11,7 @@ package com.google.android.stardroid.widget
 
 import android.content.Context
 import com.google.android.stardroid.CatalogAccess
-import com.google.android.stardroid.catalog.LocaleSpec
+import com.google.android.stardroid.locale.LocaleSource
 import com.google.android.stardroid.settings.Settings
 import com.google.android.stardroid.startup.ExperimentConfig
 import dagger.hilt.EntryPoint
@@ -32,7 +32,7 @@ interface WidgetEntryPoint {
 
     fun catalogAccess(): CatalogAccess
 
-    fun localeSpec(): LocaleSpec
+    fun localeSource(): LocaleSource
 }
 
 fun widgetEntryPoint(context: Context): WidgetEntryPoint =

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/gallery/GalleryViewModelTest.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/gallery/GalleryViewModelTest.kt
@@ -17,6 +17,7 @@ import com.google.android.stardroid.layers.FakeCatalogRepository
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
@@ -41,13 +42,15 @@ class GalleryViewModelTest {
     }
 
     private class GalleryRepository(
-        private val items: List<GalleryItem>,
+        private val items: (LocaleSpec) -> List<GalleryItem>,
     ) : CatalogRepository by FakeCatalogRepository() {
+        constructor(items: List<GalleryItem>) : this({ items })
+
         var requestedLocale: LocaleSpec? = null
 
         override suspend fun galleryItems(locale: LocaleSpec): List<GalleryItem> {
             requestedLocale = locale
-            return items
+            return items(locale)
         }
     }
 
@@ -62,7 +65,8 @@ class GalleryViewModelTest {
             val repository = GalleryRepository(catalogItems)
             val locale = LocaleSpec("es")
 
-            val viewModel = GalleryViewModel(catalog = { repository }, locale = locale)
+            val viewModel =
+                GalleryViewModel(catalog = { repository }, locale = MutableStateFlow(locale))
             runCurrent()
 
             assertThat(viewModel.items.value).isEqualTo(catalogItems)
@@ -75,9 +79,32 @@ class GalleryViewModelTest {
             val viewModel =
                 GalleryViewModel(
                     catalog = { GalleryRepository(emptyList()) },
-                    locale = LocaleSpec("en"),
+                    locale = MutableStateFlow(LocaleSpec("en")),
                 )
 
             assertThat(viewModel.items.value).isEmpty()
+        }
+
+    @Test
+    fun items_reListWhenTheAppLanguageChanges() =
+        runTest(dispatcher) {
+            val m31 = CelestialObjectId("dso/m31")
+            val repository =
+                GalleryRepository { locale ->
+                    val name =
+                        if (locale.tag == "es") "Galaxia de Andrómeda" else "Andromeda Galaxy"
+                    listOf(GalleryItem(m31, name, "m31.webp"))
+                }
+            val locale = MutableStateFlow(LocaleSpec("en"))
+
+            val viewModel = GalleryViewModel(catalog = { repository }, locale = locale)
+            runCurrent()
+            assertThat(viewModel.items.value.single().name).isEqualTo("Andromeda Galaxy")
+
+            // The view model outlives the activity recreation a language switch triggers.
+            locale.value = LocaleSpec("es")
+            runCurrent()
+
+            assertThat(viewModel.items.value.single().name).isEqualTo("Galaxia de Andrómeda")
         }
 }

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/objectinfo/ObjectInfoViewModelTest.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/objectinfo/ObjectInfoViewModelTest.kt
@@ -62,6 +62,7 @@ class ObjectInfoViewModelTest {
         val objectsByKind =
             LayerKind.entries.associateWith { MutableStateFlow<List<CatalogObject>>(emptyList()) }
         val infos = mutableMapOf<CelestialObjectId, ObjectInfo>()
+        var lastInfoLocale: LocaleSpec? = null
         val showers = MutableStateFlow<List<MeteorShower>>(emptyList())
 
         override fun layerObjects(
@@ -83,7 +84,10 @@ class ObjectInfoViewModelTest {
         override suspend fun objectInfo(
             id: CelestialObjectId,
             locale: LocaleSpec,
-        ): ObjectInfo? = infos[id]
+        ): ObjectInfo? {
+            lastInfoLocale = locale
+            return infos[id]
+        }
 
         override suspend fun infoCardObjectIds(): Set<CelestialObjectId> = infos.keys
 
@@ -104,10 +108,12 @@ class ObjectInfoViewModelTest {
 
     private val createdViewModels = mutableListOf<ObjectInfoViewModel>()
 
+    private val locale = MutableStateFlow(LocaleSpec("en"))
+
     private fun viewModel(): ObjectInfoViewModel =
         ObjectInfoViewModel(
             catalog = { repository },
-            locale = LocaleSpec("en"),
+            locale = locale,
             ephemeris = KeplerianEphemeris,
             now = { NOW },
             settings = settings,
@@ -126,6 +132,53 @@ class ObjectInfoViewModelTest {
             assertThat(vm.card.value?.name).isEqualTo("Sirius")
 
             vm.dismiss()
+            assertThat(vm.card.value).isNull()
+        }
+
+    @Test
+    fun `show looks the card up in the language the app is in now`() =
+        testScope.runCurrentTest {
+            repository.infos[SIRIUS_ID] = objectInfo(SIRIUS_ID, "Sirius")
+            val vm = viewModel()
+            vm.show(SIRIUS_ID)
+            runCurrent()
+
+            // A language switch recreates the activity but not the view model, so a captured
+            // locale would keep every later card in the language the app started in.
+            locale.value = LocaleSpec("es")
+            repository.infos[SIRIUS_ID] = objectInfo(SIRIUS_ID, "Sirio")
+            vm.dismiss()
+            vm.show(SIRIUS_ID)
+            runCurrent()
+
+            assertThat(repository.lastInfoLocale).isEqualTo(LocaleSpec("es"))
+            assertThat(vm.card.value?.name).isEqualTo("Sirio")
+        }
+
+    @Test
+    fun `an open card re-reads itself when the app language changes`() =
+        testScope.runCurrentTest {
+            repository.infos[SIRIUS_ID] = objectInfo(SIRIUS_ID, "Sirius")
+            val vm = viewModel()
+            vm.show(SIRIUS_ID)
+            runCurrent()
+
+            repository.infos[SIRIUS_ID] = objectInfo(SIRIUS_ID, "Sirio")
+            locale.value = LocaleSpec("es")
+            runCurrent()
+
+            assertThat(vm.card.value?.name).isEqualTo("Sirio")
+        }
+
+    @Test
+    fun `a language change with no card open opens nothing`() =
+        testScope.runCurrentTest {
+            repository.infos[SIRIUS_ID] = objectInfo(SIRIUS_ID, "Sirius")
+            val vm = viewModel()
+
+            locale.value = LocaleSpec("es")
+            runCurrent()
+
             assertThat(vm.card.value).isNull()
         }
 

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/objectinfo/ObjectInfoViewModelTest.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/objectinfo/ObjectInfoViewModelTest.kt
@@ -33,6 +33,7 @@ import com.google.android.stardroid.math.Vector3
 import com.google.android.stardroid.render.api.SkyCamera
 import com.google.android.stardroid.settings.FakeSettings
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -63,6 +64,9 @@ class ObjectInfoViewModelTest {
             LayerKind.entries.associateWith { MutableStateFlow<List<CatalogObject>>(emptyList()) }
         val infos = mutableMapOf<CelestialObjectId, ObjectInfo>()
         var lastInfoLocale: LocaleSpec? = null
+
+        /** Set to hold [objectInfo] mid-read, so a test can interleave a call against it. */
+        var infoGate: CompletableDeferred<Unit>? = null
         val showers = MutableStateFlow<List<MeteorShower>>(emptyList())
 
         override fun layerObjects(
@@ -86,6 +90,7 @@ class ObjectInfoViewModelTest {
             locale: LocaleSpec,
         ): ObjectInfo? {
             lastInfoLocale = locale
+            infoGate?.await()
             return infos[id]
         }
 
@@ -168,6 +173,29 @@ class ObjectInfoViewModelTest {
             runCurrent()
 
             assertThat(vm.card.value?.name).isEqualTo("Sirio")
+        }
+
+    @Test
+    fun `a card dismissed while a language change re-reads it stays dismissed`() =
+        testScope.runCurrentTest {
+            repository.infos[SIRIUS_ID] = objectInfo(SIRIUS_ID, "Sirius")
+            val vm = viewModel()
+            vm.show(SIRIUS_ID)
+            runCurrent()
+
+            val gate = CompletableDeferred<Unit>()
+            repository.infoGate = gate
+            repository.infos[SIRIUS_ID] = objectInfo(SIRIUS_ID, "Sirio")
+            locale.value = LocaleSpec("es")
+            runCurrent()
+
+            // The re-read is suspended in the catalog; the user closes the card before it lands.
+            vm.dismiss()
+            repository.infoGate = null
+            gate.complete(Unit)
+            runCurrent()
+
+            assertThat(vm.card.value).isNull()
         }
 
     @Test

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/search/SearchViewModelTest.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/search/SearchViewModelTest.kt
@@ -63,6 +63,9 @@ class SearchViewModelTest {
         var lastPrefix: String? = null
         var searchCount = 0
 
+        /** Overrides [hits] when set, so a test can vary the results by locale. */
+        var hitsFor: ((LocaleSpec) -> List<SearchHit>)? = null
+
         override fun layerObjects(
             kind: LayerKind,
             locale: LocaleSpec,
@@ -80,7 +83,8 @@ class SearchViewModelTest {
         ): List<SearchHit> {
             lastPrefix = prefix
             searchCount++
-            return hits.filter { it.name.startsWith(prefix, ignoreCase = true) }
+            return (hitsFor?.invoke(locale) ?: hits)
+                .filter { it.name.startsWith(prefix, ignoreCase = true) }
         }
 
         override suspend fun objectInfo(
@@ -111,10 +115,12 @@ class SearchViewModelTest {
 
     private var manualMode = false
 
+    private val locale = MutableStateFlow(LocaleSpec("en"))
+
     private fun viewModel(): SearchViewModel =
         SearchViewModel(
             catalog = { repository },
-            locale = MutableStateFlow(LocaleSpec("en")),
+            locale = locale,
             ephemeris = KeplerianEphemeris,
             now = { NOW },
             settings = settings,
@@ -139,6 +145,28 @@ class SearchViewModelTest {
             vm.setQuery("")
             runCurrent()
             assertThat(vm.suggestions.value).isEmpty()
+        }
+
+    @Test
+    fun `suggestions re-run in the new language when the app language changes`() =
+        testScope.runCurrentTest {
+            val spanish = SIRIUS_HIT.copy(name = "Sirio")
+            repository.hitsFor = { if (it.tag == "es") listOf(spanish) else listOf(SIRIUS_HIT) }
+            val vm = viewModel()
+            backgroundScope.launch { vm.suggestions.collect {} }
+            runCurrent()
+
+            vm.setQuery("sir")
+            advanceTimeBy(debounceSettle)
+            runCurrent()
+            assertThat(vm.suggestions.value).containsExactly(SIRIUS_HIT)
+
+            // The view model outlives the activity recreation a language switch triggers.
+            locale.value = LocaleSpec("es")
+            advanceTimeBy(debounceSettle)
+            runCurrent()
+
+            assertThat(vm.suggestions.value).containsExactly(spanish)
         }
 
     @Test

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/search/SearchViewModelTest.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/search/SearchViewModelTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -113,7 +114,7 @@ class SearchViewModelTest {
     private fun viewModel(): SearchViewModel =
         SearchViewModel(
             catalog = { repository },
-            locale = LocaleSpec("en"),
+            locale = MutableStateFlow(LocaleSpec("en")),
             ephemeris = KeplerianEphemeris,
             now = { NOW },
             settings = settings,

--- a/stardroid-v2/docs/code-overview.md
+++ b/stardroid-v2/docs/code-overview.md
@@ -244,6 +244,12 @@ D44), sensors, sound effects, and the `FlavorEdges`-supplied platform services.
 Suspend-initialized state (catalog open, layer registry) lives in `CatalogAccess` — a
 mutex-guarded first-use open with recovery.
 
+The app's locale is deliberately *not* one of the captured singletons: `locale/LocaleSource`
+re-reads the configuration per request (`current`) and re-emits it on a configuration change
+(`specs`). A language switch recreates the activities but not the process, so a captured
+`LocaleSpec` would leave every catalog-sourced string — names, map labels, info-card prose —
+in the old language until the process happened to die.
+
 `ui/MainActivity.kt` is the single activity: it owns the `GLSurfaceView` + `GLSkyRenderer`,
 and `RenderBinder` bridges Flows → renderer inside `repeatOnLifecycle(STARTED)`: camera and
 render state from `MapViewModel`, and per-layer


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Switching language recreated the activities but left the process alive, so `AppModule`'s `@Singleton` LocaleSpec — read once at startup — kept every catalog-sourced string in the language the app started in: object names, map labels, search results, gallery names, widgets and info-card prose, under a fully translated UI. View models survive the recreation too, so re-reading the locale at construction would not have been enough.

`locale/LocaleSource` never captures a locale: `current` re-reads the live configuration per call, `specs` re-emits from `onConfigurationChanged` (equal tags conflate, so a rotation emits nothing). The layers take `specs` — they were already written to re-emit on locale change, but the wiring passed a constant `flowOf` — plus a fresh `ResourceLayerStrings` per locale so their own labels follow. The view models take a `StateFlow<LocaleSpec>` and read it at query time; the gallery re-lists and an open info card re-reads itself. The `LocaleSpec` Hilt binding is gone, so a snapshot cannot be injected by accident.

Verified on an emulator across a live `set-app-locales` switch (same PID): labels flip to "Cúmulo Doble"/"Perseo", the card opens fully Spanish, and a card left open flips in place when the language changes back.


Claude-Session: https://claude.ai/code/session_01DZFr4pA2Huwxdgs8e3kw6o

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [ ] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [ ] I've run the unit tests (`./gradlew check` from `stardroid-v2/`, or `./gradlew :app:test`
      from `stardroid-v1/`, matching whichever module this PR touches)
- [ ] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

<!-- Anything reviewers should know? -->


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Introduce `LocaleSource` to track configuration language changes.

- Stream updated `LocaleSpec` to ViewModels and layers.

- Dynamically re-render open info cards and gallery.

- Add unit tests for locale switch reactivity.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  nodeConfig["Configuration Changes"] -- "triggers" --> nodeLocale["LocaleSource.specs"]
  nodeLocale -- "emits to" --> nodeLayers["CatalogAccess & Layers"]
  nodeLocale -- "emits to" --> nodeVMs["ViewModels\n(Gallery, ObjectInfo, Search)"]
  nodeVMs -- "updates" --> nodeUI["Dynamic UI & Open Cards"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>CatalogAccess.kt</strong><dd><code>Pass dynamic locale flow and layer strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-a3cec3c8ba7572fbc95fb2e8ffdc238e73b62b2056657368d178e6bd686ffd85">+10/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NotificationScheduler.kt</strong><dd><code>Use current locale dynamically in notification workers</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-72ea8e9629385099eae04f2f991fd7d82e16288bdbe35064eb0064c61b1a5c78">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MainActivity.kt</strong><dd><code>Inject `LocaleSource` into ViewModels and analytics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-cf432498811039db091d4537022f8960e51dfb32f11c02c50adddce9c9b39d95">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GalleryViewModel.kt</strong><dd><code>Collect locale flow to refresh gallery items</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-cb6c295b0022d5f9409d49e2ac008cb1fa47834c2712405b442ec532bffe6d05">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ObjectInfoViewModel.kt</strong><dd><code>Re-fetch open object info cards on locale change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-9a0620724fd1ce2a5a59696371b6a66d60a0dcd03eb6dc431299f0c1f8ce8dac">+28/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SearchViewModel.kt</strong><dd><code>Use dynamic locale `StateFlow` for search queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-9baf31d7c9a7291b6870f9ea3afeac968771d3c7c73d095c718c13450ad59dd9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CountdownWidget.kt</strong><dd><code>Access current locale via `LocaleSource`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-de041dfd30bd131ed15e22e2f86ba6ed710093e5307496bebcebea1b09f4d9e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TonightWidget.kt</strong><dd><code>Access current locale via `LocaleSource`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-d9383ea156b63e27d07192b941af05906c4f1b6a6f43b80aaf7204f422519fbd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>AppModule.kt</strong><dd><code>Remove static singleton `LocaleSpec` provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-2be088f514312fc19578e9d84a5451993537c6a4899ad7ad3ae1fe58db3b19b3">+0/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WidgetEntryPoint.kt</strong><dd><code>Expose `LocaleSource` instead of `LocaleSpec`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-3a93bea746af340bd3f4e2e0f3857ec0495d0ce8a78753180ee0a7b990f1c0ab">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>LocaleSource.kt</strong><dd><code>Introduce `LocaleSource` to observe language configuration</code></dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-2ed61dbd5610b6bb67c84e9b68a5b1ddf313808812f0cea54fbc67638f459e3c">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>GalleryViewModelTest.kt</strong><dd><code>Add test for gallery re-listing on locale change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-8eb9bdedb9238183c898cb9fb7450cb795b87a39407da176733e3ad9eb1fb901">+31/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ObjectInfoViewModelTest.kt</strong><dd><code>Add tests for object info card locale updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-3f1cf12917b3ae267510e8cc40b9ee93e643c13533b42751634b761d1a1690cd">+55/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SearchViewModelTest.kt</strong><dd><code>Update test instantiation with locale `StateFlow`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-d8c5d559ed9da4ee8e2d2745ebc29ed164c54ef107bb7331f58fc2591350e46a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>code-overview.md</strong><dd><code>Document `LocaleSource` architecture and rationale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/976/files#diff-7a67d10907571845cb6cebdd4e4f8d354f7bac88d5dfb9ba557fb803d53ea499">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

