### PR TITLE
Fix the warm welcome and terms layouts in landscape

### DIFF
--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/ChromeTour.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/ChromeTour.kt
@@ -11,7 +11,10 @@ package com.google.android.stardroid.ui.onboarding
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -38,6 +41,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.android.stardroid.ui.map.CHROME_TOUR_STOPS
@@ -62,8 +66,9 @@ private const val TOUR_STEP_MS = 1500L
  * with a v1-style neon ring + arrow + label spotlight cycling through every control. Because
  * the chrome is the real thing, the tour can't drift out of date, localizes through the same
  * string resources, and lays out correctly on every screen. Each control reports its bounds
- * through `tourTargetModifier`; stops whose control isn't on screen (an `ifroom` rail toggle
- * dropped on a short screen) are skipped. The chrome is display-only: its semantics are
+ * through `tourTargetModifier`; stops whose control isn't on screen — an `ifroom` rail toggle
+ * dropped on a short screen, or anything clipped by a small demo box — are skipped, so the
+ * tour always shows the chrome this window actually has. The chrome is display-only: its semantics are
  * cleared (TalkBack users get the slide's text) and taps are swallowed.
  */
 @Composable
@@ -84,7 +89,16 @@ internal fun ChromeTourDemo(
         }
     }
 
-    Box(modifier.onGloballyPositioned { rootCoordinates = it }) {
+    // MapChrome insets itself against the window's safe-drawing area, which is right for a
+    // full-screen map and wrong for a demo panel that is nowhere near those edges: unconsumed,
+    // it would pay the navigation-bar inset the welcome screen has already applied and a
+    // landscape display cutout's inset on an edge it does not touch, both out of the height
+    // the chrome is shortest of.
+    Box(
+        modifier
+            .consumeWindowInsets(WindowInsets.safeDrawing)
+            .onGloballyPositioned { rootCoordinates = it },
+    ) {
         // The chrome is a live rendering, not a working control surface: cleared semantics
         // keep TalkBack from announcing a dozen dead buttons, and the overlay swallows taps
         // so a press can't ripple a control that does nothing (pager swipes still work —
@@ -120,25 +134,46 @@ internal fun ChromeTourDemo(
                     .pointerInput(Unit) {},
             )
         }
+        // Attachment alone is not enough to earn a stop: a control that overflows a short
+        // demo box is still composed and positioned, just clipped, so filtering on isAttached
+        // would spend TOUR_STEP_MS spotlighting a ring drawn outside the visible box. Only
+        // controls whose bounds land inside the box are on the tour.
         val root = rootCoordinates?.takeIf { it.isAttached }
-        val stops = CHROME_TOUR_STOPS.filter { targetCoordinates[it]?.isAttached == true }
-        val stop = stops.getOrNull(step % max(1, stops.size))
-        val bounds =
-            if (root != null && stop != null) {
-                targetCoordinates[stop]?.let { root.localBoundingBoxOf(it, clipBounds = false) }
+        val stops =
+            if (root == null) {
+                emptyList()
             } else {
-                null
+                CHROME_TOUR_STOPS.mapNotNull { target ->
+                    val coordinates =
+                        targetCoordinates[target]?.takeIf { it.isAttached }
+                            ?: return@mapNotNull null
+                    val bounds = root.localBoundingBoxOf(coordinates, clipBounds = false)
+                    if (bounds.isVisibleIn(root.size)) target to bounds else null
+                }
             }
-        if (stop != null && bounds != null) {
+        val stop = stops.getOrNull(step % max(1, stops.size))
+        if (stop != null) {
             TourSpotlight(
-                bounds = bounds,
-                label = stringResource(chromeTourLabel(stop)),
+                bounds = stop.second,
+                label = stringResource(chromeTourLabel(stop.first)),
                 colors = tourColors(nightMode),
                 modifier = Modifier.fillMaxSize(),
             )
         }
     }
 }
+
+/**
+ * Whether a control's bounds sit wholly inside a box of [size]. A half-clipped control is not
+ * worth a stop — the ring would run off the edge — so this asks for the whole thing, with a
+ * pixel of tolerance for controls laid out flush against the box's own padding.
+ */
+private fun Rect.isVisibleIn(size: IntSize): Boolean =
+    !isEmpty &&
+        left >= -1f &&
+        top >= -1f &&
+        right <= size.width + 1f &&
+        bottom <= size.height + 1f
 
 /**
  * The v1 neon highlight, generalized: a glowing ring around [bounds], an arrow pointing at it

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/ChromeTour.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/ChromeTour.kt
@@ -12,8 +12,10 @@ package com.google.android.stardroid.ui.onboarding
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -68,8 +70,8 @@ private const val TOUR_STEP_MS = 1500L
  * string resources, and lays out correctly on every screen. Each control reports its bounds
  * through `tourTargetModifier`; stops whose control isn't on screen — an `ifroom` rail toggle
  * dropped on a short screen, or anything clipped by a small demo box — are skipped, so the
- * tour always shows the chrome this window actually has. The chrome is display-only: its semantics are
- * cleared (TalkBack users get the slide's text) and taps are swallowed.
+ * tour always shows the chrome this window actually has. The chrome is display-only: its
+ * semantics are cleared (TalkBack users get the slide's text) and taps are swallowed.
  */
 @Composable
 internal fun ChromeTourDemo(
@@ -94,9 +96,19 @@ internal fun ChromeTourDemo(
     // it would pay the navigation-bar inset the welcome screen has already applied and a
     // landscape display cutout's inset on an edge it does not touch, both out of the height
     // the chrome is shortest of.
+    //
+    // The top edge is deliberately left unconsumed. This box's top really is the window's top
+    // (the welcome screen applies only navigationBarsPadding), so anything MapChrome anchors
+    // there would land under the status bar or a cutout. Nothing does today — the tour passes
+    // no hudState, and the HUD is the only top-anchored zone — but consuming the whole set
+    // would make that a silent dependency on a default argument.
     Box(
         modifier
-            .consumeWindowInsets(WindowInsets.safeDrawing)
+            .consumeWindowInsets(
+                WindowInsets.safeDrawing.only(
+                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                ),
+            )
             .onGloballyPositioned { rootCoordinates = it },
     ) {
         // The chrome is a live rendering, not a working control surface: cleared semantics

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/WelcomeScreen.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/WelcomeScreen.kt
@@ -9,6 +9,7 @@
 
 package com.google.android.stardroid.ui.onboarding
 
+import android.content.res.Configuration
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -25,6 +27,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
@@ -53,11 +56,13 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.google.android.stardroid.R
 import com.google.android.stardroid.catalog.CelestialObjectId
@@ -76,6 +81,21 @@ private const val SLIDE_COUNT = 3
 
 /** Delay between revealing each sensor's result in the slide-3 check (v1's 0.8 s cadence). */
 private const val SENSOR_CHECK_STEP_MS = 800L
+
+/**
+ * The text panel's width when it sits beside the illustration in landscape. Chosen for the
+ * measure, not the space available: past roughly this width the slide descriptions stretch
+ * into a line too long to read comfortably, and every dp beyond it is worth more to the
+ * illustration — which is the half that is starved in landscape.
+ */
+private val PANEL_MAX_WIDTH: Dp = 340.dp
+
+/**
+ * The sensor check's content width in landscape. Its rows push the status icon to the far
+ * end with a weighted spacer, so across a full landscape window the label and its tick end
+ * up a screen apart.
+ */
+private val SENSOR_CONTENT_MAX_WIDTH: Dp = 480.dp
 
 /** v1's bottom text-panel scrim (`#DD0B0F19` in `fragment_welcome_slide_1.xml`). */
 private val PanelScrim = Color(0xDD0B0F19)
@@ -187,63 +207,116 @@ private fun BottomBar(
     }
 }
 
+/**
+ * A slide's two halves — the illustration and its text panel — stacked in portrait and set
+ * side by side in landscape.
+ *
+ * Landscape is the orientation with width to spare and none of the height, and the two halves
+ * want opposite things: the panel is height-cheap (it scrolls), while the illustration is
+ * width-cheap and height-hungry — [ChromeTourDemo] renders the real `MapChrome`, whose layer
+ * rail and action cluster are edge-anchored columns in landscape. Stacked, they were sharing
+ * a window height that neither could live in: the panel took its half and the chrome
+ * overflowed what was left, clipping the rail and the last of the bottom-right actions off
+ * the slide entirely.
+ *
+ * The panel takes a fixed [PANEL_MAX_WIDTH] rather than a fraction of the slide, so on wide
+ * landscape windows and tablets the surplus goes to the illustration instead of stretching
+ * the text to an unreadable measure.
+ */
+@Composable
+private fun SlideLayout(
+    backdrop: @Composable () -> Unit,
+    illustration: @Composable (Modifier) -> Unit,
+    panel: @Composable (Modifier) -> Unit,
+) {
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        backdrop()
+        if (isLandscape()) {
+            Row(Modifier.fillMaxSize()) {
+                illustration(
+                    Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                )
+                panel(
+                    Modifier
+                        .widthIn(max = PANEL_MAX_WIDTH)
+                        .fillMaxHeight(),
+                )
+            }
+        } else {
+            // Portrait keeps v1's stack, panel capped at half the slide so a large font
+            // scale scrolls the text instead of squeezing the illustration to nothing.
+            val panelMaxHeight = maxHeight / 2
+            Column(Modifier.fillMaxSize()) {
+                illustration(
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                )
+                panel(Modifier.heightIn(max = panelMaxHeight))
+            }
+        }
+    }
+}
+
+@Composable
+private fun isLandscape(): Boolean =
+    LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+
 /** Slide 1: the guided tour of the real map chrome over a real v2 sky capture. */
 @Composable
 private fun ChromeTourSlide(
     active: Boolean,
     nightMode: Boolean,
 ) {
-    BoxWithConstraints(Modifier.fillMaxSize()) {
-        val panelMaxHeight = maxHeight / 2
-        Image(
-            painterResource(R.drawable.welcome_sky_bg),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            colorFilter = nightPhotoFilter(nightMode),
-            modifier = Modifier.fillMaxSize(),
-        )
-        Column(Modifier.fillMaxSize()) {
-            ChromeTourDemo(
-                active = active,
-                nightMode = nightMode,
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .fillMaxWidth(),
+    SlideLayout(
+        backdrop = {
+            Image(
+                painterResource(R.drawable.welcome_sky_bg),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                colorFilter = nightPhotoFilter(nightMode),
+                modifier = Modifier.fillMaxSize(),
             )
+        },
+        illustration = { modifier ->
+            ChromeTourDemo(active = active, nightMode = nightMode, modifier = modifier)
+        },
+        panel = { modifier ->
             TextPanel(
                 R.string.warm_welcome_slide1_title,
                 R.string.warm_welcome_slide1_desc,
-                modifier = Modifier.heightIn(max = panelMaxHeight),
+                modifier = modifier,
             )
-        }
-    }
+        },
+    )
 }
 
 /** Slide 2: navigation modes plus a genuine info card of the Crab Nebula, over its photo. */
 @Composable
 private fun InfoCardSlide(nightMode: Boolean) {
-    BoxWithConstraints(Modifier.fillMaxSize()) {
-        val panelMaxHeight = maxHeight / 2
-        AssetBackdrop("celestial_images/deep_sky_objects/hubble_m1.jpg", nightMode)
-        Column(Modifier.fillMaxSize()) {
+    SlideLayout(
+        backdrop = {
+            AssetBackdrop("celestial_images/deep_sky_objects/hubble_m1.jpg", nightMode)
+        },
+        illustration = { modifier ->
             Box(
-                Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .padding(horizontal = 32.dp, vertical = 16.dp),
+                modifier.padding(horizontal = 32.dp, vertical = 16.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 SampleInfoCard(nightMode)
             }
+        },
+        panel = { modifier ->
             TextPanel(
                 R.string.warm_welcome_slide2_title,
                 R.string.warm_welcome_slide2_desc,
                 R.string.warm_welcome_slide2_info_desc,
-                modifier = Modifier.heightIn(max = panelMaxHeight),
+                modifier = modifier,
             )
-        }
-    }
+        },
+    )
 }
 
 /**
@@ -334,7 +407,18 @@ private fun SensorSlide(
         AssetBackdrop("celestial_images/planets/cassini_iapetus.webp", nightMode)
         Column(
             Modifier
-                .fillMaxSize()
+                .fillMaxHeight()
+                // This slide has no separate text panel to set beside anything, so landscape
+                // only needs its content held to a readable block rather than stretched the
+                // full width of the window (see SENSOR_CONTENT_MAX_WIDTH).
+                .then(
+                    if (isLandscape()) {
+                        Modifier.widthIn(max = SENSOR_CONTENT_MAX_WIDTH)
+                    } else {
+                        Modifier.fillMaxWidth()
+                    },
+                )
+                .align(Alignment.Center)
                 .verticalScroll(rememberScrollState())
                 .padding(24.dp),
             verticalArrangement = Arrangement.Center,
@@ -413,9 +497,9 @@ private fun nightPhotoFilter(nightMode: Boolean): ColorFilter? =
     if (nightMode) ColorFilter.tint(NightPhotoTint, BlendMode.Modulate) else null
 
 /**
- * v1's bottom text panel: title and body over the dark scrim strip. Callers cap its height at
- * half the slide so at large font scales it scrolls instead of squeezing the illustration
- * above it to nothing.
+ * v1's text panel: title and body over the dark scrim. Sits under the illustration in
+ * portrait and beside it in landscape; [SlideLayout] owns that placement and the size cap
+ * that goes with it, and the panel scrolls when the text outgrows what it is given.
  */
 @Composable
 private fun TextPanel(

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/WelcomeScreen.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/WelcomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -89,6 +90,14 @@ private const val SENSOR_CHECK_STEP_MS = 800L
  * illustration — which is the half that is starved in landscape.
  */
 private val PANEL_MAX_WIDTH: Dp = 340.dp
+
+/**
+ * The most of a landscape slide the text panel may take. A `Row` measures its unweighted
+ * children first, so [PANEL_MAX_WIDTH] on its own would let the panel swallow a narrow
+ * landscape window — multi-window, freeform, a small cover screen — and leave the
+ * illustration a sliver or nothing at all. Whichever of the two limits is smaller wins.
+ */
+private const val PANEL_MAX_FRACTION = 0.45f
 
 /**
  * The sensor check's content width in landscape. Its rows push the status icon to the far
@@ -219,9 +228,10 @@ private fun BottomBar(
  * overflowed what was left, clipping the rail and the last of the bottom-right actions off
  * the slide entirely.
  *
- * The panel takes a fixed [PANEL_MAX_WIDTH] rather than a fraction of the slide, so on wide
- * landscape windows and tablets the surplus goes to the illustration instead of stretching
- * the text to an unreadable measure.
+ * The panel is capped both by measure ([PANEL_MAX_WIDTH]) and by share
+ * ([PANEL_MAX_FRACTION]): the measure keeps the text readable on a wide window or tablet by
+ * handing the surplus to the illustration, and the share keeps the illustration alive on a
+ * narrow one.
  */
 @Composable
 private fun SlideLayout(
@@ -232,6 +242,7 @@ private fun SlideLayout(
     BoxWithConstraints(Modifier.fillMaxSize()) {
         backdrop()
         if (isLandscape()) {
+            val panelWidth = minOf(PANEL_MAX_WIDTH, maxWidth * PANEL_MAX_FRACTION)
             Row(Modifier.fillMaxSize()) {
                 illustration(
                     Modifier
@@ -240,7 +251,7 @@ private fun SlideLayout(
                 )
                 panel(
                     Modifier
-                        .widthIn(max = PANEL_MAX_WIDTH)
+                        .width(panelWidth)
                         .fillMaxHeight(),
                 )
             }

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/startup/StartupDialogs.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/startup/StartupDialogs.kt
@@ -11,12 +11,14 @@ package com.google.android.stardroid.ui.startup
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -36,9 +38,17 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.google.android.stardroid.R
 import com.google.android.stardroid.ui.common.StyledHtml
+
+/**
+ * The terms' reading measure. A portrait phone is narrower than this, so the cap does nothing
+ * there; it bites in landscape and on tablets, where the full window width would otherwise run
+ * the paragraphs to well over a hundred characters a line.
+ */
+private val EULA_MAX_WIDTH: Dp = 560.dp
 
 /** The manifest version name, for the What's New and Help headings (v1 `getVersionName`). */
 @Composable
@@ -94,18 +104,31 @@ fun EulaScreen(
         // The access-permission notice rides on the terms screen so it is disclosed before any
         // permission is requested (Korean Network Act art. 22-2 items 1-3; see eula.xml). Help
         // renders the same key, so a user who has already accepted can still read it.
-        StyledHtml(
-            stringResource(R.string.eula_text) +
-                stringResource(R.string.permissions_notice) +
-                stringResource(R.string.eula_agree_line),
-            nightMode = nightMode,
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-        )
+        // The scroll lives on the full-width box, not on the capped column: a narrower
+        // scrollable would leave the surplus width beside it inert, and a drag started there
+        // — the natural place to put a thumb on a wide screen — would do nothing.
+        Box(
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState()),
+            // Start-aligned, not centred: the top app bar's title sits at the leading edge,
+            // and a centred column would start well inboard of it — and land on the centred
+            // Sky Map watermark behind the screen.
+            contentAlignment = Alignment.TopStart,
+        ) {
+            StyledHtml(
+                stringResource(R.string.eula_text) +
+                    stringResource(R.string.permissions_notice) +
+                    stringResource(R.string.eula_agree_line),
+                nightMode = nightMode,
+                modifier =
+                    Modifier
+                        .widthIn(max = EULA_MAX_WIDTH)
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Description

On a first install held in landscape, the warm welcome was laid out for portrait and broke.

Each slide stacked its illustration over its text panel. In landscape that splits a window
height neither half can live in: the panel takes its half, leaving the chrome tour roughly
160 dp for a `MapChrome` whose layer rail needs 261 dp before a single `ifroom` toggle. The
rail and the last of the bottom-right actions — Auto/Manual and the overflow, the only route
to Help and Settings — overflowed and were clipped off the slide. The tour then spotlighted
them anyway, because it picked its stops by `isAttached` and a clipped control is still
composed and positioned, so several steps drew their ring outside the visible box and looked
like they did nothing.

`SlideLayout` now stacks the two halves in portrait, unchanged, and sets them side by side in
landscape — the orientation with width to spare and no height, where the panel is height-cheap
(it scrolls) and the illustration is width-cheap and height-hungry. The panel takes a fixed
width rather than a fraction, so a wide window or tablet gives its surplus to the illustration
instead of stretching the text past a readable measure.

Second commit: the terms screen had the same too-wide measure in landscape — around 110
characters a line — so its text is capped at 560 dp. A portrait phone is narrower than that,
so portrait is unaffected.

**Portrait is unchanged throughout.**

## Type of Change

- [x] Bug fix
- [ ] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [x] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [x] I've run the unit tests (`./gradlew check` from `stardroid-v2/`, or `./gradlew :app:test`
      from `stardroid-v1/`, matching whichever module this PR touches)
- [x] I've tested on a device/emulator if applicable
- [ ] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

Verified on a Pixel 6a emulator, both orientations, from a cleared first-run install:

- Landscape slide 1 shows the rail and the full five-button cluster with the text beside them;
  six consecutive tour steps landed on Auto/Manual, Stars, Deep-sky objects, Meteor showers,
  More layers and options and Time travel, every ring on screen.
- Rail members that the real landscape map also drops stay dropped — the tour shows the chrome
  the window actually has, rather than pointing at controls that aren't there.
- Landscape slides 2 and 3 fit without scrolling; portrait is visually identical (whole-frame
  pixel diff on the terms screen is max 10/255, mean ~1 — emulator rendering noise, identical
  line breaks).

Two commits rather than one, because the welcome and terms fixes are independent — happy to
squash if you'd rather.

Not fixed here, noticed while testing: the Sky Map watermark sits behind the terms body text
at full contrast, which makes "Safety & Liability" hard to read. That's a visual-design call
rather than a layout bug, so I left it alone.

___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Arrange onboarding slides side-by-side in landscape mode.

- Constrain landscape text width across welcome and EULA screens.

- Skip clipped or out-of-bounds controls during chrome tour.

- Consume safe-drawing insets in the chrome tour demo container.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  orientation["Screen Orientation Check"] -- "Landscape" --> rowLayout["SlideLayout (Side-by-side Row)"]
  orientation -- "Portrait" --> colLayout["SlideLayout (Stacked Column)"]
  rowLayout --> tourDemo["ChromeTourDemo"]
  tourDemo -- "Filters bounds" --> stopFilter["Skip clipped controls"]
  eulaScreen["EulaScreen"] -- "Landscape / Tablet" --> eulaCap["Constrain text measure (EULA_MAX_WIDTH)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromeTour.kt</strong><dd><code>Consume insets and ignore clipped stops in chrome tour</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/ChromeTour.kt

<ul><li>Consumed <code>WindowInsets.safeDrawing</code> to avoid incorrect nested insetting <br>inside the demo box.<br> <li> Added bounds filtering using <code>isVisibleIn</code> to omit clipped or off-screen <br>tour targets from the spotlight cycle.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/990/files#diff-5ccea9f9dc578c8b45fe39e3c835eecf81db74e2c18f916961a95506200aea6f">+47/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WelcomeScreen.kt</strong><dd><code>Support side-by-side landscape layout in welcome onboarding</code></dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/WelcomeScreen.kt

<ul><li>Introduced <code>SlideLayout</code> to display illustrations and text side-by-side <br>in landscape mode.<br> <li> Applied <code>PANEL_MAX_WIDTH</code> to the slide text panel and <br><code>SENSOR_CONTENT_MAX_WIDTH</code> to <code>SensorSlide</code>.<br> <li> Refactored <code>ChromeTourSlide</code> and <code>InfoCardSlide</code> to use <code>SlideLayout</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/990/files#diff-1d573bea1272c89d2e1ffb29e475625ccae35b15726f11456f0037ed8d3844a2">+119/-35</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StartupDialogs.kt</strong><dd><code>Constrain EULA text reading measure in landscape and wide screens</code></dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/startup/StartupDialogs.kt

<ul><li>Wrapped terms text in a full-sized scrollable <code>Box</code> while constraining <br>line measure to <code>EULA_MAX_WIDTH</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/990/files#diff-2bcc2cdce1f107b72c8151fba5ddb513b8111e58b0c58602e74e2f63f154a41a">+35/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


