### PR TITLE
Enable true edge-to-edge in stardroid-v2's MainActivity

### DIFF
--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/MainActivity.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/MainActivity.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -379,6 +380,13 @@ class MainActivity : ComponentActivity() {
         // v1 kept the screen alive unconditionally while the map is up (stargazers stare,
         // they don't touch); the flag replaces v1's belt-and-braces SCREEN_BRIGHT_WAKE_LOCK.
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        // The postSplashScreenTheme's windowFullscreen hides the status bar, but leaves the
+        // window fitting itself around the navigation bar — opaque nav bar on API <35, where
+        // the OS doesn't yet force edge-to-edge (R2.2/R2.4's cutout fixes already assume the
+        // sky extends under both bars). This is what makes every navigationBarsPadding() call
+        // in MapScreen/MapChrome mean something instead of resolving to ~0.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.isNavigationBarContrastEnforced = false
         displayRotation.rotation.value = currentDisplayRotation()
         // v1 StardroidApplication's per-process start snapshot; rotation recreates this
         // activity, so only the first creation logs.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Fixes the remaining half of #995: stardroid-v2's fullscreen theme already hides the status bar and the map HUD/time-travel/full-screen-destination top bars already pad for safeDrawing/cutout insets (R2.2/R2.4), but nothing ever called `WindowCompat.setDecorFitsSystemWindows(window, false)`. On Android <15 that left the navigation bar reserving opaque space instead of letting the sky render behind it — the same grey-bar symptom as the original report, just on the nav bar. Adds the decorFitsSystemWindows call plus `isNavigationBarContrastEnforced = false` in `MainActivity.onCreate`. The app's existing HUD/chrome insets handling needed no changes.

Could not run a Gradle build in this session (tool approval unavailable) — please verify with `ktlintCheck` and on-device, ideally on an API <35 device.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enable edge-to-edge window rendering

- Disable navigation bar contrast enforcement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MainActivity["MainActivity.onCreate()"] -- "Disable system fits" --> WindowCompat["WindowCompat.setDecorFitsSystemWindows(false)"]
  MainActivity -- "Disable contrast enforcement" --> NavContrast["isNavigationBarContrastEnforced = false"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainActivity.kt</strong><dd><code>Enable edge-to-edge window rendering in MainActivity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/MainActivity.kt

<ul><li>Call <code>WindowCompat.setDecorFitsSystemWindows(window, false)</code> to enable <br>edge-to-edge rendering behind system navigation bars.<br> <li> Set <code>window.isNavigationBarContrastEnforced = false</code> to prevent <br>system-enforced scrims over the navigation bar.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/999/files#diff-cf432498811039db091d4537022f8960e51dfb32f11c02c50adddce9c9b39d95">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

