### PR TITLE
Guard search catalog queries against crashing on exception

### DIFF
--- a/stardroid-v2/app/build.gradle.kts
+++ b/stardroid-v2/app/build.gradle.kts
@@ -96,6 +96,14 @@ android {
         // string per locale (356 on the first salvage import) and buries real lint findings.
         warning += "MissingTranslation"
     }
+
+    testOptions {
+        // JVM unit tests run without Robolectric, so android.util.Log (and other unmocked
+        // android.jar stubs) throw at call time instead of no-oping (issue #1003 PR review:
+        // SearchViewModel's Log.e in a catch block was silently swallowing the exception it
+        // was meant to log, since the RuntimeException it threw escaped the catch entirely).
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/analytics/AnalyticsEvents.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/analytics/AnalyticsEvents.kt
@@ -85,6 +85,13 @@ object AnalyticsEvents {
     const val SEARCH_TERM = "search_term"
     const val SEARCH_SUCCESS = "search_success"
     const val SEARCH_FAILED_EVENT = "search_failed_ev"
+
+    // A caught exception from the catalog query itself (issue #1003), distinct from
+    // [SEARCH_FAILED_EVENT]'s "the query legitimately matched nothing". Same rationale as the
+    // satellite-fetch events above: no per-device stack trace, so the aggregate count by
+    // [SEARCH_QUERY_ERROR_TYPE] is what would surface a systemic bug in production.
+    const val SEARCH_QUERY_ERROR_EVENT = "search_query_error_ev"
+    const val SEARCH_QUERY_ERROR_TYPE = "error_type"
     const val OBJECT_LOCKED_EVENT = "object_locked_ev"
     const val OBJECT_LOCKED_NAME = "object_name"
     const val OBJECT_LOCKED_MODE = "mode"

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchViewModel.kt
@@ -9,6 +9,7 @@
 
 package com.google.android.stardroid.ui.search
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.stardroid.analytics.Analytics
@@ -31,6 +32,7 @@ import com.google.android.stardroid.math.RaDec
 import com.google.android.stardroid.math.Vector3
 import com.google.android.stardroid.render.api.LayerId
 import com.google.android.stardroid.settings.Settings
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -114,7 +116,7 @@ class SearchViewModel(
                 if (q.isBlank()) {
                     emptyList()
                 } else {
-                    catalog().searchByPrefix(q.trim(), spec, SUGGESTION_LIMIT)
+                    searchByPrefixSafely(q.trim(), spec)
                 }
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
@@ -172,7 +174,7 @@ class SearchViewModel(
             return
         }
         viewModelScope.launch {
-            val hits = catalog().searchByPrefix(q, locale.value, SUGGESTION_LIMIT)
+            val hits = searchByPrefixSafely(q, locale.value)
             val chosen =
                 hits.firstOrNull { it.name.equals(q, ignoreCase = true) } ?: hits.singleOrNull()
             if (chosen != null) {
@@ -213,6 +215,35 @@ class SearchViewModel(
         _target.value = target
         setQuery("")
     }
+
+    /**
+     * The catalog query is a Room/SQLite call we do not fully control (issue #1003: reports
+     * from two unrelated OEMs crashing on ordinary queries like "sun"/"moon", cause unconfirmed
+     * — possibly a third-party IME/Compose interop bug upstream of this call, possibly a Room
+     * failure). Whichever it is, a failed lookup should degrade to "no results" rather than take
+     * the app down. [CancellationException] is rethrown so `mapLatest` can still cancel a
+     * superseded query.
+     */
+    private suspend fun searchByPrefixSafely(
+        query: String,
+        spec: LocaleSpec,
+    ): List<SearchHit> =
+        try {
+            catalog().searchByPrefix(query, spec, SUGGESTION_LIMIT)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // No Crashlytics wired up (D92's satellite-fetch events are the closest precedent):
+            // this aggregate event, not a stack trace, is how we'd notice a systemic bug is loose
+            // in production. `adb logcat` still has the full exception for anyone who can repro.
+            Log.e(TAG, "Search query failed", e)
+            val errorType = e::class.simpleName ?: "unknown"
+            analytics.trackEvent(
+                AnalyticsEvents.SEARCH_QUERY_ERROR_EVENT,
+                mapOf(AnalyticsEvents.SEARCH_QUERY_ERROR_TYPE to errorType),
+            )
+            emptyList()
+        }
 
     private fun searchFailed(term: String) {
         analytics.trackEvent(
@@ -262,6 +293,8 @@ class SearchViewModel(
         ephemeris.topocentricPosition(body, now(), location()).toGeocentricVector()
 
     companion object {
+        private const val TAG = "SearchViewModel"
+
         /** Ranked-list length; v1's suggestion cursor was unbounded, the FTS query is not. */
         private const val SUGGESTION_LIMIT = 20
 

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/search/SearchViewModelTest.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/search/SearchViewModelTest.kt
@@ -66,6 +66,9 @@ class SearchViewModelTest {
         /** Overrides [hits] when set, so a test can vary the results by locale. */
         var hitsFor: ((LocaleSpec) -> List<SearchHit>)? = null
 
+        /** Set to simulate a Room/SQLite failure (issue #1003) instead of returning [hits]. */
+        var throwOnSearch: (() -> Throwable)? = null
+
         override fun layerObjects(
             kind: LayerKind,
             locale: LocaleSpec,
@@ -83,6 +86,7 @@ class SearchViewModelTest {
         ): List<SearchHit> {
             lastPrefix = prefix
             searchCount++
+            throwOnSearch?.let { throw it() }
             return (hitsFor?.invoke(locale) ?: hits)
                 .filter { it.name.startsWith(prefix, ignoreCase = true) }
         }
@@ -246,6 +250,46 @@ class SearchViewModelTest {
                 .containsExactly(AnalyticsEvents.SEARCH_FAILED_EVENT)
             assertThat(analytics.events[0].params)
                 .containsEntry(AnalyticsEvents.SEARCH_TERM, "xyzzy")
+        }
+
+    @Test
+    fun `a catalog exception while typing is caught, not thrown`() =
+        testScope.runCurrentTest {
+            repository.throwOnSearch = { IllegalStateException("boom") }
+            val vm = viewModel()
+            backgroundScope.launch { vm.suggestions.collect {} }
+            runCurrent()
+
+            vm.setQuery("sir")
+            advanceTimeBy(debounceSettle)
+            runCurrent()
+
+            assertThat(vm.suggestions.value).isEmpty()
+            assertThat(analytics.eventNames())
+                .containsExactly(AnalyticsEvents.SEARCH_QUERY_ERROR_EVENT)
+            assertThat(analytics.events[0].params)
+                .containsEntry(AnalyticsEvents.SEARCH_QUERY_ERROR_TYPE, "IllegalStateException")
+        }
+
+    @Test
+    fun `a catalog exception on submit reports no results instead of crashing`() =
+        testScope.runCurrentTest {
+            repository.throwOnSearch = { IllegalStateException("boom") }
+            val vm = viewModel()
+            vm.setQuery("sir")
+            vm.submit()
+            runCurrent()
+
+            assertThat(vm.target.value).isNull()
+            assertThat(vm.noResults.value).isTrue()
+            // The caught exception yields an empty hit list, which submit() then reports as an
+            // ordinary no-results failure on top of the error event — the user sees one dialog,
+            // not a crash, but two signals reach analytics.
+            assertThat(analytics.eventNames())
+                .containsExactly(
+                    AnalyticsEvents.SEARCH_QUERY_ERROR_EVENT,
+                    AnalyticsEvents.SEARCH_FAILED_EVENT,
+                ).inOrder()
         }
 
     @Test


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Wraps the Room/SQLite `searchByPrefix` call used by both as-you-type suggestions and submit() in a try/catch, so a failing query degrades to "no results" instead of crashing the app.

Fixes #1003.

Adds a new `search_query_error_ev` analytics event (exception class name only) so a systemic bug would still show up in aggregate GA4 counts, since this app has no Crashlytics/non-fatal reporting wired up. The full exception is still logged via Log.e for local repro.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Wrap catalog prefix searches in try-catch

- Return empty results when queries fail

- Log search exceptions and track analytics

- Add unit tests for query exceptions


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Search Query Input"] -- "Trigger search" --> B["searchByPrefixSafely"]
    B -- "Success" --> C["Return Search Results"]
    B -- "Exception" --> D["Log error and track analytics"]
    D -- "Fallback" --> E["Return empty list"]
    B -- "Cancellation" --> F["Rethrow CancellationException"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Analytics</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AnalyticsEvents.kt</strong><dd><code>Add analytics event constants for search query errors</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/analytics/AnalyticsEvents.kt

<ul><li>Add <code>SEARCH_QUERY_ERROR_EVENT</code> constant for tracking caught catalog <br>query exceptions<br> <li> Add <code>SEARCH_QUERY_ERROR_TYPE</code> parameter key for logging exception types</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1005/files#diff-439f7af7cbec4db6aef8ce121aa5358878d8d666f317e6269a05b7f21bee22df">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SearchViewModel.kt</strong><dd><code>Safeguard search catalog queries against unexpected exceptions</code></dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchViewModel.kt

<ul><li>Add <code>searchByPrefixSafely</code> to safely execute catalog queries<br> <li> Rethrow <code>CancellationException</code> to preserve coroutine cancellation <br>semantics<br> <li> Catch generic exceptions, log to Logcat, report error analytics, and <br>return an empty list<br> <li> Route suggestion generation and search submission through <br><code>searchByPrefixSafely</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1005/files#diff-9baf31d7c9a7291b6870f9ea3afeac968771d3c7c73d095c718c13450ad59dd9">+35/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SearchViewModelTest.kt</strong><dd><code>Add unit tests for search query failure handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/ui/search/SearchViewModelTest.kt

<ul><li>Add <code>throwOnSearch</code> configuration to test catalog repository<br> <li> Add test verifying exceptions during search typing are caught and <br>reported to analytics<br> <li> Add test verifying exceptions during submit degrade to empty results <br>without crashing</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1005/files#diff-d8c5d559ed9da4ee8e2d2745ebc29ed164c54ef107bb7331f58fc2591350e46a">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

