### PR TITLE
Wrap time travel dialog buttons instead of squeezing them

### DIFF
--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/timetravel/TimeTravelUi.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/timetravel/TimeTravelUi.kt
@@ -17,7 +17,10 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -158,7 +161,7 @@ fun TimeTravelPlayer(viewModel: TimeTravelViewModel) {
  * v1's time-travel dialog in Compose: pick a date, a time, or a popular event, then Go —
  * or just "Start from now" if nothing was touched (v1's two-mode Go button).
  */
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun TimeTravelDialog(
     viewModel: TimeTravelViewModel,
@@ -187,10 +190,16 @@ fun TimeTravelDialog(
                     stringResource(R.string.time_travel_visiting, formatter.formatInstant(target)),
                     modifier = Modifier.padding(bottom = 12.dp),
                 )
-                Row(modifier = Modifier.padding(bottom = 12.dp)) {
+                // FlowRow rather than Row: long translations (e.g. Greek) can outgrow the
+                // dialog's width side by side, which squeezed the second button into an
+                // unreadably narrow, many-line sliver instead of simply wrapping.
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(bottom = 12.dp),
+                ) {
                     FilledTonalButton(
                         onClick = { showDatePicker = true },
-                        modifier = Modifier.padding(end = 8.dp),
                     ) { Text(stringResource(R.string.time_travel_pick_date)) }
                     FilledTonalButton(
                         onClick = { showTimePicker = true },


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

The "Set date"/"Set time" buttons in the time travel dialog sat in a plain `Row`, which squeezes the second button into an unreadably narrow, many-line sliver when a translation (e.g. Greek "Ορισμός ώρας") is too long to fit both buttons on one line.

Switches to `FlowRow` so the buttons wrap onto their own line, stacked, whenever there isn't enough horizontal room.

Fixes #996.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `Row` with `FlowRow` for buttons

- Prevent button squeezing for long translations

- Add horizontal and vertical button spacing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Dialog["TimeTravelDialog"] -- "contains" --> FlowRow["FlowRow Layout"]
  FlowRow -- "wraps buttons" --> DateButton["Pick Date Button"]
  FlowRow -- "wraps buttons" --> TimeButton["Pick Time Button"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TimeTravelUi.kt</strong><dd><code>Wrap time travel picker buttons using `FlowRow`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/timetravel/TimeTravelUi.kt

<ul><li>Replaced <code>Row</code> with <code>FlowRow</code> for the date and time selection buttons<br> <li> Added horizontal and vertical spacing of 8.dp between buttons<br> <li> Added <code>@OptIn(ExperimentalLayoutApi::class)</code> to support <code>FlowRow</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/998/files#diff-40eaa3a297ac32a8df017cdbb8d98fa2eda2b546eb7fd1ea55e77e4a932041a2">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

