### PR TITLE
Fix crash on app start for Greek locale: malformed hud_ra_value format string

### DIFF
--- a/stardroid-v2/app/src/main/res/values-el/strings.xml
+++ b/stardroid-v2/app/src/main/res/values-el/strings.xml
@@ -111,7 +111,7 @@
     <string name="hud_az_label" translation_description="Map-HUD row label: azimuth (compass bearing) of the point at the centre of the screen. Keep short.">Αζ.</string>
     <string name="hud_fov_label" translation_description="Map-HUD row label: the field of view (how many degrees of sky the screen spans). Keep short.">ΟΠ</string>
     <string name="hud_correction_label" translation_description="Map-HUD row label for the manual sensor-alignment correction the user set by dragging. Keep very short.">Ρύθμ.</string>
-    <string name="hud_ra_value" translation_description="Right ascension in the conventional hours-and-minutes notation, e.g. \'18h 38m\'. %1$d is hours (0-23), %2$02d is minutes (00-59).">%1$dω %2$02λ</string>
+    <string name="hud_ra_value" translation_description="Right ascension in the conventional hours-and-minutes notation, e.g. \'18h 38m\'. %1$d is hours (0-23), %2$02d is minutes (00-59).">%1$dω %2$02dλ</string>
     <!-- tm:omitted name="hud_signed_degrees_value" reason="identical_to_source" -->
     <!-- tm:omitted name="hud_azimuth_value" reason="identical_to_source" -->
     <!-- tm:omitted name="hud_fov_value" reason="identical_to_source" -->


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Fixes a malformed Greek (el) translation of `hud_ra_value` that was missing the `d` format conversion character (`%2$02λ` instead of `%2$02dλ`). This threw `java.util.UnknownFormatConversionException` every time `MapHud.kt` composed `stringResource(R.string.hud_ra_value, ...)`, i.e. on startup for any device with Greek as the active language.

Fixes #992

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix crash on startup in Greek locale

- Correct malformed format specifier in `hud_ra_value`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>strings.xml</strong><dd><code>Fix malformed format specifier in Greek `hud_ra_value`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/main/res/values-el/strings.xml

<ul><li>Add missing <code>d</code> conversion specifier to <code>hud_ra_value</code> format string <br>(<code>%2$02dλ</code>).<br> <li> Resolve <code>UnknownFormatConversionException</code> when loading the string <br>resource.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/993/files#diff-4c71178ea6715d2fae7fbdd11cef986d7aeeeb6b5523796f2dcd38fd2139abbb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

