### PR TITLE
Quick wins: options page, splash fade, HUD width, docs

### DIFF
--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/MainActivity.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/MainActivity.kt
@@ -402,11 +402,15 @@ class MainActivity : ComponentActivity() {
         }
 
         val imageLoader = AssetImageLoader(assets)
+        // Splash→sky reveal (ux-polish.md item 2, step 2): a cold start fades the sky in on
+        // first composition; a recreation (rotation, process restore) starts visible.
+        val isRecreation = savedInstanceState != null
         val glRenderer =
             GLSkyRenderer(
                 resources.displayMetrics.density,
                 imageLoader::load,
                 rendererInfoStore::set,
+                onFirstFrame = { if (!isRecreation) runOnUiThread(::revealSky) },
             )
         glSurfaceView =
             GLSurfaceView(this).apply {
@@ -419,6 +423,8 @@ class MainActivity : ComponentActivity() {
                 // Costless when the renderer clears opaque (the non-AR default).
                 holder.setFormat(PixelFormat.TRANSLUCENT)
                 setZOrderMediaOverlay(true)
+                // Covered until the renderer reports its first drawn frame; see revealSky.
+                alpha = if (isRecreation) 1f else 0f
             }
         val connector = RenderConnector(glRenderer, glSurfaceView)
         val binder = RenderBinder(connector)
@@ -544,6 +550,11 @@ class MainActivity : ComponentActivity() {
             hasAccelerometer = sensors.hasSensor(SensorKind.ACCELEROMETER),
             hasGyroscope = sensors.hasSensor(SensorKind.GYROSCOPE),
         )
+    }
+
+    /** Cross-fades the sky in over ~1 s (ux-polish.md item 2, step 2); runs on the UI thread. */
+    private fun revealSky() {
+        glSurfaceView.animate().alpha(1f).setDuration(SKY_REVEAL_MILLIS).start()
     }
 
     private fun applyScreenDimming(
@@ -727,6 +738,9 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         private const val SAVED_SESSION_START_TIME_KEY = "saved_session_start_time"
+
+        /** The splash→sky cross-fade length (ux-polish.md item 2, step 2). */
+        private const val SKY_REVEAL_MILLIS = 1_000L
 
         /** v1 `DiagnosticActivity.updateLocation`'s GPS-provider probe. */
         private fun gpsStatus(context: Context): GpsStatus {

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/SkyMapNavHost.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/SkyMapNavHost.kt
@@ -28,8 +28,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.google.android.stardroid.R
+import com.google.android.stardroid.analytics.AnalyticsEvents
 import com.google.android.stardroid.camera.SkyCameraPreview
 import com.google.android.stardroid.catalog.ObjectInfo
+import com.google.android.stardroid.startup.Experiment
 import com.google.android.stardroid.startup.ExperimentConfig
 import com.google.android.stardroid.ui.calibration.CompassCalibrationScreen
 import com.google.android.stardroid.ui.calibration.CompassCalibrationViewModel
@@ -43,11 +45,13 @@ import com.google.android.stardroid.ui.layers.LayersViewModel
 import com.google.android.stardroid.ui.location.LocationViewModel
 import com.google.android.stardroid.ui.map.MapScreen
 import com.google.android.stardroid.ui.map.MapViewModel
+import com.google.android.stardroid.ui.map.PendingMapAction
 import com.google.android.stardroid.ui.objectinfo.ImageExpandOverlay
 import com.google.android.stardroid.ui.objectinfo.MoonWidgetPromoRow
 import com.google.android.stardroid.ui.objectinfo.ObjectInfoCard
 import com.google.android.stardroid.ui.objectinfo.ObjectInfoViewModel
 import com.google.android.stardroid.ui.onboarding.WelcomeScreen
+import com.google.android.stardroid.ui.options.OptionsScreen
 import com.google.android.stardroid.ui.search.SearchViewModel
 import com.google.android.stardroid.ui.settings.SettingsScreen
 import com.google.android.stardroid.ui.settings.SettingsViewModel
@@ -57,6 +61,7 @@ import kotlinx.coroutines.launch
 /** The Navigation-Compose destinations (screens-and-startup.md's graph). */
 object Routes {
     const val MAP = "map"
+    const val OPTIONS = "options"
     const val WELCOME = "welcome?replay={replay}"
     const val SETTINGS = "settings"
     const val GALLERY = "gallery"
@@ -68,6 +73,19 @@ object Routes {
     fun calibration(userInitiated: Boolean) = "calibration/$userInitiated"
 
     fun welcomeReplay() = "welcome?replay=true"
+}
+
+/** Saved-state key on the map entry: a [PendingMapAction] the options page handed over. */
+private const val PENDING_MAP_ACTION = "pending_map_action"
+
+/**
+ * Hands a map-anchored action to the map and returns to it: the options page's Location
+ * and Share rows pop home first, because the location sheet and the sky capture live on
+ * the map screen.
+ */
+private fun NavHostController.requestMapAction(action: PendingMapAction) {
+    previousBackStackEntry?.savedStateHandle?.set(PENDING_MAP_ACTION, action)
+    popBackStack()
 }
 
 /** Presence of the sensors the warm welcome's third slide reports on. */
@@ -133,7 +151,7 @@ fun SkyMapNavHost(
         navController = navController,
         startDestination = if (startOnWelcome) Routes.WELCOME else Routes.MAP,
     ) {
-        composable(Routes.MAP) {
+        composable(Routes.MAP) { entry ->
             MapScreen(
                 glSurfaceView,
                 snackbarHostState,
@@ -148,12 +166,21 @@ fun SkyMapNavHost(
                 calibrationViewModel,
                 sensorWarningSuppressed = sensorWarningSuppressed,
                 onOpenSettings = { navController.navigate(Routes.SETTINGS) },
+                onOpenOptions = { navController.navigate(Routes.OPTIONS) },
                 onOpenGallery = { navController.navigate(Routes.GALLERY) },
                 onOpenTutorial = { navController.navigate(Routes.welcomeReplay()) },
                 onOpenHelp = { navController.navigate(Routes.HELP) },
                 onOpenWhatsNew = { navController.navigate(Routes.WHATS_NEW) },
                 onOpenCalibration = { userInitiated ->
                     navController.navigate(Routes.calibration(userInitiated))
+                },
+                mapActionRequests =
+                    entry.savedStateHandle.getStateFlow<PendingMapAction?>(
+                        PENDING_MAP_ACTION,
+                        null,
+                    ),
+                onPendingMapActionConsumed = {
+                    entry.savedStateHandle[PENDING_MAP_ACTION] = null
                 },
                 onRequestLocationPermission = onRequestLocationPermission,
                 onRequestAutoLocation = onRequestAutoLocation,
@@ -162,6 +189,47 @@ fun SkyMapNavHost(
                 hasCameraPermission = hasCameraPermission,
                 onRequestCameraPermission = onRequestCameraPermission,
                 experimentConfig = experimentConfig,
+            )
+        }
+
+        composable(Routes.OPTIONS) {
+            OptionsScreen(
+                onBack = { navController.popBackStack() },
+                onOpenHelp = {
+                    mapViewModel.logMenuItem(AnalyticsEvents.HELP_OPENED_LABEL)
+                    navController.navigate(Routes.HELP)
+                },
+                onOpenTutorial = {
+                    mapViewModel.logMenuItem(AnalyticsEvents.TUTORIAL_OPENED_LABEL)
+                    navController.navigate(Routes.welcomeReplay())
+                },
+                onOpenSettings = {
+                    mapViewModel.logMenuItem(AnalyticsEvents.SETTINGS_OPENED_LABEL)
+                    navController.navigate(Routes.SETTINGS)
+                },
+                onOpenLocation = {
+                    navController.requestMapAction(PendingMapAction.OPEN_LOCATION)
+                },
+                onOpenGallery = {
+                    mapViewModel.logMenuItem(AnalyticsEvents.GALLERY_OPENED_LABEL)
+                    navController.navigate(Routes.GALLERY)
+                },
+                // Sharing is behind the SHARE_SKY experiment; off, the row simply isn't
+                // offered.
+                onShareSky =
+                    if (experimentConfig.isEnabled(Experiment.SHARE_SKY)) {
+                        { navController.requestMapAction(PendingMapAction.SHARE_SKY) }
+                    } else {
+                        null
+                    },
+                onOpenWhatsNew = {
+                    mapViewModel.logMenuItem(AnalyticsEvents.WHATS_NEW_OPENED_LABEL)
+                    navController.navigate(Routes.WHATS_NEW)
+                },
+                onOpenCalibration = {
+                    mapViewModel.logMenuItem(AnalyticsEvents.CALIBRATION_OPENED_LABEL)
+                    navController.navigate(Routes.calibration(true))
+                },
             )
         }
 
@@ -176,7 +244,7 @@ fun SkyMapNavHost(
                 ),
         ) { entry ->
             // Two ways in: the first-run flow starts here with no map below (navigate to the
-            // map, dropping the welcome), and the overflow sheet's Tutorial replays it over a
+            // map, dropping the welcome), and the options page's Tutorial replays it over a
             // live map (just pop back to it). Replays stay out of the D49 first-run funnel —
             // no analytics, no re-marking the seen preference.
             val replay = entry.arguments?.getBoolean("replay") == true

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/calibration/CompassCalibrationUi.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/calibration/CompassCalibrationUi.kt
@@ -95,7 +95,7 @@ fun CompassCalibrationScreen(
         topBar = {
             TopAppBar(
                 title = { Text(barTitle) },
-                windowInsets = topBarWindowInsets(barTitle),
+                windowInsets = topBarWindowInsets(),
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/common/TopBarInsets.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/common/TopBarInsets.kt
@@ -13,65 +13,27 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.union
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.text.rememberTextMeasurer
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
 /**
- * Window insets for the top app bar of an opaque full-screen destination (Gallery, Help,
- * Settings, Diagnostics, compass calibration).
+ * Window insets for the top app bar of an opaque full-screen destination (Options, Gallery,
+ * Help, Settings, Diagnostics, compass calibration).
  *
  * The app runs under a fullscreen theme that hides the status bar, so Material 3's default top
  * bar insets (`systemBars`) collapse to ~0 and — crucially — never account for the display
  * cutout. On a notched phone that slides the screen's title under the camera cutout. Using
  * `safeDrawing` keeps the cutout inset (plus the top/side system-bar space when it exists), so
- * titles clear the notch in both portrait and landscape.
- *
- * Passing [title] — for bars whose only top-band content is the nav icon and the title —
- * enables a refinement: when no cutout horizontally overlaps the bar's leading band (nav icon
- * plus the measured collapsed title), the top inset is dropped and the title rides high beside
- * the cutout instead of always ducking below it. The check is inherently language-specific: a
- * short English title can clear a right-shifted punch hole that its longer German translation
- * would hit, which is why the title is measured rather than assumed. Bars with trailing action
- * icons should pass no title — the band check ignores the trailing edge.
+ * titles clear the notch in both portrait and landscape, and every destination's back arrow
+ * sits at the same height. The 8 dp floor is air for the arrow on cutout-less devices, where
+ * safeDrawing's top is 0 under the fullscreen theme.
  */
 @Composable
-fun topBarWindowInsets(title: String? = null): WindowInsets {
-    val full =
-        WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
-    if (title == null) return full
-    val density = LocalDensity.current
-    // A visible status bar owns the top band regardless of where the cutout sits.
-    if (WindowInsets.statusBars.getTop(density) > 0) return full
-    val view = LocalView.current
-    val cutouts = view.rootWindowInsets?.displayCutout?.boundingRects.orEmpty()
-    // No cutout: safeDrawing's top is already ~0 under the fullscreen theme.
-    if (cutouts.isEmpty()) return full
-    val titleWidthPx =
-        rememberTextMeasurer().measure(title, MaterialTheme.typography.titleLarge).size.width
-    val bandPx =
-        with(density) { (TITLE_START_DP + TITLE_SLACK_DP).dp.toPx() } + titleWidthPx
-    val barHeightPx = with(density) { COLLAPSED_BAR_HEIGHT_DP.dp.toPx() }
-    val ltr = LocalLayoutDirection.current == LayoutDirection.Ltr
-    val clashes =
-        cutouts.any { rect ->
-            rect.top < barHeightPx &&
-                if (ltr) rect.left < bandPx else rect.right > view.width - bandPx
-        }
-    return if (clashes) full else WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
-}
+fun topBarWindowInsets(): WindowInsets =
+    WindowInsets.safeDrawing
+        .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
+        .union(WindowInsets(top = MIN_TOP_DP.dp))
 
-/** M3 collapsed-bar title x-origin: 16 dp start padding + the 48 dp nav-icon slot. */
-private const val TITLE_START_DP = 64
-
-/** The collapsed bar band a cutout must vertically reach into to matter. */
-private const val COLLAPSED_BAR_HEIGHT_DP = 64
-
-/** Air between the measured title and the cutout before the bar ducks below it. */
-private const val TITLE_SLACK_DP = 16
+/** Air above the bar when no cutout or status bar pads it (fullscreen theme). */
+private const val MIN_TOP_DP = 8

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/diagnostics/DiagnosticsUi.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/diagnostics/DiagnosticsUi.kt
@@ -103,7 +103,7 @@ fun DiagnosticsScreen(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.diagnostics_title)) },
-                windowInsets = topBarWindowInsets(stringResource(R.string.diagnostics_title)),
+                windowInsets = topBarWindowInsets(),
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/gallery/GalleryUi.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/gallery/GalleryUi.kt
@@ -83,7 +83,7 @@ fun GalleryScreen(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.gallery_title)) },
-                windowInsets = topBarWindowInsets(stringResource(R.string.gallery_title)),
+                windowInsets = topBarWindowInsets(),
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/help/HelpScreen.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/help/HelpScreen.kt
@@ -96,7 +96,7 @@ fun HelpScreen(
         topBar = {
             LargeTopAppBar(
                 title = { Text(stringResource(R.string.help_dialog_title)) },
-                windowInsets = topBarWindowInsets(stringResource(R.string.help_dialog_title)),
+                windowInsets = topBarWindowInsets(),
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/help/WhatsNewScreen.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/help/WhatsNewScreen.kt
@@ -34,7 +34,7 @@ import com.google.android.stardroid.ui.common.topBarWindowInsets
 /**
  * The What's New & Credits destination (D74): the release notes, the support pitch, and the
  * credits that used to be appended to the bottom of the Help document, now first-class and
- * reachable from the overflow sheet. The startup `WhatsNewDialog` still shows the short
+ * reachable from the options page. The startup `WhatsNewDialog` still shows the short
  * release notes once per upgrade; this screen is where they stay findable afterwards.
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -49,8 +49,7 @@ fun WhatsNewScreen(
         topBar = {
             LargeTopAppBar(
                 title = { Text(stringResource(R.string.whats_new_screen_title)) },
-                windowInsets =
-                    topBarWindowInsets(stringResource(R.string.whats_new_screen_title)),
+                windowInsets = topBarWindowInsets(),
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapChrome.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapChrome.kt
@@ -173,7 +173,7 @@ fun MapChrome(
     onOpenSearch: () -> Unit,
     onOpenTimeTravel: () -> Unit,
     onOpenLayersSheet: () -> Unit,
-    onOpenOverflow: () -> Unit,
+    onOpenOptions: () -> Unit,
     modifier: Modifier = Modifier,
     // Null hides the HUD — the warm-welcome tour renders this chrome with canned state and
     // no live pointing to show.
@@ -280,7 +280,7 @@ fun MapChrome(
                 onToggleNightMode = onToggleNightMode,
                 onOpenSearch = onOpenSearch,
                 onOpenTimeTravel = onOpenTimeTravel,
-                onOpenOverflow = onOpenOverflow,
+                onOpenOptions = onOpenOptions,
                 tourTargetModifier = tourTargetModifier,
                 modifier = Modifier.padding(end = 8.dp, bottom = 8.dp),
             )
@@ -687,7 +687,7 @@ private fun ActionCluster(
     onToggleNightMode: () -> Unit,
     onOpenSearch: () -> Unit,
     onOpenTimeTravel: () -> Unit,
-    onOpenOverflow: () -> Unit,
+    onOpenOptions: () -> Unit,
     tourTargetModifier: (ChromeTourTarget) -> Modifier,
     modifier: Modifier = Modifier,
 ) {
@@ -746,13 +746,9 @@ private fun ActionCluster(
                 }
             }
         }
-        // Tonal, not bare: ⋮ is the only way to reach Help, Settings and seven other
-        // destinations, and as an unfilled glyph on the starfield it read as decoration and
-        // went unfound (Hannah's feedback, 2026-08). Search keeps the sole filled-primary
-        // slot, so promoting this to match its three neighbours costs no hierarchy.
         ActionTooltip(stringResource(R.string.more_button)) { description ->
             FilledTonalIconButton(
-                onClick = onOpenOverflow,
+                onClick = onOpenOptions,
                 modifier = tourTargetModifier(ChromeTourTarget.Overflow),
             ) {
                 Icon(painterResource(R.drawable.ic_more_vert), description)
@@ -810,75 +806,6 @@ private fun ActionTooltip(
         state = rememberTooltipState(),
     ) {
         content(label)
-    }
-}
-
-/**
- * Zone C: the ⋮ overflow sheet — destinations and one-shot actions, not sky-drawing
- * controls, so they don't earn permanent pixels. Sibling of [LayersSheet]: this sheet
- * navigates away from the map; the Layers sheet configures what it draws.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun OverflowSheet(
-    onShareSky: () -> Unit,
-    // Sharing is behind the SHARE_SKY experiment; off, the row simply isn't offered.
-    shareEnabled: Boolean = true,
-    onOpenGallery: () -> Unit,
-    onOpenLocation: () -> Unit,
-    onOpenCalibration: () -> Unit,
-    onOpenTutorial: () -> Unit,
-    onOpenHelp: () -> Unit,
-    onOpenWhatsNew: () -> Unit,
-    onOpenSettings: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
-        Column(
-            Modifier
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-        ) {
-            // Ordered by when a user needs them, not by how the app is built: Help and
-            // Tutorial were 7th and 6th of nine and fell below the fold on a short phone,
-            // which is precisely where a lost newcomer stops scrolling (Hannah's feedback,
-            // 2026-08). Diagnostics has left for Settings → Advanced entirely.
-            OverflowRow(R.drawable.ic_help, R.string.help_button, onOpenHelp)
-            OverflowRow(R.drawable.ic_tutorial, R.string.tutorial_button, onOpenTutorial)
-            OverflowRow(R.drawable.ic_settings, R.string.settings_button, onOpenSettings)
-            OverflowRow(R.drawable.ic_location, R.string.location_button, onOpenLocation)
-            OverflowRow(R.drawable.ic_gallery, R.string.gallery_button, onOpenGallery)
-            if (shareEnabled) {
-                OverflowRow(R.drawable.ic_share, R.string.share_button, onShareSky)
-            }
-            OverflowRow(R.drawable.ic_whats_new, R.string.whats_new_button, onOpenWhatsNew)
-            OverflowRow(R.drawable.ic_calibrate, R.string.calibration_button, onOpenCalibration)
-        }
-    }
-}
-
-@Composable
-private fun OverflowRow(
-    @DrawableRes icon: Int,
-    @StringRes label: Int,
-    onClick: () -> Unit,
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clip(CircleShape)
-                .clickable(onClick = onClick)
-                .padding(horizontal = 12.dp, vertical = 14.dp),
-    ) {
-        Icon(
-            painterResource(icon),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
-        )
-        Text(stringResource(label), style = MaterialTheme.typography.bodyLarge)
     }
 }
 

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapHud.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapHud.kt
@@ -13,7 +13,6 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -38,11 +37,19 @@ import com.google.android.stardroid.R
 import kotlin.math.roundToInt
 
 /**
+ * The card's fixed width, sized to fit the widest row — the correction row's label,
+ * widest value, and 48 dp reset button — so appearing rows and changing values never
+ * resize the card.
+ */
+private val HUD_WIDTH = 176.dp
+
+/**
  * The map HUD (map-hud.md, D65): a compact top-right pointing readout — RA/Dec, Alt/Az,
  * FOV, and the drag-to-align correction with its reset. Information chrome: it renders
  * inside the same show/hide container as the rest of the chrome and re-tints through the
  * theme in night mode. Values arrive pre-throttled ([MapViewModel.hudState]); tabular
- * figures keep them from jittering as they tick.
+ * figures keep them from jittering as they tick, and the fixed card width ([HUD_WIDTH])
+ * keeps appearing rows from resizing it.
  */
 @Composable
 fun MapHud(
@@ -54,7 +61,7 @@ fun MapHud(
     Column(
         modifier =
             modifier
-                .width(IntrinsicSize.Max)
+                .width(HUD_WIDTH)
                 .clip(shape)
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.62f))
                 .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f), shape)

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapScreen.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapScreen.kt
@@ -117,6 +117,7 @@ import com.google.android.stardroid.ui.timetravel.TravelEffect
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -127,6 +128,13 @@ import kotlin.math.min
 
 /** What [ImageExpandOverlay] needs from an [ObjectInfo] — small enough to survive rotation. */
 private data class ExpandedImage(val imageRef: String, val name: String, val credit: String?)
+
+/**
+ * A one-shot action the options page hands back to the map: its Location and Share rows
+ * are map-anchored (the location sheet and the sky capture live on the map), so they pop
+ * home and deliver the action through the nav back stack entry's saved state.
+ */
+enum class PendingMapAction { OPEN_LOCATION, SHARE_SKY }
 
 private val ExpandedImageSaver =
     Saver<ExpandedImage?, List<String?>>(
@@ -155,11 +163,15 @@ fun MapScreen(
     calibrationViewModel: CompassCalibrationViewModel,
     sensorWarningSuppressed: Boolean,
     onOpenSettings: () -> Unit,
+    onOpenOptions: () -> Unit,
     onOpenGallery: () -> Unit,
     onOpenTutorial: () -> Unit,
     onOpenHelp: () -> Unit,
     onOpenWhatsNew: () -> Unit,
     onOpenCalibration: (userInitiated: Boolean) -> Unit,
+    // The options page's two map-anchored rows arrive here after it pops back home.
+    mapActionRequests: StateFlow<PendingMapAction?>,
+    onPendingMapActionConsumed: () -> Unit,
     onRequestLocationPermission: () -> Unit,
     onRequestAutoLocation: () -> Unit,
     onOpenAppSettings: () -> Unit,
@@ -189,7 +201,6 @@ fun MapScreen(
     // diagnostics, and calibration are no longer local booleans here — they're Navigation
     // destinations (D48), reached through the onOpenX callbacks below.
     var showLayersSheet by rememberSaveable { mutableStateOf(false) }
-    var showOverflowSheet by rememberSaveable { mutableStateOf(false) }
     var showTimeTravelDialog by rememberSaveable { mutableStateOf(false) }
     var showSearchDialog by rememberSaveable { mutableStateOf(false) }
     var showLocationSheet by rememberSaveable { mutableStateOf(false) }
@@ -371,6 +382,22 @@ fun MapScreen(
             // otherwise be leaked outright.
             map?.recycle()
             still?.recycle()
+        }
+    }
+    // The options page's Location/Share rows deliver their action on return; consume it and
+    // act here, where the sheet state and the GL surface the share captures both live.
+    val pendingMapAction by mapActionRequests.collectAsStateWithLifecycle()
+    LaunchedEffect(pendingMapAction) {
+        when (pendingMapAction) {
+            PendingMapAction.OPEN_LOCATION -> {
+                onPendingMapActionConsumed()
+                showLocationSheet = true
+            }
+            PendingMapAction.SHARE_SKY -> {
+                onPendingMapActionConsumed()
+                startShare()
+            }
+            null -> Unit
         }
     }
     // The camera layer's plumbing lives while the layer is on: the preview binds under the
@@ -675,7 +702,7 @@ fun MapScreen(
                     showTimeTravelDialog = true
                 },
                 onOpenLayersSheet = { showLayersSheet = true },
-                onOpenOverflow = { showOverflowSheet = true },
+                onOpenOptions = onOpenOptions,
             )
         }
 
@@ -733,51 +760,6 @@ fun MapScreen(
                         }
                     }
                 },
-            )
-        }
-
-        if (showOverflowSheet) {
-            OverflowSheet(
-                onShareSky = {
-                    showOverflowSheet = false
-                    startShare()
-                },
-                shareEnabled = shareEnabled,
-                onOpenGallery = {
-                    showOverflowSheet = false
-                    mapViewModel.logMenuItem(AnalyticsEvents.GALLERY_OPENED_LABEL)
-                    onOpenGallery()
-                },
-                onOpenLocation = {
-                    showOverflowSheet = false
-                    showLocationSheet = true
-                },
-                onOpenCalibration = {
-                    showOverflowSheet = false
-                    mapViewModel.logMenuItem(AnalyticsEvents.CALIBRATION_OPENED_LABEL)
-                    onOpenCalibration(true)
-                },
-                onOpenTutorial = {
-                    showOverflowSheet = false
-                    mapViewModel.logMenuItem(AnalyticsEvents.TUTORIAL_OPENED_LABEL)
-                    onOpenTutorial()
-                },
-                onOpenHelp = {
-                    showOverflowSheet = false
-                    mapViewModel.logMenuItem(AnalyticsEvents.HELP_OPENED_LABEL)
-                    onOpenHelp()
-                },
-                onOpenWhatsNew = {
-                    showOverflowSheet = false
-                    mapViewModel.logMenuItem(AnalyticsEvents.WHATS_NEW_OPENED_LABEL)
-                    onOpenWhatsNew()
-                },
-                onOpenSettings = {
-                    showOverflowSheet = false
-                    mapViewModel.logMenuItem(AnalyticsEvents.SETTINGS_OPENED_LABEL)
-                    onOpenSettings()
-                },
-                onDismiss = { showOverflowSheet = false },
             )
         }
 

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/map/MapViewModel.kt
@@ -980,8 +980,9 @@ class MapViewModel(
          * D86 dropped this from 0.5°, and on-device evaluation dropped it again from 0.1°. At
          * 0.1° only Jupiter and Saturn resolve as discs; Mars and Mercury are 21 px and the ice
          * giants sit on the absolute floor. At 0.03° Mars and Mercury reach 71 px, Uranus 31 and
-         * Neptune 20, while Jupiter's 256-pixel texture is magnified only 1.4x. Going further to
-         * 0.02° would magnify it 2.1x and undo the sharpness the re-derived art (D85) bought.
+         * Neptune 20, and Jupiter's disc spans ~46% of the screen with Saturn's rings resolved
+         * (solar-system-imagery.md §3) — exactly the framing the 512-pixel art (D85) was sized
+         * for. Going deeper magnifies that art past its native resolution, and the discs soften.
          */
         const val MIN_FOV_DEG = 0.03
 

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/ChromeTour.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/onboarding/ChromeTour.kt
@@ -131,7 +131,7 @@ internal fun ChromeTourDemo(
                 onOpenSearch = {},
                 onOpenTimeTravel = {},
                 onOpenLayersSheet = {},
-                onOpenOverflow = {},
+                onOpenOptions = {},
                 tourTargetModifier = { target ->
                     Modifier.onGloballyPositioned { targetCoordinates[target] = it }
                 },

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/options/OptionsScreen.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/options/OptionsScreen.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Penterakt LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.google.android.stardroid.ui.options
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.google.android.stardroid.R
+import com.google.android.stardroid.ui.common.topBarWindowInsets
+
+/**
+ * The ⋮ button's full-screen page: the destinations and one-shot actions that don't earn
+ * permanent map pixels. Rows are ordered by when a user needs them — Help and Tutorial
+ * first, where a lost newcomer finds them without scrolling (Hannah's feedback, 2026-08).
+ *
+ * Location and Share stay map-anchored (the location sheet and the sky capture live on
+ * the map), so their callbacks hand a pending action back to the map before returning;
+ * everything else navigates onward from here.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OptionsScreen(
+    onBack: () -> Unit,
+    onOpenHelp: () -> Unit,
+    onOpenTutorial: () -> Unit,
+    onOpenSettings: () -> Unit,
+    onOpenLocation: () -> Unit,
+    onOpenGallery: () -> Unit,
+    onShareSky: (() -> Unit)?,
+    onOpenWhatsNew: () -> Unit,
+    onOpenCalibration: () -> Unit,
+) {
+    // No collapsing scroll behavior: with eight short rows the collapse range would offer
+    // scroll where there's nothing to scroll. The column still scrolls on overflow (small
+    // screens, landscape, large font scales).
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.more_button)) },
+                windowInsets = topBarWindowInsets(),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.settings_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 8.dp),
+        ) {
+            OptionsRow(R.drawable.ic_help, R.string.help_button, onOpenHelp)
+            OptionsRow(R.drawable.ic_tutorial, R.string.tutorial_button, onOpenTutorial)
+            OptionsRow(R.drawable.ic_settings, R.string.settings_button, onOpenSettings)
+            OptionsRow(R.drawable.ic_location, R.string.location_button, onOpenLocation)
+            OptionsRow(R.drawable.ic_gallery, R.string.gallery_button, onOpenGallery)
+            if (onShareSky != null) {
+                OptionsRow(R.drawable.ic_share, R.string.share_button, onShareSky)
+            }
+            OptionsRow(R.drawable.ic_whats_new, R.string.whats_new_button, onOpenWhatsNew)
+            OptionsRow(R.drawable.ic_calibrate, R.string.calibration_button, onOpenCalibration)
+        }
+    }
+}
+
+@Composable
+private fun OptionsRow(
+    @DrawableRes icon: Int,
+    @StringRes label: Int,
+    onClick: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(CircleShape)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 12.dp, vertical = 14.dp),
+    ) {
+        Icon(
+            painterResource(icon),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Text(stringResource(label), style = MaterialTheme.typography.bodyLarge)
+    }
+}

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsUi.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsUi.kt
@@ -84,7 +84,7 @@ fun SettingsScreen(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.settings_title)) },
-                windowInsets = topBarWindowInsets(stringResource(R.string.settings_title)),
+                windowInsets = topBarWindowInsets(),
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -208,7 +208,7 @@ fun SettingsScreen(
                     checked = state.enableAnalytics,
                     onCheckedChange = viewModel::setEnableAnalytics,
                 )
-                // Relocated from the ⋮ overflow sheet: a sensor/location readout is a
+                // Relocated from the ⋮ menu: a sensor/location readout is a
                 // support tool, not something most people need most of the time, and it
                 // was crowding out Help there (Hannah's feedback, 2026-08). "Settings →
                 // Diagnostics" stays an easy instruction to give in a support reply.

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/startup/StartupViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/startup/StartupViewModel.kt
@@ -67,7 +67,7 @@ class StartupViewModel(
 
     /**
      * The welcome pager came up on first run (v1's funnel start). Tutorial replays from the
-     * overflow sheet bypass these funnel callbacks entirely, so the D49 metrics stay first-run
+     * options page bypass these funnel callbacks entirely, so the D49 metrics stay first-run
      * only. A v1-history device also logs the one-off upgrade event here — this fires once per
      * arrival, whether or not the tour itself gets finished.
      */

--- a/stardroid-v2/app/src/main/res/values/strings.xml
+++ b/stardroid-v2/app/src/main/res/values/strings.xml
@@ -94,7 +94,7 @@
     <string name="layers_group_reference" translation_description="Layers-sheet group header for reference elements drawn over the sky (coordinate grid, horizon, ecliptic).">Reference</string>
     <string name="layers_group_display" translation_description="Layers-sheet group header for display settings that change how the sky is rendered rather than what is drawn.">Display</string>
     <string name="show_layers" translation_description="Accessibility description and label for the button opening the layer-visibility sheet, which holds the layers that do not fit on the rail plus display options.">More layers and options</string>
-    <string name="more_button" translation_description="Accessibility label and tooltip for the map-screen button (three vertical dots) opening the overflow menu of further destinations such as Gallery and Settings.">More options</string>
+    <string name="more_button" translation_description="Accessibility label and tooltip for the map-screen button (three vertical dots) opening the full-screen options page of further destinations such as Gallery and Settings.">More options</string>
     <string name="night_mode" translation_description="Label for the toggle switching the display to a dim red night-vision-preserving mode.">Night mode</string>
     <string name="switch_to_manual" translation_description="Tooltip and accessibility label for the button that switches the map from auto (sensor-driven) mode to manual (drag) mode.">Switch to manual mode</string>
     <string name="switch_to_auto" translation_description="Tooltip and accessibility label for the button that switches the map from manual (drag) mode to auto (sensor-driven) mode.">Switch to auto mode</string>
@@ -134,7 +134,7 @@
     <string name="ar_iso_slider" translation_description="Accessibility label for the temporary developer slider setting the camera\'s manual ISO sensitivity in through-camera mode.">Camera ISO</string>
     <string name="ar_shutter_slider_label" translation_description="Very short label for the temporary developer slider setting the camera\'s manual shutter (exposure) time in through-camera mode.">Shtr</string>
     <string name="ar_shutter_slider" translation_description="Accessibility label for the temporary developer slider setting the camera\'s manual shutter (exposure) time in through-camera mode.">Camera shutter time</string>
-    <string name="share_button" translation_description="Overflow-menu row that captures the current sky view as an image and opens the system share sheet.">Share the sky</string>
+    <string name="share_button" translation_description="Row on the options page (opened with the three-dots button) that captures the current sky view as an image and opens the system share sheet.">Share the sky</string>
     <string name="share_chooser_title" translation_description="Title of the system share sheet when sharing a captured sky image.">Share this sky</string>
     <string name="share_invitation" translation_description="Short invitation stamped on the footer of shared sky images, above the store link.">See what you\'re looking at — get Sky Map free</string>
     <string name="share_text" translation_description="Text accompanying a shared sky image in apps that accept both an image and text. %1$s is the app-store link.">See what you\'re looking at — get Sky Map free: %1$s</string>

--- a/stardroid-v2/docs/CONTRIBUTING-translations.md
+++ b/stardroid-v2/docs/CONTRIBUTING-translations.md
@@ -1,0 +1,89 @@
+# Contributing translations to Sky Map v2
+
+Thank you for improving Sky Map's translations! Translation PRs are very welcome — this
+guide covers what to translate, how to mark your work as human-reviewed, and how to
+submit it.
+
+> Sky Map v2's strings run through an AI translation pipeline (the `tm` CLI, configured
+> in `stardroid-v2/.tmconfig.toml`) that periodically retranslates stale or missing
+> content. A hand-written or hand-verified string must be flagged so the pipeline never
+> overwrites it — see [Marking your work as human-reviewed](#marking-your-work-as-human-reviewed).
+
+## Before you start
+
+- Accept the [Contributor License Agreement](../../CLA.md) when the bot prompts you on
+  your PR — required for all contributions, one time only.
+- Make your changes on a feature branch, and combine them into a **single commit**
+  before requesting review (see the repo's [CONTRIBUTING.md](../../CONTRIBUTING.md)).
+- Run `./gradlew check` from `stardroid-v2/` before opening the PR — it lints the
+  resource files as well as building.
+
+## What to translate
+
+Translate natural-language UI text: labels, dialog copy, help/what's-new content, and
+celestial object/type names where a language has an established term.
+
+**Leave these untouched:**
+
+- Names of people and organizations
+- URLs
+- Product names (`Sky Map`, `Android`)
+- Error codes, IDs, and other technical keys
+- Format placeholders (`%1$s`, `%s`, `%1$d`, etc.)
+- XML/HTML markup (`<blockquote>`, `<b>`, `<br/>`, `&lt;`/`&gt;` entities)
+- Catalog designations meant to stay canonical (`M31`, `NGC 224`)
+
+For celestial object and type names specifically: use the established name in your
+language as used in Wikipedia/scientific literature. If none exists, keep the English
+or catalog name rather than inventing a translation — see `.tmconfig.toml`'s `[app]`
+and `[locale_context]` tables for per-language conventions already documented for the
+automated pipeline (they apply to human translators too), and the shared glossary at
+[`translation_glossary.md`](../../translation_glossary.md).
+
+## Marking your work as human-reviewed
+
+How you mark a string as human-verified depends on which file you're editing. Only one
+of the two mechanisms below is discoverable by reading the file, so read both.
+
+### Android string resources (`values-*/strings.xml`, `whatsnew.xml`, `credits.xml`, `help.xml`, `eula.xml`)
+
+Add `tm_human="true"` directly on the `<string>` (or `<string-array>`/`<plurals>`)
+element:
+
+```xml
+<string name="calibration_heading_warning" tm_human="true">La bussola del tuo telefono richiede la tua attenzione!</string>
+```
+
+This is visible in the file itself and travels with the string in every future diff —
+no other step needed. For real examples, see any locale under
+`app/src/main/res/values-fr/`.
+
+### Catalog source data (`source-data/types.json`, `source-data/names/*.csv`, `source-data/info_cards/*`)
+
+These formats have **no in-file flag**. Human-verified status for them is tracked
+out-of-band in the `.tmstate.toml` sidecar at the `stardroid-v2/` module root, which is
+only ever written by the `tm` CLI — a contributor hand-editing the JSON/CSV directly
+currently has no way to flag their edit as human-verified, and nothing in the files
+tells them that sidecar exists.
+
+Until that gap is closed, the supported paths are:
+
+- If you have the `tm` CLI set up, run it against your edit so the state file records
+  your values as human-authored.
+  <!-- TODO(maintainer): replace with the exact supported invocation, verified against
+       the tm CLI — e.g. does `tm translate <locale> --source <source> -k <key> --force`
+       write the value *and* mark it human-translated? -->
+- If you don't, say so in your PR description (as [#985](https://github.com/sky-map-team/stardroid/pull/985)
+  did) and ask a maintainer to run it, or to hand-flag the affected keys, before merge.
+  **Don't assume a plain hand-edit to one of these files is protected** — without the
+  flag, a future `tm translate --include-stale` run may silently retranslate it.
+
+## Opening the PR
+
+- Note in the PR description what you changed and why (wording fixes, missing entries,
+  etc.) — see [#985](https://github.com/sky-map-team/stardroid/pull/985) for a good
+  example.
+- If you notice an issue with the **English source** while translating, mention it but
+  leave it out of the translation PR — file a separate issue or PR for the English text.
+- Keep PRs small and focused; a wording pass and a new-locale addition are better as
+  two PRs than one.

--- a/stardroid-v2/docs/README.md
+++ b/stardroid-v2/docs/README.md
@@ -22,7 +22,7 @@ the two ever drift.
 | [design/catalog-and-schema.md](design/catalog-and-schema.md) | `:core:catalog`, Room schema, build-time DB generation | slices 4a–4d, D32–D35 |
 | [design/layers-and-app.md](design/layers-and-app.md) | Layer system, ViewModel decomposition, app edges | slices 4d–23; **comets still to come** |
 | [design/screens-and-startup.md](design/screens-and-startup.md) | Supporting screens, startup routing, settings | slice 16, D48 |
-| [design/ux-polish.md](design/ux-polish.md) | Two hands-on feedback rounds: chrome, dialogs, time travel, snackbars, location map, meteor layer | slices 20–23, D52–D58, D60; **one loose end — the splash cross-fade** |
+| [design/ux-polish.md](design/ux-polish.md) | Two hands-on feedback rounds: chrome, dialogs, time travel, snackbars, location map, meteor layer | slices 20–23, D52–D58, D60; splash cross-fade landed |
 | [design/map-hud.md](design/map-hud.md) | The top-right map pointing readout — RA/Dec, Alt/Az, FOV, alignment correction | agreed D65, implemented D66 |
 | [design/camera-ar-mode.md](design/camera-ar-mode.md) | Through-camera (AR) mode, drag-to-align, share | D64, D67–D71 (flag-gated, D80) |
 | [design/color-scheme-proposal.md](design/color-scheme-proposal.md) | The "Deep Space / Star Gold" brand palette — rationale and before/after | accepted and implemented, D73 |
@@ -48,6 +48,7 @@ the two ever drift.
 | decisions.md | Running log of product/technical decisions and their rationale — the authority behind every status above |
 | [code-overview.md](code-overview.md) | Top-down tour of the codebase as built — module graph, build machinery, subsystem pointers, doc-health table |
 | [improvements-over-v1.md](improvements-over-v1.md) | The full at-launch feature surface (unflagged only) plus the net-new-vs-v1 highlights drawn from it — the source for help text, store copy, screenshots, and release notes |
+| [CONTRIBUTING-translations.md](CONTRIBUTING-translations.md) | Contributor guide for translation PRs — scope, the `tm_human` / `.tmstate.toml` human-review marking, PR mechanics |
 | [info-card-coverage.md](info-card-coverage.md) | Which labelled objects still lack info cards, why that blocks tap-to-identify, and how to write new ones |
 | [design/sensor-correction-model.md](design/sensor-correction-model.md) | Sensor error physics and why drag-to-align's az/alt correction matches them |
 | [design/ephemeris-accuracy.md](design/ephemeris-accuracy.md) §1–2 | Coordinate-frame audit and the residual error budget (precession fix, D84) |
@@ -184,7 +185,7 @@ rewrite brief in [../README.md](../README.md).
   snackbars, the location map (D52/D53), plus the topocentric Moon (D54) and the
   sun/moon-disc-size stance (D55).
 - **Slice 22** — the three-zone map chrome: layer rail, action cluster, overflow sheet
-  (D56/D57).
+  (D56/D57); the sheet was later replaced by the full-screen ⋮ options page.
 - **Slice 23** — the meteor-shower layer, closing D37's last computed-layer deferral (D58).
 - **Slice 24** — Hilt replaces the hand-wired `AppGraph` for the singleton graph (D59).
 - **Polish and identity** — second hands-on feedback round (D60), the warm welcome rebuilt as
@@ -225,7 +226,6 @@ The complete list of things these docs describe that do **not** exist in the cod
   ([design/render-gles3.md](design/render-gles3.md)).
 - Widgets & notifications phase 4 — conjunctions, moon phases, rise alerts
   ([design/widgets-and-notifications.md](design/widgets-and-notifications.md)).
-- The splash-to-sky cross-fade ([design/ux-polish.md](design/ux-polish.md) item 2, step 2).
 
 For the user-facing view of what v2 adds over v1, the full at-launch feature surface, and
 which features are built but unannounced, see

--- a/stardroid-v2/docs/code-overview.md
+++ b/stardroid-v2/docs/code-overview.md
@@ -282,7 +282,8 @@ accel+magnetometer fusion fallback and speed/damping settings; `SensorAccuracyMo
 calibration prompts.
 
 `MapChrome` implements the three-zone chrome (D56/D57): layer rail (with `ifroom` overflow
-semantics), action cluster, overflow sheet — all tagged with `ChromeTourTarget` so the warm
+semantics), action cluster, and the ⋮ button that opens the full-screen options page
+(`ui/options/OptionsScreen.kt`) — all tagged with `ChromeTourTarget` so the warm
 welcome can spotlight the *real* chrome with canned state.
 
 ### Supporting screens

--- a/stardroid-v2/docs/design/camera-ar-mode.md
+++ b/stardroid-v2/docs/design/camera-ar-mode.md
@@ -5,8 +5,8 @@ round were resolved on 2026-07-26 (see Decisions at the end; recorded as D64 in
 `decisions.md`); slice 1 (the camera underlay, plus D69's dev exposure controls), slice 2
 (drag-to-align), slice 3 (map-only Share), and slice 4 (the camera share layouts) are
 implemented. This expands the two stubs already reserved in `ux-polish.md`: the
-"through-camera / AR mode" Display toggle (Layers sheet) and the "Share" action (overflow
-sheet).
+"through-camera / AR mode" Display toggle (Layers sheet) and the "Share" action (options
+page).
 
 An interactive mockup accompanies this doc: open `mockups/camera-ar-mode.html` in a browser.
 It simulates the stacked-plane compositing model (Part 1, Option A) with a misaligned sky to
@@ -233,7 +233,7 @@ Deferred to its own design pass once Part 1 exists, but the exploration so far:
   Play/F-Droid link (QR?) — assets in `assets/branding/` (All Rights Reserved, per the
   split-license rules). `EXTRA_TEXT` carries the invitation + store link for apps that
   take text; the image goes via `FileProvider` + `ACTION_SEND` chooser.
-- **UX home**: Share row in the Zone C overflow sheet (already reserved in `ux-polish.md`),
+- **UX home**: Share row on the Zone C options page (already reserved in `ux-polish.md`),
   plus likely a transient in-AR shutter affordance, since "photograph the moment" is most
   compelling while the camera layer is live. Layout choice (overlay vs side-by-side) at
   share time — a small two-option sheet with thumbnails.

--- a/stardroid-v2/docs/design/map-hud.md
+++ b/stardroid-v2/docs/design/map-hud.md
@@ -58,7 +58,9 @@ outline, same corner radius family), right-aligned text in tabular figures
 `labelSmall`-ish caps. Day mode: dim neutral text with the theme primary reserved for the
 correction row; night mode: everything through the red scheme like the rest of the chrome.
 Target width ≈ 120–140 dp; four rows ≈ 88 dp tall — comparable footprint to the
-time-travel player, but in a corner.
+time-travel player, but in a corner. As built, the card holds a fixed width (176 dp —
+room for the correction row's widest value plus its reset button), so ticking values and
+rows appearing never resize it.
 
 ## Data plumbing
 

--- a/stardroid-v2/docs/design/screens-and-startup.md
+++ b/stardroid-v2/docs/design/screens-and-startup.md
@@ -12,15 +12,15 @@ Single-activity Navigation-Compose graph:
 
 ```
 map (start)                      settings          gallery
-  ├─ dialogs/sheets owned by      diagnostics       locationManagement
-  │  map features (search         compassCalibration
-  │  results, object info,        onboarding (conditional start, see below)
-  │  time travel, help, …)
+  ├─ dialogs/sheets owned by      options           locationManagement
+  │  map features (search         diagnostics
+  │  results, object info,        compassCalibration
+  │  time travel, layers, …)      onboarding (conditional start, see below)
 ```
 
 *Status (D48)*: implemented. Map (or the warm welcome) is the start destination; settings,
-gallery, diagnostics, and calibration are destinations; dialogs/sheets (including help and
-the D43 location sheet) stay map-owned.
+options, gallery, diagnostics, and calibration are destinations; dialogs/sheets (notably the
+D43 location sheet) stay map-owned.
 
 ## Startup routing (port of `StartupRouter`)
 

--- a/stardroid-v2/docs/design/time-travel.md
+++ b/stardroid-v2/docs/design/time-travel.md
@@ -485,7 +485,7 @@ time plus something to look at. That is why the scrubber does not subsume it.
 
 What changes:
 
-- **The dialog becomes a sheet**, sibling to the Layers and ⋮ sheets (D57), opened by
+- **The dialog becomes a sheet**, sibling to the Layers sheet (D57), opened by
   **tapping the date readout**. The readout is the affordance, so no button is spent on it
   and presets cost no permanent pixels.
 - **Grouped by how you reach for them** — *Tonight* (computed, relative to where the clock

--- a/stardroid-v2/docs/design/ux-polish.md
+++ b/stardroid-v2/docs/design/ux-polish.md
@@ -63,27 +63,38 @@ The four actions used *while looking at the sky*, as icon buttons, plus overflow
   making all four filled-primary would recreate the jumble in miniature.
 - **Time travel**, **Night mode** (moon ↔ sun glyph swap), **Auto/Manual**
   (compass ↔ hand glyph swap) — `FilledTonalIconButton`s.
-- **⋮ More** — a plain `IconButton` opening the overflow sheet. Three-step visual
-  hierarchy: filled → tonal → bare.
+- **⋮ More** — a `FilledTonalIconButton` opening the options page. Three-step visual
+  hierarchy: filled → tonal → bare. (It was a bare `IconButton` in the sheet days; it
+  earned the promotion in slice 22 — ⋮ is the only route to Help, Settings and the other
+  secondary destinations, and as an unfilled glyph on the starfield it read as decoration.)
 
 In **landscape** the cluster moves to the right edge as a bottom-anchored column (roughly
 where v1's right panel sat); the rail stays on the left. Both edges use the existing
 safe-drawing/cutout padding.
 
-### Zone C — the overflow sheet (⋮)
+### Zone C — the options page (⋮)
 
-A `ModalBottomSheet` of icon + label `ListItem` rows: Gallery, Location, Diagnostics,
-Calibrate, Help, Settings. These are destinations and one-shot actions — things that are
-*not* sky-drawing controls — so they don't earn permanent pixels. A future **Share** action
-belongs here too.
+As shipped, ⋮ opens a **full-screen options page** (a Navigation destination like Settings
+or Help, `ui/options/OptionsScreen.kt`) rather than the originally designed bottom sheet —
+a page of icon + label rows: Help, Tutorial, Settings, Location, Gallery, (Share, behind
+the SHARE_SKY experiment), What's New, Calibration. These are destinations and one-shot
+actions — things that are *not* sky-drawing controls — so they don't earn permanent map
+pixels. Ordered by when a user needs them: Help and Tutorial sit on top, where a lost
+newcomer finds them without scrolling (Hannah's feedback, 2026-08). Diagnostics lives in
+Settings → Advanced.
 
-### The Layers sheet, and how the two sheets relate
+Location and Share stay map-anchored (the location sheet and the sky capture live on the
+map), so their rows hand a pending action through the nav back stack's saved state and pop
+home; the map consumes it on return. Everything else navigates onward from the page, so
+e.g. Settings' back button returns to the options page.
 
-The two sheets are siblings (same anatomy, both modal over the map) with distinct jobs:
-the ⋮ sheet **navigates away** from the map; the Layers sheet **configures** what the map
-draws while you stay put. Neither embeds the other. The rail is not a third concept — it is
-a shortcut surface showing the primary subset of the Layers sheet, which is the canonical,
-unbounded list.
+### The Layers sheet, and how the two surfaces relate
+
+The Layers sheet and the options page are siblings with distinct jobs: the ⋮ page
+**navigates away** from the map; the Layers sheet **configures** what the map draws while
+you stay put. Neither embeds the other. The rail is not a third concept — it is a shortcut
+surface showing the primary subset of the Layers sheet, which is the canonical, unbounded
+list.
 
 The Layers sheet replaces the current "boring list of check boxes": the same vector icons,
 labels, and M3 `Switch`es, grouped to mirror the rail:
@@ -117,20 +128,23 @@ truth: the existing layer-visibility preferences).
   rail-to-sheet alternatives evaluated, and the pinnable-rail future) was reviewed on
   2026-07-11; the agreed variant is the one described here.
 
-## 2. Splash screen — ⚠️ step 1 done, step 2 still proposed
+## 2. Splash screen — ✅ done (both steps)
 
 > On first open the splash screen is plain and generic
 
-v2 uses the AndroidX `SplashScreen` API. Two-step proposal:
+v2 uses the AndroidX `SplashScreen` API. Two steps:
 
 1. **Quick — ✅ done:** a branded `windowSplashScreenAnimatedIcon` (the Sky Map logo) on
    `Theme.SkyMap.Starting`, over `splash_navy` from the brand palette (D73); assets live in
    `app/src/main/res/` (All Rights Reserved per the split-license rules).
-2. **Richer — proposed, not built:** v1 faded a full-bleed night-sky photograph
-   (`stardroid_big_image`) into the
-   app. The modern equivalent: keep the system splash minimal, then cross-fade the GL sky in
-   from black over ~1 s on first composition (the renderer already starts black), which
-   reads as "the sky reveals itself" rather than a static plate. No extra asset needed.
+2. **The sky reveals itself — ✅ done:** v1 faded a full-bleed night-sky photograph
+   (`stardroid_big_image`) into the app; v2 keeps the system splash minimal and cross-fades
+   the GL sky in from the window background over ~1 s on first composition. `GLSkyRenderer`
+   grew a one-shot `onFirstFrame` hook (GL thread, fired at the end of the first frame that
+   draws an actual sky); `MainActivity` starts the surface at alpha 0 and animates it to 1
+   when the hook fires, so the sky reads as revealing itself rather than popping in.
+   Rotations and process restores skip the reveal — the surface just starts visible. No
+   extra asset needed.
 
 ## 3. EULA / What's New / Help dialogs — ✅ done (slice 21, D53)
 

--- a/stardroid-v2/docs/improvements-over-v1.md
+++ b/stardroid-v2/docs/improvements-over-v1.md
@@ -123,7 +123,7 @@ bundled DB (D63). **Use 3,186 in copy** — the remainder is seed data for a fut
   SharedPreferences while v2 reads DataStore, and v1's preferences are deliberately not
   migrated (D1), so the pager shows for everyone (D80). Its experiment flag was retired at
   launch — this is a fully shipped feature, safe for help text and store copy.
-- The tour is replayable any time via overflow → Tutorial
+- The tour is replayable any time via the ⋮ options page → Tutorial
 - Settings in five sections: Controls, Appearance, Sensors, Notifications, Other
 - Analytics opt-out on gms; the F-Droid build has no analytics at all
 - 31 UI locales — 28 core languages fully translated including Help, plus 3 partial/legacy
@@ -205,7 +205,7 @@ or [the full surface](#the-full-at-launch-feature-surface) above with a real
 | Feature | Flag | Decisions |
 |---|---|---|
 | Through-camera (AR) mode, with drag-to-align | `camera_ar_enabled` | D64, D67, D68 |
-| Share the sky (overflow row + in-AR shutter, camera composite layouts) | `share_sky_enabled` | D70, D71 |
+| Share the sky (options-page row + in-AR shutter, camera composite layouts) | `share_sky_enabled` | D70, D71 |
 | Moon-phase home-screen widget | `moon_widget_enabled` | D75 |
 | Tonight's-Sky and Countdown widgets | `tonight_widget_enabled` | D76 |
 | Shower-peak and tonight-digest notifications | `notifications_enabled` | D77 |

--- a/stardroid-v2/render/gles1/src/main/kotlin/com/google/android/stardroid/render/gles1/GLSkyRenderer.kt
+++ b/stardroid-v2/render/gles1/src/main/kotlin/com/google/android/stardroid/render/gles1/GLSkyRenderer.kt
@@ -52,11 +52,15 @@ import javax.microedition.khronos.opengles.GL11
  * @param onRendererInfo invoked on the GL thread once per surface creation with what the GPU
  *   and driver turned out to be (diagnostics only — see [RendererInfo]). Called again after
  *   EGL context loss, since the replacement context may not be the same implementation.
+ * @param onFirstFrame invoked on the GL thread once, at the end of the first [onDrawFrame]
+ *   that draws actual sky content (the gradient dome, or at least one submitted layer scene) —
+ *   a camera-only frame can precede any layer submit. Never re-armed on EGL context loss.
  */
 class GLSkyRenderer(
     private val density: Float,
     private val imageLoader: (ImageRef) -> Bitmap?,
     private val onRendererInfo: (RendererInfo) -> Unit = {},
+    private val onFirstFrame: () -> Unit = {},
 ) : GLSurfaceView.Renderer, SkyRenderer {
     @Volatile private var camera: SkyCamera? = null
 
@@ -64,6 +68,9 @@ class GLSkyRenderer(
 
     @Volatile private var viewport: Viewport? = null
     private val scenes = ConcurrentHashMap<LayerId, LayerScene>()
+
+    // GL-thread-only: guards the one-shot [onFirstFrame] callback.
+    private var firstFrameReported = false
 
     /** Bumped after every [scenes] mutation so the GL thread knows to rebuild [drawOrder]. */
     private val scenesVersion = AtomicLong()
@@ -317,6 +324,18 @@ class GLSkyRenderer(
             // 4. Labels
             val labelGpu = cachedLabel(gl, layerId, scene, state, viewport.density)
             LabelDrawer.draw(gl, labelGpu, camera, projection, viewport, state)
+        }
+
+        // First frame with real content: a camera-only render can beat the first layer
+        // submit, and revealing that frame would fade the splash into a black surface.
+        // First frame with real content: a camera-only render can beat the first layer
+        // submit, and revealing that frame would fade the splash into a black surface.
+        val hasSkyContent =
+            drawOrder.isNotEmpty() ||
+                (gradient != null && !state.nightMode && !state.transparentBackground)
+        if (!firstFrameReported && hasSkyContent) {
+            firstFrameReported = true
+            onFirstFrame()
         }
     }
 


### PR DESCRIPTION
Hello! 

Just a batch of small, focused improvements to stardroid-v2 (as 1 squashed commit):

- The ⋮ button now opens a full-screen options page (replacing the bottom sheet). Same rows, ordered so Help and Tutorial sit where a lost newcomer finds them 🙂 Every full-screen destination's top bar is now consistent too. title beside the back arrow, identical insets everywhere (the old per-title cutout refinement made arrow heights differ between screens and sometime cut by screen border)

<img width="919" height="2048" alt="image" src="https://github.com/user-attachments/assets/4429e5aa-c8e4-42d9-aa21-b9a4606a2d5a" />

- Splash -> on cold start the sky fades in over ~1 s once the renderer draws its first frame; recreations start visible (ux-polish.md item 2 step 2)

- Map HUD gets a constant width (176 dp): appearing correction rows and ticking values no longer resize the card every second (they used to do that which kinda annoyed me haha 😅 )

What did i test ? 
- ./gradlew check (unit tests, ktlint, Konsist) green; CI will run the instrumented suite.
- Verified on device: options page navigation/back stack, Location/Share pending actions, splash fade (cold start vs rotation), HUD width, top-bar placement, chrome tour

No new strings or assets (only translator-facing `translation_description` text changed)
Also, this PR has been made with the help of OpenCode (GLM 5.3)

Looking forward to a review / opinion :) 
Lot of love to SkyMap and its devs