### PR TITLE
Fix M65/M66 losing their primary catalog label to the shared Leo Triplet alias

### DIFF
--- a/stardroid-v2/.tmstate.toml
+++ b/stardroid-v2/.tmstate.toml
@@ -1,5 +1,10 @@
 version = 1
 
+[human_translated.object-types."types.json".fr]
+keys = [
+    "constellation",
+]
+
 [same_as_parent.object-names.names.fr]
 keys = [
     "constellation/cancer",
@@ -7246,11 +7251,6 @@ keys = [
     "dso/willman_1",
 ]
 
-[same_as_parent.object-types.fr]
-keys = [
-    "constellation",
-]
-
 [same_as_parent.object-types."types.json".en-GB]
 keys = [
     "asterism",
@@ -7295,6 +7295,11 @@ keys = [
 [same_as_parent.object-types."types.json".de]
 keys = [
     "planet",
+]
+
+[same_as_parent.object-types."types.json".fr]
+keys = [
+    "constellation",
 ]
 
 [same_as_parent.object-types."types.json".id]

--- a/stardroid-v2/source-data/names/en.csv
+++ b/stardroid-v2/source-data/names/en.csv
@@ -137,7 +137,9 @@ dso/m57,Ring Nebula,1
 dso/m6,Butterfly Cluster,1
 dso/m63,Sunflower Galaxy,1
 dso/m64,Black Eye Galaxy,1
+dso/m65,M65,1
 dso/m65,Leo Triplet,0
+dso/m66,M66,1
 dso/m66,Leo Triplet,0
 dso/m7,Scorpion's Tail,1
 dso/m7,Ptolemy Cluster,0

--- a/stardroid-v2/source-data/names/fr.csv
+++ b/stardroid-v2/source-data/names/fr.csv
@@ -132,7 +132,9 @@ dso/m57,Nébuleuse de l'Anneau,1
 dso/m6,Amas du Papillon,1
 dso/m63,Galaxie du Tournesol,1
 dso/m64,Galaxie de l'Œil noir,1
+dso/m65,M65,1
 dso/m65,Triplet du Lion,0
+dso/m66,M66,1
 dso/m66,Triplet du Lion,0
 dso/m7,Queue du Scorpion,1
 dso/m7,Amas de Ptolémée,0

--- a/stardroid-v2/source-data/names/it.csv
+++ b/stardroid-v2/source-data/names/it.csv
@@ -138,7 +138,9 @@ dso/m57,Nebulosa Anello,1
 dso/m6,Ammasso Farfalla,1
 dso/m63,Galassia Girasole,1
 dso/m64,Galassia Occhio Nero,1
+dso/m65,M65,1
 dso/m65,Tripletta del Leone,0
+dso/m66,M66,1
 dso/m66,Tripletta del Leone,0
 dso/m7,Coda dello scorpione,1
 dso/m7,Ammasso di Tolomeo,0


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Description

M65/M66 have shown the identical ambiguous "Leo Triplet" label instead of their own catalog
designation since the `en.csv` alias was added — surfaced while auditing #985's fr/it mirror of
that same entry. `en.csv`/`fr.csv`/`it.csv` only carried an `is_primary=0` "Leo Triplet"-family
row for these two objects, with no locale-level primary row of their own.

Once a locale file has *any* row for an object, `RoomCatalogRepository`'s `pickByChain` picks the
nearest matching locale and only looks for a primary *within that locale's own rows* — it never
falls back further down the chain to `universal.csv`'s primary if the nearest locale lacks one.
So both galaxies rendered as "Leo Triplet" on the map/search in every locale that touched the
object, rather than "M65"/"M66".

Fix: add `M65,1` / `M66,1` rows to `en.csv`, `fr.csv`, `it.csv` alongside the existing alias
rows, so each locale that touches these objects carries a complete row set per the
whole-object sparse-override contract (`csv_overrides.py`). `tm validate` is clean for all three
locales now (the `it` locale's remaining 4 errors are pre-existing `help.xml` `<br/>` mismatches,
unrelated to this change — confirmed present before #985 too).

Also corrects `.tmstate.toml` provenance for #985's `types.json` `fr: "Constellation"` entry: it
was only recorded as `same_as_parent` (a pipeline inference from an earlier run), not
`human_translated`, even though a contributor deliberately reviewed and confirmed it as part of
#985. Both flags are now set together, matching what actually happened — a human confirmed the
parent-language fallback was correct, not just that it coincidentally matched.

See #988 for a follow-up on the underlying name-locale shadowing design, which put this
non-obvious footgun in front of anyone adding a single alias by hand.

## Type of Change

- [x] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [x] I've read the contributing guidelines
- [x] I've run the unit tests (`./gradlew :data:generator:test` — the relevant suite for this
      data-only change; full `./gradlew check` not run)
- [ ] I've tested on a device/emulator if applicable
- [x] Single commit

## Notes for Reviewers

`tm validate fr` / `tm validate it` / `tm validate en` all confirmed clean for the touched keys
before and after. Verified the resolution logic by hand-tracing `pickByChain` against the new row
shape (nearest-locale `M65`/`M66` primary now wins over the shared alias, with `Leo Triplet` /
`Triplet du Lion` / `Tripletta del Leone` / `NGC 3623` still surfacing as secondary designations).


___

### **PR Type**
Other


___

### **Description**
- Record French constellation type translation provenance.

- Fix section header for parent fallback metadata.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  node1["types.json (fr: constellation)"] -- "Mark as human translated & same-as-parent" --> node2[".tmstate.toml"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.tmstate.toml</strong><dd><code>Update French object type translation state metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/.tmstate.toml

<ul><li>Mark the French <code>constellation</code> object type entry as human translated.<br> <li> Align the <code>same_as_parent</code> section header format to <code>types.json.fr</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/989/files#diff-e5e0993eb93752566badcf1e75716154c9ebe7fcc95d82e7a42725adcf552e23">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

