### PR TITLE
Keep the horizon leveller running until a fling actually stops

### DIFF
--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapViewModel.kt
@@ -830,7 +830,12 @@ class MapViewModel(
                     val sinAngle = (cam.up cross target) dot cam.lineOfSight
                     val cosAngle = cam.up dot target
                     val angleDeg = atan2(sinAngle, cosAngle) * RADIANS_TO_DEGREES
-                    if (abs(angleDeg) < LEVEL_STOP_DEG) break
+                    // A diagonal fling's pitch+yaw composition isn't a true combined rotation
+                    // (MapViewModel#onDrag), so it reintroduces a little roll on every frame it
+                    // runs. Don't declare victory on an instantaneous close-enough reading while
+                    // the fling is still actively re-tilting the horizon underneath us (#960) —
+                    // only stop once the fling itself is done.
+                    if (abs(angleDeg) < LEVEL_STOP_DEG && flingJob?.isActive != true) break
                     // The share of the remaining angle this frame takes: v1's flat 20% per
                     // 50 ms tick, re-expressed as a continuous rate so the spring settles in
                     // the same time whatever the refresh rate (D93).

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/map/MapViewModelTest.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/map/MapViewModelTest.kt
@@ -828,6 +828,53 @@ class MapViewModelTest {
             assertThat(vm.camera.value).isEqualTo(stopped)
         }
 
+    /**
+     * Issue #960: `onFling` and `onGestureEnd` are two independent coroutines racing on the
+     * same camera. The old exit condition — "the angle read under the stop threshold, so
+     * stop" — only ever sampled the angle instantaneously; if the fling was still running,
+     * and still capable of re-tilting the horizon (as a diagonal fling does, frame by frame),
+     * the leveler could see a momentary zero and quit for good, leaving any later drift
+     * uncorrected until the next gesture. A rotate mid-fling stands in for that drift here,
+     * since it's a controllable way to introduce it without depending on the exact numeric
+     * roll error a diagonal drag happens to accumulate.
+     */
+    @Test
+    fun `the leveler keeps fixing drift that lands while a fling is still running`() =
+        testScope.runCurrentTest {
+            val vm = viewModel(sensors = false)
+            runCurrent()
+
+            // Level the horizon first and let it fully settle with nothing else running.
+            vm.onRotate(37f)
+            vm.onGestureEnd()
+            advanceTimeBy(10_000)
+            runCurrent()
+            vm.stopLeveling()
+
+            // Start a fling; onGestureEnd fires right after it, as MapScreen does on lift.
+            vm.onFling(1000f, 0f, 1000)
+            vm.onGestureEnd()
+            // Give the leveler time to read the (already level) horizon and, pre-fix, exit.
+            advanceTimeBy(500)
+            runCurrent()
+
+            // Something re-tilts the horizon while the fling is still going.
+            vm.onRotate(5f)
+            val tilted = vm.camera.value.up
+
+            // ~1000 px/s decays under the fling's stop threshold at ~3 s (see the fling tests
+            // above); give the leveler ample time after that too.
+            advanceTimeBy(4_500)
+            runCurrent()
+
+            val cam = vm.camera.value
+            val zenith = SkyModel.localFrame(TIME, LocationController.DEFAULT_LOCATION).up
+            val target =
+                (zenith - cam.lineOfSight * (zenith dot cam.lineOfSight)).normalized()
+            assertThat(cam.up.distanceTo(target)).isLessThan(0.01)
+            assertThat(cam.up.distanceTo(tilted)).isGreaterThan(0.01)
+        }
+
     // ---- The map HUD (map-hud.md, D65) ---------------------------------------------------
 
     @Test


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Fixes a bug where the horizon auto-leveller would sometimes stay tilted after a fast diagonal fling, despite auto-level being enabled.

## Root cause

`MapViewModel.onFling` and `MapViewModel.onGestureEnd` (the horizon leveller) run as two independent coroutines that both mutate the shared `_camera` state every frame. The leveller's stop condition only checked the instantaneous angle to the horizon, with no awareness that a fling was still running and still capable of re-tilting it.

A diagonal fling drags via `onDrag`'s pitch-then-yaw composition, which is only a first-order approximation of a combined rotation for diagonal motion — every frame of a diagonal fling reintroduces a small roll error into `cam.up` (axis-aligned flings don't). Because the leveller's spring converges fast, it exits within a couple of frames while the fling keeps re-injecting drift for the rest of its multi-second decay, with nothing left to correct it.

## Fix

The leveller now only exits once the horizon is level and no fling is actively running. Added a regression test that starts a fling, lets the leveller read an already-level horizon, then introduces drift mid-fling and asserts it still gets corrected.

Fixes #960.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Keep horizon auto-leveler active until active flings finish

- Prevent diagonal fling drift from leaving the horizon tilted

- Add unit test verifying auto-leveler corrects drift mid-fling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  fling["Fling Gesture (flingJob)"] -- "Active" --> levelerCheck["Leveler Exit Condition Check"]
  levelerCheck -- "Angle < threshold & fling inactive" --> stop["Stop Leveling"]
  levelerCheck -- "Fling still active" --> continueLeveling["Continue Auto-Leveling Loop"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MapViewModel.kt</strong><dd><code>Check fling job status before stopping horizon leveler</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapViewModel.kt

<ul><li>Updated the horizon leveler loop exit check to verify <br><code>flingJob?.isActive != true</code> before stopping.<br> <li> Ensures the leveler does not terminate while a fling is still actively <br>re-introducing roll tilt.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/984/files#diff-8d3d394352c482be581e0cd54c08690caf35f546a87bf6d305dd5eb4482ce957">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MapViewModelTest.kt</strong><dd><code>Add regression test for mid-fling horizon leveling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/map/MapViewModelTest.kt

<ul><li>Added unit test checking that the leveler remains active and corrects <br>tilt introduced during a fling animation.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/984/files#diff-2451bcf9930acd4c71062715bbe5595dc95ba58e9deea3594040b948afd09f3e">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

