### PR TITLE
v2: add optional smoothing for the fused rotation-vector sensor path

### DIFF
--- a/stardroid-v2/app/build.gradle.kts
+++ b/stardroid-v2/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     namespace = "com.google.android.stardroid"
     defaultConfig {
         applicationId = "com.google.android.stardroid"
-        versionCode = 1729
+        versionCode = 1730
         versionName = "2.0.2:Apollo"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // D95: CI passes -PskipGlBenchmarks=true, which the D19 perf gate reads to skip

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/di/AppModule.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/di/AppModule.kt
@@ -197,6 +197,7 @@ object AppModule {
                 settings.sensorSpeed,
                 settings.sensorDamping,
                 settings.reverseMagneticZ,
+                settings.rotationSmoothing,
                 ::SensorConfig,
             )
         val delegate =

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/di/AppModule.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/di/AppModule.kt
@@ -34,6 +34,8 @@ import com.google.android.stardroid.sensors.SensorManagerStatusSource
 import com.google.android.stardroid.sensors.SensorOrientationSource
 import com.google.android.stardroid.sensors.SensorStatusSource
 import com.google.android.stardroid.settings.DataStoreSettings
+import com.google.android.stardroid.settings.SensorDamping
+import com.google.android.stardroid.settings.SensorSpeed
 import com.google.android.stardroid.settings.Settings
 import com.google.android.stardroid.startup.DataStoreStartupState
 import com.google.android.stardroid.startup.ExperimentConfig
@@ -58,6 +60,14 @@ private val Context.settingsDataStore by preferencesDataStore(name = "settings")
 // v1 `ApplicationConstants.READ_TOS_PREF_VERSION`: set once v1's EULA is accepted, so its
 // presence means this device ran v1. Read-only, detection-only — never written from v2.
 private const val V1_READ_TOS_PREF_KEY = "read_tos_version"
+
+/** The legacy (non-gyro) sensor path's settings, grouped for a typed [combine]. */
+private data class LegacyPathSettings(
+    val disableGyro: Boolean,
+    val sensorSpeed: SensorSpeed,
+    val sensorDamping: SensorDamping,
+    val reverseMagneticZ: Boolean,
+)
 
 /**
  * The app's singleton object graph, moved verbatim from the hand-wired `AppGraph` when Hilt
@@ -191,15 +201,32 @@ object AppModule {
         settings: Settings,
         displayRotation: DisplayRotationBus,
     ): OrientationSource {
-        val sensorConfigs =
+        // Nested because SensorConfig now has 6 fields — past combine's 5-flow typed overload,
+        // so the legacy-path settings are grouped first (see SettingsViewModel for the same
+        // pattern, adopted after PR #1006 review flagged the array-cast alternative as fragile).
+        val legacyPathSettings =
             combine(
                 settings.disableGyro,
                 settings.sensorSpeed,
                 settings.sensorDamping,
                 settings.reverseMagneticZ,
-                settings.rotationSmoothing,
-                ::SensorConfig,
+                ::LegacyPathSettings,
             )
+        val sensorConfigs =
+            combine(
+                legacyPathSettings,
+                settings.rotationLowPass,
+                settings.rotationDeadband,
+            ) { legacy, rotationLowPass, rotationDeadband ->
+                SensorConfig(
+                    disableGyro = legacy.disableGyro,
+                    speed = legacy.sensorSpeed,
+                    damping = legacy.sensorDamping,
+                    reverseMagneticZ = legacy.reverseMagneticZ,
+                    rotationLowPass = rotationLowPass,
+                    rotationDeadband = rotationDeadband,
+                )
+            }
         val delegate =
             SensorOrientationSource(
                 application.getSystemService(SensorManager::class.java),

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmoother.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmoother.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Penterakt LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.google.android.stardroid.sensors
+
+import com.google.android.stardroid.settings.RotationSmoothing
+import kotlin.math.abs
+import kotlin.math.acos
+import kotlin.math.min
+import kotlin.math.sin
+
+/**
+ * Spherical-linear-interpolation smoothing of the fused rotation-vector quaternion (issues
+ * [#963](https://github.com/sky-map-team/stardroid/issues/963) /
+ * [#1001](https://github.com/sky-map-team/stardroid/issues/1001)): some phones' `TYPE_ROTATION_VECTOR`
+ * fusion is noisy enough to make labels hard to read even holding the phone still. Operates on
+ * the raw quaternion — `TYPE_ROTATION_VECTOR`'s `event.values` already *are* one — rather than
+ * the derived rotation matrix, since SLERP is the geometrically correct way to interpolate along
+ * the rotation manifold.
+ *
+ * Each sample moves the smoothed quaternion a fraction [alpha] of the way toward the raw sample
+ * (lower = more smoothing, more lag), except samples within [deadbandRadians] of the current
+ * smoothed value, which are ignored outright — the "hold steady through micro-movements" half of
+ * the fix.
+ */
+class QuaternionSlerpSmoother(private val alpha: Float, private val deadbandRadians: Float) {
+    private var current: FloatArray? = null
+
+    /** [raw] is a unit quaternion as `(x, y, z, w)`. Returns the smoothed quaternion, same form. */
+    fun update(raw: FloatArray): FloatArray {
+        val prev = current
+        if (prev == null) {
+            // Start at the first sample rather than decaying in from zero — see
+            // ExponentiallyWeightedSmoother for the same reasoning.
+            current = raw.copyOf()
+            return raw
+        }
+
+        // Quaternions double-cover rotations: q and -q represent the same rotation, but SLERPing
+        // toward the "wrong" sign spins the long way around. Flip raw if it's closer to -prev.
+        val dot = dot(prev, raw)
+        val target = if (dot < 0f) negate(raw) else raw
+        val angle = 2f * acos(min(1f, abs(dot)))
+        if (angle < deadbandRadians) return prev
+
+        val smoothed = slerp(prev, target, alpha)
+        current = smoothed
+        return smoothed
+    }
+
+    companion object {
+        private fun dot(
+            a: FloatArray,
+            b: FloatArray,
+        ): Float = a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3]
+
+        private fun negate(q: FloatArray) = floatArrayOf(-q[0], -q[1], -q[2], -q[3])
+
+        /** Spherical linear interpolation from [from] toward [to] by fraction [t], assuming [to]. */
+        private fun slerp(
+            from: FloatArray,
+            to: FloatArray,
+            t: Float,
+        ): FloatArray {
+            val cosHalfTheta = min(1f, abs(dot(from, to)))
+            // Nearly identical inputs: linear interpolation avoids a division by ~0 in the
+            // sin(theta) denominator below and is indistinguishable from SLERP at this scale.
+            if (cosHalfTheta > 0.9995f) {
+                val result = FloatArray(4) { from[it] + (to[it] - from[it]) * t }
+                return normalize(result)
+            }
+            val halfTheta = acos(cosHalfTheta)
+            val sinHalfTheta = sin(halfTheta)
+            val ratioFrom = sin((1 - t) * halfTheta) / sinHalfTheta
+            val ratioTo = sin(t * halfTheta) / sinHalfTheta
+            return FloatArray(4) { from[it] * ratioFrom + to[it] * ratioTo }
+        }
+
+        private fun normalize(q: FloatArray): FloatArray {
+            val length = kotlin.math.sqrt(dot(q, q))
+            return FloatArray(4) { q[it] / length }
+        }
+
+        /** v1-style ladder: OFF disables smoothing entirely; higher levels damp harder. */
+        internal fun alphaAndDeadbandRadiansFor(smoothing: RotationSmoothing): Pair<Float, Float> =
+            when (smoothing) {
+                RotationSmoothing.OFF -> 1f to 0f
+                RotationSmoothing.LOW -> 0.5f to Math.toRadians(0.15).toFloat()
+                RotationSmoothing.MEDIUM -> 0.3f to Math.toRadians(0.3).toFloat()
+                RotationSmoothing.HIGH -> 0.15f to Math.toRadians(0.5).toFloat()
+            }
+    }
+}

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmoother.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmoother.kt
@@ -37,7 +37,10 @@ class QuaternionSlerpSmoother(private val alpha: Float, private val deadbandRadi
         val prev = current
         if (prev == null) {
             // Start at the first sample rather than decaying in from zero — see
-            // ExponentiallyWeightedSmoother for the same reasoning.
+            // ExponentiallyWeightedSmoother for the same reasoning. Returning the caller's own
+            // [raw] array (rather than a copy) is only safe because the caller consumes it
+            // synchronously before the next event can mutate the shared scratch buffer behind
+            // it — don't buffer/retain this return value across events.
             current = raw.copyOf()
             return raw
         }

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmoother.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmoother.kt
@@ -9,7 +9,7 @@
 
 package com.google.android.stardroid.sensors
 
-import com.google.android.stardroid.settings.RotationSmoothing
+import com.google.android.stardroid.settings.RotationSmoothingLevel
 import kotlin.math.abs
 import kotlin.math.acos
 import kotlin.math.min
@@ -87,13 +87,25 @@ class QuaternionSlerpSmoother(private val alpha: Float, private val deadbandRadi
             return FloatArray(4) { q[it] / length }
         }
 
-        /** v1-style ladder: OFF disables smoothing entirely; higher levels damp harder. */
-        internal fun alphaAndDeadbandRadiansFor(smoothing: RotationSmoothing): Pair<Float, Float> =
-            when (smoothing) {
-                RotationSmoothing.OFF -> 1f to 0f
-                RotationSmoothing.LOW -> 0.5f to Math.toRadians(0.15).toFloat()
-                RotationSmoothing.MEDIUM -> 0.3f to Math.toRadians(0.3).toFloat()
-                RotationSmoothing.HIGH -> 0.15f to Math.toRadians(0.5).toFloat()
+        /**
+         * Low-pass ladder: OFF passes samples through unsmoothed (`alpha = 1`); higher levels
+         * move less of the way toward each new sample, i.e. damp harder.
+         */
+        internal fun alphaFor(level: RotationSmoothingLevel): Float =
+            when (level) {
+                RotationSmoothingLevel.OFF -> 1f
+                RotationSmoothingLevel.LOW -> 0.5f
+                RotationSmoothingLevel.MEDIUM -> 0.3f
+                RotationSmoothingLevel.HIGH -> 0.15f
+            }
+
+        /** Deadband ladder: OFF suppresses nothing; higher levels ignore larger movements. */
+        internal fun deadbandRadiansFor(level: RotationSmoothingLevel): Float =
+            when (level) {
+                RotationSmoothingLevel.OFF -> 0f
+                RotationSmoothingLevel.LOW -> Math.toRadians(0.15).toFloat()
+                RotationSmoothingLevel.MEDIUM -> Math.toRadians(0.3).toFloat()
+                RotationSmoothingLevel.HIGH -> Math.toRadians(0.5).toFloat()
             }
     }
 }

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/SensorConfig.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/SensorConfig.kt
@@ -9,18 +9,22 @@
 
 package com.google.android.stardroid.sensors
 
+import com.google.android.stardroid.settings.RotationSmoothing
 import com.google.android.stardroid.settings.SensorDamping
 import com.google.android.stardroid.settings.SensorSpeed
 
 /**
  * The sensor-preference snapshot `SensorOrientationSource` runs under (v1's `disable_gyro`,
- * `sensor_speed`, `sensor_damping`, `reverse_magnetic_z`). Speed, damping, and the magnetic-Z
- * reversal only affect the classic accelerometer+magnetometer path — v1 ran the fused
- * rotation-vector sensor at a fixed rate and fed it no raw magnetometer data, and so does v2.
+ * `sensor_speed`, `sensor_damping`, `reverse_magnetic_z`, plus v2's own `rotation_smoothing`).
+ * Speed, damping, and the magnetic-Z reversal only affect the classic accelerometer+magnetometer
+ * path — v1 ran the fused rotation-vector sensor at a fixed rate and fed it no raw magnetometer
+ * data, and so does v2. [rotationSmoothing] is the opposite: it only affects the fused path
+ * (issues #963 / #1001 — some phones' fusion is noisy enough to need it).
  */
 data class SensorConfig(
     val disableGyro: Boolean = false,
     val speed: SensorSpeed = SensorSpeed.STANDARD,
     val damping: SensorDamping = SensorDamping.EXTRA_HIGH,
     val reverseMagneticZ: Boolean = false,
+    val rotationSmoothing: RotationSmoothing = RotationSmoothing.OFF,
 )

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/SensorConfig.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/SensorConfig.kt
@@ -9,22 +9,24 @@
 
 package com.google.android.stardroid.sensors
 
-import com.google.android.stardroid.settings.RotationSmoothing
+import com.google.android.stardroid.settings.RotationSmoothingLevel
 import com.google.android.stardroid.settings.SensorDamping
 import com.google.android.stardroid.settings.SensorSpeed
 
 /**
  * The sensor-preference snapshot `SensorOrientationSource` runs under (v1's `disable_gyro`,
- * `sensor_speed`, `sensor_damping`, `reverse_magnetic_z`, plus v2's own `rotation_smoothing`).
- * Speed, damping, and the magnetic-Z reversal only affect the classic accelerometer+magnetometer
- * path — v1 ran the fused rotation-vector sensor at a fixed rate and fed it no raw magnetometer
- * data, and so does v2. [rotationSmoothing] is the opposite: it only affects the fused path
- * (issues #963 / #1001 — some phones' fusion is noisy enough to need it).
+ * `sensor_speed`, `sensor_damping`, `reverse_magnetic_z`, plus v2's own `rotation_low_pass` and
+ * `rotation_deadband`). Speed, damping, and the magnetic-Z reversal only affect the classic
+ * accelerometer+magnetometer path — v1 ran the fused rotation-vector sensor at a fixed rate and
+ * fed it no raw magnetometer data, and so does v2. [rotationLowPass]/[rotationDeadband] are the
+ * opposite: they only affect the fused path (issues #963 / #1001 — some phones' fusion is noisy
+ * enough to need it), and are kept independent so their effects can be evaluated separately.
  */
 data class SensorConfig(
     val disableGyro: Boolean = false,
     val speed: SensorSpeed = SensorSpeed.STANDARD,
     val damping: SensorDamping = SensorDamping.EXTRA_HIGH,
     val reverseMagneticZ: Boolean = false,
-    val rotationSmoothing: RotationSmoothing = RotationSmoothing.OFF,
+    val rotationLowPass: RotationSmoothingLevel = RotationSmoothingLevel.OFF,
+    val rotationDeadband: RotationSmoothingLevel = RotationSmoothingLevel.OFF,
 )

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/SensorOrientationSource.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/SensorOrientationSource.kt
@@ -17,7 +17,7 @@ import android.view.Surface
 import com.google.android.stardroid.astronomy.orientationFromSensors
 import com.google.android.stardroid.math.Matrix3
 import com.google.android.stardroid.math.Vector3
-import com.google.android.stardroid.settings.RotationSmoothing
+import com.google.android.stardroid.settings.RotationSmoothingLevel
 import com.google.android.stardroid.settings.SensorDamping
 import com.google.android.stardroid.settings.SensorSpeed
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -64,9 +64,10 @@ class SensorOrientationSource(
                 old.disableGyro != new.disableGyro -> false
                 rotationSensor != null && !old.disableGyro ->
                     // The settings screen hides speed/damping/reverseMagneticZ while the fused
-                    // path is active (they don't apply to it); rotationSmoothing is the one
-                    // setting shown here, so it's the only one that can actually have changed.
-                    old.rotationSmoothing == new.rotationSmoothing
+                    // path is active (they don't apply to it); rotationLowPass/rotationDeadband
+                    // are the settings shown here, so they're the only ones that can change.
+                    old.rotationLowPass == new.rotationLowPass &&
+                        old.rotationDeadband == new.rotationDeadband
                 else ->
                     old.speed == new.speed &&
                         old.damping == new.damping &&
@@ -79,7 +80,8 @@ class SensorOrientationSource(
                     rotationVectorOrientations(
                         sensorManager,
                         rotationSensor,
-                        current.rotationSmoothing,
+                        current.rotationLowPass,
+                        current.rotationDeadband,
                     )
                 accelerometer != null && magnetometer != null ->
                     legacyOrientations(sensorManager, accelerometer, magnetometer, current)
@@ -90,7 +92,8 @@ class SensorOrientationSource(
     private fun rotationVectorOrientations(
         manager: SensorManager,
         sensor: Sensor,
-        rotationSmoothing: RotationSmoothing,
+        rotationLowPass: RotationSmoothingLevel,
+        rotationDeadband: RotationSmoothingLevel,
     ): Flow<Matrix3> =
         callbackFlow {
             // Some devices (e.g. Galaxy S4) report more than four values; Android only needs four.
@@ -102,15 +105,21 @@ class SensorOrientationSource(
             val quaternion = FloatArray(4)
             val rotationMatrix = FloatArray(9)
             val remappedMatrix = FloatArray(9)
-            // Off by default (see SensorConfig): only allocate/run the smoother when a level is
-            // actually selected, so devices that leave this off pay no cost at all.
+            // Both off by default (see SensorConfig): only allocate/run the smoother when at
+            // least one is actually selected, so devices that leave both off pay no cost at all.
             val smoother =
-                if (rotationSmoothing == RotationSmoothing.OFF) {
+                if (rotationLowPass == RotationSmoothingLevel.OFF &&
+                    rotationDeadband == RotationSmoothingLevel.OFF
+                ) {
                     null
                 } else {
-                    val (alpha, deadbandRadians) =
-                        QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(rotationSmoothing)
-                    QuaternionSlerpSmoother(alpha, deadbandRadians)
+                    QuaternionSlerpSmoother(
+                        alpha = QuaternionSlerpSmoother.alphaFor(rotationLowPass),
+                        deadbandRadians =
+                            QuaternionSlerpSmoother.deadbandRadiansFor(
+                                rotationDeadband,
+                            ),
+                    )
                 }
             val listener =
                 object : SensorEventListener {

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/SensorOrientationSource.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/sensors/SensorOrientationSource.kt
@@ -17,6 +17,7 @@ import android.view.Surface
 import com.google.android.stardroid.astronomy.orientationFromSensors
 import com.google.android.stardroid.math.Matrix3
 import com.google.android.stardroid.math.Vector3
+import com.google.android.stardroid.settings.RotationSmoothing
 import com.google.android.stardroid.settings.SensorDamping
 import com.google.android.stardroid.settings.SensorSpeed
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -62,9 +63,10 @@ class SensorOrientationSource(
             when {
                 old.disableGyro != new.disableGyro -> false
                 rotationSensor != null && !old.disableGyro ->
-                    // The settings screen disables speed/damping/reverseMagneticZ while the
-                    // gyro path is active, so they can't have changed underneath us here.
-                    true
+                    // The settings screen hides speed/damping/reverseMagneticZ while the fused
+                    // path is active (they don't apply to it); rotationSmoothing is the one
+                    // setting shown here, so it's the only one that can actually have changed.
+                    old.rotationSmoothing == new.rotationSmoothing
                 else ->
                     old.speed == new.speed &&
                         old.damping == new.damping &&
@@ -74,7 +76,11 @@ class SensorOrientationSource(
             when {
                 sensorManager == null -> emptyFlow()
                 rotationSensor != null && !current.disableGyro ->
-                    rotationVectorOrientations(sensorManager, rotationSensor)
+                    rotationVectorOrientations(
+                        sensorManager,
+                        rotationSensor,
+                        current.rotationSmoothing,
+                    )
                 accelerometer != null && magnetometer != null ->
                     legacyOrientations(sensorManager, accelerometer, magnetometer, current)
                 else -> emptyFlow()
@@ -84,6 +90,7 @@ class SensorOrientationSource(
     private fun rotationVectorOrientations(
         manager: SensorManager,
         sensor: Sensor,
+        rotationSmoothing: RotationSmoothing,
     ): Flow<Matrix3> =
         callbackFlow {
             // Some devices (e.g. Galaxy S4) report more than four values; Android only needs four.
@@ -92,13 +99,26 @@ class SensorOrientationSource(
             // so keep a three-element buffer too and pass whichever matches the sample's arity.
             val truncated3 = FloatArray(3)
             val truncated4 = FloatArray(4)
+            val quaternion = FloatArray(4)
             val rotationMatrix = FloatArray(9)
             val remappedMatrix = FloatArray(9)
+            // Off by default (see SensorConfig): only allocate/run the smoother when a level is
+            // actually selected, so devices that leave this off pay no cost at all.
+            val smoother =
+                if (rotationSmoothing == RotationSmoothing.OFF) {
+                    null
+                } else {
+                    val (alpha, deadbandRadians) =
+                        QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(rotationSmoothing)
+                    QuaternionSlerpSmoother(alpha, deadbandRadians)
+                }
             val listener =
                 object : SensorEventListener {
                     override fun onSensorChanged(event: SensorEvent) {
                         val vector =
-                            if (event.values.size >= 4) {
+                            if (smoother != null) {
+                                smoother.update(toQuaternion(event.values, quaternion))
+                            } else if (event.values.size >= 4) {
                                 System.arraycopy(event.values, 0, truncated4, 0, 4)
                                 truncated4
                             } else {
@@ -124,6 +144,24 @@ class SensorOrientationSource(
             manager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_GAME)
             awaitClose { manager.unregisterListener(listener) }
         }.conflate()
+
+    /** Fills [out] with the sample's quaternion `(x, y, z, w)`, deriving `w` if absent. */
+    private fun toQuaternion(
+        values: FloatArray,
+        out: FloatArray,
+    ): FloatArray {
+        out[0] = values[0]
+        out[1] = values[1]
+        out[2] = values[2]
+        out[3] =
+            if (values.size >= 4) {
+                values[3]
+            } else {
+                val sumSquares = out[0] * out[0] + out[1] * out[1] + out[2] * out[2]
+                kotlin.math.sqrt(kotlin.math.max(0f, 1f - sumSquares))
+            }
+        return out
+    }
 
     private fun legacyOrientations(
         manager: SensorManager,

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/settings/DataStoreSettings.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/settings/DataStoreSettings.kt
@@ -157,6 +157,13 @@ class DataStoreSettings(
         dataStore.edit { it[SENSOR_DAMPING] = damping.name }
     }
 
+    override val rotationSmoothing: Flow<RotationSmoothing> =
+        enum(ROTATION_SMOOTHING, RotationSmoothing.OFF)
+
+    override suspend fun setRotationSmoothing(smoothing: RotationSmoothing) {
+        dataStore.edit { it[ROTATION_SMOOTHING] = smoothing.name }
+    }
+
     override val reverseMagneticZ: Flow<Boolean> = boolean(REVERSE_MAGNETIC_Z, default = false)
 
     override suspend fun setReverseMagneticZ(enabled: Boolean) {
@@ -336,6 +343,8 @@ class DataStoreSettings(
         private val SENSOR_SPEED = stringPreferencesKey("sensor_speed")
 
         private val SENSOR_DAMPING = stringPreferencesKey("sensor_damping")
+
+        private val ROTATION_SMOOTHING = stringPreferencesKey("rotation_smoothing")
 
         private val REVERSE_MAGNETIC_Z = booleanPreferencesKey("reverse_magnetic_z")
 

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/settings/DataStoreSettings.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/settings/DataStoreSettings.kt
@@ -157,11 +157,18 @@ class DataStoreSettings(
         dataStore.edit { it[SENSOR_DAMPING] = damping.name }
     }
 
-    override val rotationSmoothing: Flow<RotationSmoothing> =
-        enum(ROTATION_SMOOTHING, RotationSmoothing.OFF)
+    override val rotationLowPass: Flow<RotationSmoothingLevel> =
+        enum(ROTATION_LOW_PASS, RotationSmoothingLevel.OFF)
 
-    override suspend fun setRotationSmoothing(smoothing: RotationSmoothing) {
-        dataStore.edit { it[ROTATION_SMOOTHING] = smoothing.name }
+    override suspend fun setRotationLowPass(level: RotationSmoothingLevel) {
+        dataStore.edit { it[ROTATION_LOW_PASS] = level.name }
+    }
+
+    override val rotationDeadband: Flow<RotationSmoothingLevel> =
+        enum(ROTATION_DEADBAND, RotationSmoothingLevel.OFF)
+
+    override suspend fun setRotationDeadband(level: RotationSmoothingLevel) {
+        dataStore.edit { it[ROTATION_DEADBAND] = level.name }
     }
 
     override val reverseMagneticZ: Flow<Boolean> = boolean(REVERSE_MAGNETIC_Z, default = false)
@@ -344,7 +351,9 @@ class DataStoreSettings(
 
         private val SENSOR_DAMPING = stringPreferencesKey("sensor_damping")
 
-        private val ROTATION_SMOOTHING = stringPreferencesKey("rotation_smoothing")
+        private val ROTATION_LOW_PASS = stringPreferencesKey("rotation_low_pass")
+
+        private val ROTATION_DEADBAND = stringPreferencesKey("rotation_deadband")
 
         private val REVERSE_MAGNETIC_Z = booleanPreferencesKey("reverse_magnetic_z")
 

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/settings/Settings.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/settings/Settings.kt
@@ -54,6 +54,19 @@ enum class SensorDamping {
 }
 
 /**
+ * Smoothing strength for the fused rotation-vector path (issues #963 / #1001) — unlike
+ * [SensorSpeed]/[SensorDamping], this acts on the gyro path itself, since some phones' fusion is
+ * noisy enough to jitter the view even held still. Off by default: most devices fuse cleanly
+ * already, and this must not regress them.
+ */
+enum class RotationSmoothing {
+    OFF,
+    LOW,
+    MEDIUM,
+    HIGH,
+}
+
+/**
  * The app's persisted preferences, as flows so consumers react to changes from any writer
  * (map controls now, the settings screen later). Keys are new — v1's `source_provider.N`
  * SharedPreferences are deliberately not migrated (D1).
@@ -178,6 +191,11 @@ interface Settings {
     val sensorDamping: Flow<SensorDamping>
 
     suspend fun setSensorDamping(damping: SensorDamping)
+
+    /** Fused rotation-vector smoothing strength (issues #963 / #1001). Off by default. */
+    val rotationSmoothing: Flow<RotationSmoothing>
+
+    suspend fun setRotationSmoothing(smoothing: RotationSmoothing)
 
     /**
      * Negate the magnetometer's Z axis before fusion (v1's `reverse_magnetic_z`) — a

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/settings/Settings.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/settings/Settings.kt
@@ -54,12 +54,16 @@ enum class SensorDamping {
 }
 
 /**
- * Smoothing strength for the fused rotation-vector path (issues #963 / #1001) — unlike
- * [SensorSpeed]/[SensorDamping], this acts on the gyro path itself, since some phones' fusion is
- * noisy enough to jitter the view even held still. Off by default: most devices fuse cleanly
- * already, and this must not regress them.
+ * A strength level shared by the two fused-rotation-vector smoothing knobs below (issues #963 /
+ * #1001) — unlike [SensorSpeed]/[SensorDamping], these act on the gyro path itself, since some
+ * phones' fusion is noisy enough to jitter the view even held still. Both default to OFF: most
+ * devices fuse cleanly already, and this must not regress them.
+ *
+ * Kept as two independent settings (low-pass and deadband) rather than one combined "smoothing"
+ * level so their effects can be evaluated separately in the field — it's not yet known whether
+ * jitter on a given device needs one, the other, or both.
  */
-enum class RotationSmoothing {
+enum class RotationSmoothingLevel {
     OFF,
     LOW,
     MEDIUM,
@@ -192,10 +196,22 @@ interface Settings {
 
     suspend fun setSensorDamping(damping: SensorDamping)
 
-    /** Fused rotation-vector smoothing strength (issues #963 / #1001). Off by default. */
-    val rotationSmoothing: Flow<RotationSmoothing>
+    /**
+     * Low-pass (SLERP) strength on the fused rotation-vector quaternion (issues #963 / #1001).
+     * Off by default. See [RotationSmoothingLevel].
+     */
+    val rotationLowPass: Flow<RotationSmoothingLevel>
 
-    suspend fun setRotationSmoothing(smoothing: RotationSmoothing)
+    suspend fun setRotationLowPass(level: RotationSmoothingLevel)
+
+    /**
+     * Deadband strength on the fused rotation-vector quaternion: samples within the angular
+     * threshold of the current value are ignored outright (issues #963 / #1001). Off by
+     * default. See [RotationSmoothingLevel].
+     */
+    val rotationDeadband: Flow<RotationSmoothingLevel>
+
+    suspend fun setRotationDeadband(level: RotationSmoothingLevel)
 
     /**
      * Negate the magnetometer's Z axis before fusion (v1's `reverse_magnetic_z`) — a

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsUi.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsUi.kt
@@ -62,6 +62,7 @@ import com.google.android.stardroid.analytics.AnalyticsEvents
 import com.google.android.stardroid.astronomy.ViewDirectionMode
 import com.google.android.stardroid.settings.AutoDimness
 import com.google.android.stardroid.settings.FontSize
+import com.google.android.stardroid.settings.RotationSmoothing
 import com.google.android.stardroid.settings.SensorDamping
 import com.google.android.stardroid.settings.SensorSpeed
 import com.google.android.stardroid.ui.common.topBarWindowInsets
@@ -180,6 +181,17 @@ fun SettingsScreen(
                         summary = stringResource(R.string.settings_classic_sensors_only),
                         checked = state.reverseMagneticZ,
                         onCheckedChange = viewModel::setReverseMagneticZ,
+                    )
+                } else {
+                    // The inverse of the block above: this only acts on the fused path, so it
+                    // only shows while that path is selected (issues #963 / #1001).
+                    ChoiceRow(
+                        title = stringResource(R.string.settings_rotation_smoothing),
+                        summary = stringResource(R.string.settings_rotation_smoothing_summary),
+                        options = RotationSmoothing.entries,
+                        selected = state.rotationSmoothing,
+                        label = { rotationSmoothingLabel(it) },
+                        onSelect = viewModel::setRotationSmoothing,
                     )
                 }
                 SwitchRow(
@@ -507,6 +519,17 @@ private fun sensorDampingLabel(damping: SensorDamping): String =
             SensorDamping.HIGH -> R.string.settings_sensor_damping_high
             SensorDamping.EXTRA_HIGH -> R.string.settings_sensor_damping_extra_high
             SensorDamping.REALLY_HIGH -> R.string.settings_sensor_damping_really_high
+        },
+    )
+
+@Composable
+private fun rotationSmoothingLabel(smoothing: RotationSmoothing): String =
+    stringResource(
+        when (smoothing) {
+            RotationSmoothing.OFF -> R.string.settings_rotation_smoothing_off
+            RotationSmoothing.LOW -> R.string.settings_rotation_smoothing_low
+            RotationSmoothing.MEDIUM -> R.string.settings_rotation_smoothing_medium
+            RotationSmoothing.HIGH -> R.string.settings_rotation_smoothing_high
         },
     )
 

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsUi.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsUi.kt
@@ -62,7 +62,7 @@ import com.google.android.stardroid.analytics.AnalyticsEvents
 import com.google.android.stardroid.astronomy.ViewDirectionMode
 import com.google.android.stardroid.settings.AutoDimness
 import com.google.android.stardroid.settings.FontSize
-import com.google.android.stardroid.settings.RotationSmoothing
+import com.google.android.stardroid.settings.RotationSmoothingLevel
 import com.google.android.stardroid.settings.SensorDamping
 import com.google.android.stardroid.settings.SensorSpeed
 import com.google.android.stardroid.ui.common.topBarWindowInsets
@@ -183,15 +183,25 @@ fun SettingsScreen(
                         onCheckedChange = viewModel::setReverseMagneticZ,
                     )
                 } else {
-                    // The inverse of the block above: this only acts on the fused path, so it
-                    // only shows while that path is selected (issues #963 / #1001).
+                    // The inverse of the block above: these only act on the fused path, so
+                    // they only show while that path is selected (issues #963 / #1001). Kept
+                    // as two independent controls rather than one combined level so their
+                    // effects can be evaluated separately in the field.
                     ChoiceRow(
-                        title = stringResource(R.string.settings_rotation_smoothing),
-                        summary = stringResource(R.string.settings_rotation_smoothing_summary),
-                        options = RotationSmoothing.entries,
-                        selected = state.rotationSmoothing,
-                        label = { rotationSmoothingLabel(it) },
-                        onSelect = viewModel::setRotationSmoothing,
+                        title = stringResource(R.string.settings_rotation_low_pass),
+                        summary = stringResource(R.string.settings_rotation_low_pass_summary),
+                        options = RotationSmoothingLevel.entries,
+                        selected = state.rotationLowPass,
+                        label = { rotationSmoothingLevelLabel(it) },
+                        onSelect = viewModel::setRotationLowPass,
+                    )
+                    ChoiceRow(
+                        title = stringResource(R.string.settings_rotation_deadband),
+                        summary = stringResource(R.string.settings_rotation_deadband_summary),
+                        options = RotationSmoothingLevel.entries,
+                        selected = state.rotationDeadband,
+                        label = { rotationSmoothingLevelLabel(it) },
+                        onSelect = viewModel::setRotationDeadband,
                     )
                 }
                 SwitchRow(
@@ -522,14 +532,16 @@ private fun sensorDampingLabel(damping: SensorDamping): String =
         },
     )
 
+// Shared by both the low-pass and deadband ChoiceRows — same four generic strength labels
+// regardless of which knob is being set.
 @Composable
-private fun rotationSmoothingLabel(smoothing: RotationSmoothing): String =
+private fun rotationSmoothingLevelLabel(level: RotationSmoothingLevel): String =
     stringResource(
-        when (smoothing) {
-            RotationSmoothing.OFF -> R.string.settings_rotation_smoothing_off
-            RotationSmoothing.LOW -> R.string.settings_rotation_smoothing_low
-            RotationSmoothing.MEDIUM -> R.string.settings_rotation_smoothing_medium
-            RotationSmoothing.HIGH -> R.string.settings_rotation_smoothing_high
+        when (level) {
+            RotationSmoothingLevel.OFF -> R.string.settings_rotation_smoothing_off
+            RotationSmoothingLevel.LOW -> R.string.settings_rotation_smoothing_low
+            RotationSmoothingLevel.MEDIUM -> R.string.settings_rotation_smoothing_medium
+            RotationSmoothingLevel.HIGH -> R.string.settings_rotation_smoothing_high
         },
     )
 

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsViewModel.kt
@@ -50,6 +50,42 @@ data class SettingsUiState(
     val satelliteData: Boolean = false,
 )
 
+// Grouped so `state` below combines at most 5 flows at a time, each into a small typed data
+// class via a constructor reference — combine's array-unpacking overload (kicks in past 5
+// flows) loses static types and made the old flat version an `values[N] as T` index puzzle
+// that grew more error-prone with every added setting.
+private data class ControlsPrefs(
+    val tapToIdentify: Boolean,
+    val tapToIdentifyInAutoMode: Boolean,
+    val autoLevelHorizon: Boolean,
+)
+
+private data class AppearancePrefs(
+    val fontSize: FontSize,
+    val autoDimness: AutoDimness,
+    val showSkyGradient: Boolean,
+)
+
+private data class SensorPrefs(
+    val disableGyro: Boolean,
+    val sensorSpeed: SensorSpeed,
+    val sensorDamping: SensorDamping,
+    val reverseMagneticZ: Boolean,
+    val rotationSmoothing: RotationSmoothing,
+)
+
+private data class MagneticPrefs(
+    val useMagneticCorrection: Boolean,
+    val viewDirectionMode: ViewDirectionMode,
+)
+
+private data class OtherPrefs(
+    val enableAnalytics: Boolean,
+    val showerAlertsEnabled: Boolean,
+    val tonightDigestEnabled: Boolean,
+    val satelliteDataEnabled: Boolean,
+)
+
 /**
  * The settings screen over the typed [Settings] flows (screens-and-startup.md): one UI state
  * combining every preference, one suspend write per control. Consumers of each preference
@@ -70,44 +106,53 @@ class SettingsViewModel(
 
     val state: StateFlow<SettingsUiState> =
         combine(
-            settings.tapToIdentify,
-            settings.tapToIdentifyInAutoMode,
-            settings.autoLevelHorizon,
-            settings.fontSize,
-            settings.autoDimness,
-            settings.showSkyGradient,
-            settings.disableGyro,
-            settings.sensorSpeed,
-            settings.sensorDamping,
-            settings.reverseMagneticZ,
-            settings.useMagneticCorrection,
-            settings.viewDirectionMode,
-            settings.enableAnalytics,
-            settings.showerAlertsEnabled,
-            settings.tonightDigestEnabled,
-            settings.satelliteDataEnabled,
-            settings.rotationSmoothing,
-        ) { values ->
+            combine(
+                settings.tapToIdentify,
+                settings.tapToIdentifyInAutoMode,
+                settings.autoLevelHorizon,
+                ::ControlsPrefs,
+            ),
+            combine(
+                settings.fontSize,
+                settings.autoDimness,
+                settings.showSkyGradient,
+                ::AppearancePrefs,
+            ),
+            combine(
+                settings.disableGyro,
+                settings.sensorSpeed,
+                settings.sensorDamping,
+                settings.reverseMagneticZ,
+                settings.rotationSmoothing,
+                ::SensorPrefs,
+            ),
+            combine(settings.useMagneticCorrection, settings.viewDirectionMode, ::MagneticPrefs),
+            combine(
+                settings.enableAnalytics,
+                settings.showerAlertsEnabled,
+                settings.tonightDigestEnabled,
+                settings.satelliteDataEnabled,
+                ::OtherPrefs,
+            ),
+        ) { controls, appearance, sensors, magnetic, other ->
             SettingsUiState(
-                tapToIdentify = values[0] as Boolean,
-                tapToIdentifyInAutoMode = values[1] as Boolean,
-                autoLevelHorizon = values[2] as Boolean,
-                fontSize = values[3] as FontSize,
-                autoDimness = values[4] as AutoDimness,
-                showSkyGradient = values[5] as Boolean,
-                disableGyro = values[6] as Boolean,
-                sensorSpeed = values[7] as SensorSpeed,
-                sensorDamping = values[8] as SensorDamping,
-                reverseMagneticZ = values[9] as Boolean,
-                useMagneticCorrection = values[10] as Boolean,
-                viewDirectionMode = values[11] as ViewDirectionMode,
-                enableAnalytics = values[12] as Boolean,
-                showerAlerts = values[13] as Boolean,
-                tonightDigest = values[14] as Boolean,
-                // Appended, never inserted: this combine unpacks by position, so a new flow in the
-                // middle would silently shift every index after it.
-                satelliteData = values[15] as Boolean,
-                rotationSmoothing = values[16] as RotationSmoothing,
+                tapToIdentify = controls.tapToIdentify,
+                tapToIdentifyInAutoMode = controls.tapToIdentifyInAutoMode,
+                autoLevelHorizon = controls.autoLevelHorizon,
+                fontSize = appearance.fontSize,
+                autoDimness = appearance.autoDimness,
+                showSkyGradient = appearance.showSkyGradient,
+                disableGyro = sensors.disableGyro,
+                sensorSpeed = sensors.sensorSpeed,
+                sensorDamping = sensors.sensorDamping,
+                reverseMagneticZ = sensors.reverseMagneticZ,
+                rotationSmoothing = sensors.rotationSmoothing,
+                useMagneticCorrection = magnetic.useMagneticCorrection,
+                viewDirectionMode = magnetic.viewDirectionMode,
+                enableAnalytics = other.enableAnalytics,
+                showerAlerts = other.showerAlertsEnabled,
+                tonightDigest = other.tonightDigestEnabled,
+                satelliteData = other.satelliteDataEnabled,
             )
         }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState())
 

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import com.google.android.stardroid.analytics.NoOpAnalytics
 import com.google.android.stardroid.astronomy.ViewDirectionMode
 import com.google.android.stardroid.settings.AutoDimness
 import com.google.android.stardroid.settings.FontSize
+import com.google.android.stardroid.settings.RotationSmoothing
 import com.google.android.stardroid.settings.SensorDamping
 import com.google.android.stardroid.settings.SensorSpeed
 import com.google.android.stardroid.settings.Settings
@@ -39,6 +40,7 @@ data class SettingsUiState(
     val disableGyro: Boolean = false,
     val sensorSpeed: SensorSpeed = SensorSpeed.STANDARD,
     val sensorDamping: SensorDamping = SensorDamping.EXTRA_HIGH,
+    val rotationSmoothing: RotationSmoothing = RotationSmoothing.OFF,
     val reverseMagneticZ: Boolean = false,
     val useMagneticCorrection: Boolean = true,
     val viewDirectionMode: ViewDirectionMode = ViewDirectionMode.STANDARD,
@@ -84,6 +86,7 @@ class SettingsViewModel(
             settings.showerAlertsEnabled,
             settings.tonightDigestEnabled,
             settings.satelliteDataEnabled,
+            settings.rotationSmoothing,
         ) { values ->
             SettingsUiState(
                 tapToIdentify = values[0] as Boolean,
@@ -104,6 +107,7 @@ class SettingsViewModel(
                 // Appended, never inserted: this combine unpacks by position, so a new flow in the
                 // middle would silently shift every index after it.
                 satelliteData = values[15] as Boolean,
+                rotationSmoothing = values[16] as RotationSmoothing,
             )
         }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState())
 
@@ -150,6 +154,11 @@ class SettingsViewModel(
     fun setSensorDamping(damping: SensorDamping) {
         trackChange("sensor_damping", damping)
         viewModelScope.launch { settings.setSensorDamping(damping) }
+    }
+
+    fun setRotationSmoothing(smoothing: RotationSmoothing) {
+        trackChange("rotation_smoothing", smoothing)
+        viewModelScope.launch { settings.setRotationSmoothing(smoothing) }
     }
 
     fun setReverseMagneticZ(enabled: Boolean) {

--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsViewModel.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/settings/SettingsViewModel.kt
@@ -17,7 +17,7 @@ import com.google.android.stardroid.analytics.NoOpAnalytics
 import com.google.android.stardroid.astronomy.ViewDirectionMode
 import com.google.android.stardroid.settings.AutoDimness
 import com.google.android.stardroid.settings.FontSize
-import com.google.android.stardroid.settings.RotationSmoothing
+import com.google.android.stardroid.settings.RotationSmoothingLevel
 import com.google.android.stardroid.settings.SensorDamping
 import com.google.android.stardroid.settings.SensorSpeed
 import com.google.android.stardroid.settings.Settings
@@ -40,7 +40,8 @@ data class SettingsUiState(
     val disableGyro: Boolean = false,
     val sensorSpeed: SensorSpeed = SensorSpeed.STANDARD,
     val sensorDamping: SensorDamping = SensorDamping.EXTRA_HIGH,
-    val rotationSmoothing: RotationSmoothing = RotationSmoothing.OFF,
+    val rotationLowPass: RotationSmoothingLevel = RotationSmoothingLevel.OFF,
+    val rotationDeadband: RotationSmoothingLevel = RotationSmoothingLevel.OFF,
     val reverseMagneticZ: Boolean = false,
     val useMagneticCorrection: Boolean = true,
     val viewDirectionMode: ViewDirectionMode = ViewDirectionMode.STANDARD,
@@ -66,12 +67,22 @@ private data class AppearancePrefs(
     val showSkyGradient: Boolean,
 )
 
+// Split further into a legacy-path sub-group since SensorPrefs itself now has 6 fields —
+// past combine's 5-flow typed overload (same nesting used in AppModule's SensorConfig combine).
+private data class LegacySensorPrefs(
+    val disableGyro: Boolean,
+    val sensorSpeed: SensorSpeed,
+    val sensorDamping: SensorDamping,
+    val reverseMagneticZ: Boolean,
+)
+
 private data class SensorPrefs(
     val disableGyro: Boolean,
     val sensorSpeed: SensorSpeed,
     val sensorDamping: SensorDamping,
     val reverseMagneticZ: Boolean,
-    val rotationSmoothing: RotationSmoothing,
+    val rotationLowPass: RotationSmoothingLevel,
+    val rotationDeadband: RotationSmoothingLevel,
 )
 
 private data class MagneticPrefs(
@@ -119,13 +130,25 @@ class SettingsViewModel(
                 ::AppearancePrefs,
             ),
             combine(
-                settings.disableGyro,
-                settings.sensorSpeed,
-                settings.sensorDamping,
-                settings.reverseMagneticZ,
-                settings.rotationSmoothing,
-                ::SensorPrefs,
-            ),
+                combine(
+                    settings.disableGyro,
+                    settings.sensorSpeed,
+                    settings.sensorDamping,
+                    settings.reverseMagneticZ,
+                    ::LegacySensorPrefs,
+                ),
+                settings.rotationLowPass,
+                settings.rotationDeadband,
+            ) { legacy, rotationLowPass, rotationDeadband ->
+                SensorPrefs(
+                    disableGyro = legacy.disableGyro,
+                    sensorSpeed = legacy.sensorSpeed,
+                    sensorDamping = legacy.sensorDamping,
+                    reverseMagneticZ = legacy.reverseMagneticZ,
+                    rotationLowPass = rotationLowPass,
+                    rotationDeadband = rotationDeadband,
+                )
+            },
             combine(settings.useMagneticCorrection, settings.viewDirectionMode, ::MagneticPrefs),
             combine(
                 settings.enableAnalytics,
@@ -146,7 +169,8 @@ class SettingsViewModel(
                 sensorSpeed = sensors.sensorSpeed,
                 sensorDamping = sensors.sensorDamping,
                 reverseMagneticZ = sensors.reverseMagneticZ,
-                rotationSmoothing = sensors.rotationSmoothing,
+                rotationLowPass = sensors.rotationLowPass,
+                rotationDeadband = sensors.rotationDeadband,
                 useMagneticCorrection = magnetic.useMagneticCorrection,
                 viewDirectionMode = magnetic.viewDirectionMode,
                 enableAnalytics = other.enableAnalytics,
@@ -201,9 +225,14 @@ class SettingsViewModel(
         viewModelScope.launch { settings.setSensorDamping(damping) }
     }
 
-    fun setRotationSmoothing(smoothing: RotationSmoothing) {
-        trackChange("rotation_smoothing", smoothing)
-        viewModelScope.launch { settings.setRotationSmoothing(smoothing) }
+    fun setRotationLowPass(level: RotationSmoothingLevel) {
+        trackChange("rotation_low_pass", level)
+        viewModelScope.launch { settings.setRotationLowPass(level) }
+    }
+
+    fun setRotationDeadband(level: RotationSmoothingLevel) {
+        trackChange("rotation_deadband", level)
+        viewModelScope.launch { settings.setRotationDeadband(level) }
     }
 
     fun setReverseMagneticZ(enabled: Boolean) {

--- a/stardroid-v2/app/src/main/res/values/strings.xml
+++ b/stardroid-v2/app/src/main/res/values/strings.xml
@@ -335,6 +335,12 @@
     <string name="settings_sensor_damping_extra_high" translation_description="Extra high sensor damping factor">About right</string>
     <string name="settings_sensor_damping_really_high" translation_description="Really high sensor damping factor - this will make the app sluggish">Laggy</string>
     <string name="settings_classic_sensors_only" translation_description="Summary noting a sensor preference only applies to the legacy non-gyroscope sensor path">Only applies when legacy sensors are in use</string>
+    <string name="settings_rotation_smoothing" translation_description="Preference title for smoothing the gyroscope-based sensor path, to reduce jitter on some devices">Sensor Smoothing</string>
+    <string name="settings_rotation_smoothing_summary" translation_description="Explanation of the sensor smoothing preference and its trade-off">Reduces jitter on devices with a noisy sensor. Higher settings are steadier but slower to respond to real movement.</string>
+    <string name="settings_rotation_smoothing_off" translation_description="Sensor smoothing disabled">Off</string>
+    <string name="settings_rotation_smoothing_low" translation_description="Low sensor smoothing strength">Low</string>
+    <string name="settings_rotation_smoothing_medium" translation_description="Medium sensor smoothing strength">Medium</string>
+    <string name="settings_rotation_smoothing_high" translation_description="High sensor smoothing strength">High</string>
     <string name="settings_reverse_magnetic_z" translation_description="Preference title for reversing the magnetometer Z axis, a workaround for devices with a mis-mounted compass sensor">Reverse magnetic Z</string>
     <string name="settings_magnetic_correction" translation_description="Preference label: apply magnetic declination correction so the compass points to true north instead of magnetic north">Use magnetic correction</string>
     <string name="settings_magnetic_correction_summary" translation_description="Summary for the magnetic correction preference">Corrects the compass for the difference between magnetic and true north</string>

--- a/stardroid-v2/app/src/main/res/values/strings.xml
+++ b/stardroid-v2/app/src/main/res/values/strings.xml
@@ -335,8 +335,10 @@
     <string name="settings_sensor_damping_extra_high" translation_description="Extra high sensor damping factor">About right</string>
     <string name="settings_sensor_damping_really_high" translation_description="Really high sensor damping factor - this will make the app sluggish">Laggy</string>
     <string name="settings_classic_sensors_only" translation_description="Summary noting a sensor preference only applies to the legacy non-gyroscope sensor path">Only applies when legacy sensors are in use</string>
-    <string name="settings_rotation_smoothing" translation_description="Preference title for smoothing the gyroscope-based sensor path, to reduce jitter on some devices">Sensor Smoothing</string>
-    <string name="settings_rotation_smoothing_summary" translation_description="Explanation of the sensor smoothing preference and its trade-off">Reduces jitter on devices with a noisy sensor. Higher settings are steadier but slower to respond to real movement.</string>
+    <string name="settings_rotation_low_pass" translation_description="Preference title for low-pass filtering the gyroscope-based sensor path, to reduce jitter on some devices">Sensor Low-Pass</string>
+    <string name="settings_rotation_low_pass_summary" translation_description="Explanation of the sensor low-pass preference and its trade-off">Reduces jitter on devices with a noisy sensor by blending in new readings gradually. Higher settings are steadier but slower to respond to real movement.</string>
+    <string name="settings_rotation_deadband" translation_description="Preference title for ignoring tiny gyroscope-based sensor movements, to reduce jitter on some devices">Sensor Deadband</string>
+    <string name="settings_rotation_deadband_summary" translation_description="Explanation of the sensor deadband preference and its trade-off">Ignores movements smaller than a threshold. Higher settings ignore bigger movements, which can make small deliberate adjustments less responsive.</string>
     <string name="settings_rotation_smoothing_off" translation_description="Sensor smoothing disabled">Off</string>
     <string name="settings_rotation_smoothing_low" translation_description="Low sensor smoothing strength">Low</string>
     <string name="settings_rotation_smoothing_medium" translation_description="Medium sensor smoothing strength">Medium</string>

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmootherTest.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmootherTest.kt
@@ -9,7 +9,7 @@
 
 package com.google.android.stardroid.sensors
 
-import com.google.android.stardroid.settings.RotationSmoothing
+import com.google.android.stardroid.settings.RotationSmoothingLevel
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.math.cos
@@ -78,18 +78,26 @@ class QuaternionSlerpSmootherTest {
     }
 
     @Test
-    fun `smoothing ladder is off by default and strictly increasing in deadband`() {
-        val off = QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(RotationSmoothing.OFF)
-        assertThat(off.first).isEqualTo(1f)
-        assertThat(off.second).isEqualTo(0f)
+    fun `low-pass ladder is off by default and strictly decreasing in alpha`() {
+        assertThat(QuaternionSlerpSmoother.alphaFor(RotationSmoothingLevel.OFF)).isEqualTo(1f)
 
-        val low = QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(RotationSmoothing.LOW)
-        val medium = QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(RotationSmoothing.MEDIUM)
-        val high = QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(RotationSmoothing.HIGH)
-        assertThat(low.second).isLessThan(medium.second)
-        assertThat(medium.second).isLessThan(high.second)
-        assertThat(low.first).isGreaterThan(medium.first)
-        assertThat(medium.first).isGreaterThan(high.first)
+        val low = QuaternionSlerpSmoother.alphaFor(RotationSmoothingLevel.LOW)
+        val medium = QuaternionSlerpSmoother.alphaFor(RotationSmoothingLevel.MEDIUM)
+        val high = QuaternionSlerpSmoother.alphaFor(RotationSmoothingLevel.HIGH)
+        assertThat(low).isGreaterThan(medium)
+        assertThat(medium).isGreaterThan(high)
+    }
+
+    @Test
+    fun `deadband ladder is off by default and strictly increasing`() {
+        assertThat(QuaternionSlerpSmoother.deadbandRadiansFor(RotationSmoothingLevel.OFF))
+            .isEqualTo(0f)
+
+        val low = QuaternionSlerpSmoother.deadbandRadiansFor(RotationSmoothingLevel.LOW)
+        val medium = QuaternionSlerpSmoother.deadbandRadiansFor(RotationSmoothingLevel.MEDIUM)
+        val high = QuaternionSlerpSmoother.deadbandRadiansFor(RotationSmoothingLevel.HIGH)
+        assertThat(low).isLessThan(medium)
+        assertThat(medium).isLessThan(high)
     }
 
     companion object {

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmootherTest.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/sensors/QuaternionSlerpSmootherTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Penterakt LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.google.android.stardroid.sensors
+
+import com.google.android.stardroid.settings.RotationSmoothing
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.math.cos
+import kotlin.math.sin
+
+class QuaternionSlerpSmootherTest {
+    @Test
+    fun `first sample passes through unsmoothed`() {
+        val smoother = QuaternionSlerpSmoother(alpha = 0.3f, deadbandRadians = 0f)
+        val first = smoother.update(rotationAboutZ(10.0))
+        assertThat(first.toList()).isEqualTo(rotationAboutZ(10.0).toList())
+    }
+
+    @Test
+    fun `converges toward a steady target`() {
+        val smoother = QuaternionSlerpSmoother(alpha = 0.3f, deadbandRadians = 0f)
+        val target = rotationAboutZ(10.0)
+        smoother.update(IDENTITY)
+        var last = IDENTITY
+        repeat(50) { last = smoother.update(target) }
+        assertThat(angleBetweenDegrees(last, target)).isLessThan(0.01)
+    }
+
+    @Test
+    fun `deadband holds steady through micro-movements`() {
+        val smoother =
+            QuaternionSlerpSmoother(alpha = 0.5f, deadbandRadians = Math.toRadians(0.5).toFloat())
+        smoother.update(IDENTITY)
+        // A 0.1 degree wobble is well under the 0.5 degree deadband.
+        val held = smoother.update(rotationAboutZ(0.1))
+        assertThat(held.toList()).isEqualTo(IDENTITY.toList())
+    }
+
+    @Test
+    fun `movement past the deadband is not suppressed`() {
+        val smoother =
+            QuaternionSlerpSmoother(alpha = 0.5f, deadbandRadians = Math.toRadians(0.5).toFloat())
+        smoother.update(IDENTITY)
+        val moved = smoother.update(rotationAboutZ(5.0))
+        assertThat(angleBetweenDegrees(moved, IDENTITY)).isGreaterThan(0.01)
+    }
+
+    @Test
+    fun `output stays a unit quaternion`() {
+        val smoother = QuaternionSlerpSmoother(alpha = 0.3f, deadbandRadians = 0f)
+        smoother.update(IDENTITY)
+        val smoothed = smoother.update(rotationAboutZ(37.0))
+        val magnitude =
+            kotlin.math.sqrt(
+                smoothed[0] * smoothed[0] + smoothed[1] * smoothed[1] +
+                    smoothed[2] * smoothed[2] + smoothed[3] * smoothed[3],
+            )
+        assertThat(magnitude.toDouble()).isWithin(1e-4).of(1.0)
+    }
+
+    @Test
+    fun `a sign-flipped sample of the same rotation causes no movement`() {
+        val smoother = QuaternionSlerpSmoother(alpha = 0.5f, deadbandRadians = 0f)
+        val q = rotationAboutZ(170.0)
+        smoother.update(q)
+        // -q represents the exact same rotation as q; naively SLERPing toward it (instead of
+        // recognizing the shorter path back to q) would spin the view nearly all the way around.
+        val negated = FloatArray(4) { -q[it] }
+        val result = smoother.update(negated)
+        assertThat(angleBetweenDegrees(result, q)).isLessThan(0.01)
+    }
+
+    @Test
+    fun `smoothing ladder is off by default and strictly increasing in deadband`() {
+        val off = QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(RotationSmoothing.OFF)
+        assertThat(off.first).isEqualTo(1f)
+        assertThat(off.second).isEqualTo(0f)
+
+        val low = QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(RotationSmoothing.LOW)
+        val medium = QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(RotationSmoothing.MEDIUM)
+        val high = QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor(RotationSmoothing.HIGH)
+        assertThat(low.second).isLessThan(medium.second)
+        assertThat(medium.second).isLessThan(high.second)
+        assertThat(low.first).isGreaterThan(medium.first)
+        assertThat(medium.first).isGreaterThan(high.first)
+    }
+
+    companion object {
+        private val IDENTITY = floatArrayOf(0f, 0f, 0f, 1f)
+
+        private fun rotationAboutZ(degrees: Double): FloatArray {
+            val halfAngle = Math.toRadians(degrees) / 2.0
+            return floatArrayOf(0f, 0f, sin(halfAngle).toFloat(), cos(halfAngle).toFloat())
+        }
+
+        private fun angleBetweenDegrees(
+            a: FloatArray,
+            b: FloatArray,
+        ): Double {
+            val dot = a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3]
+            val clamped = kotlin.math.min(1f, kotlin.math.abs(dot))
+            return Math.toDegrees(2.0 * kotlin.math.acos(clamped.toDouble()))
+        }
+    }
+}

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/settings/FakeSettings.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/settings/FakeSettings.kt
@@ -166,6 +166,14 @@ class FakeSettings : Settings {
         sensorDampingState.value = damping
     }
 
+    val rotationSmoothingState = MutableStateFlow(RotationSmoothing.OFF)
+
+    override val rotationSmoothing: Flow<RotationSmoothing> = rotationSmoothingState
+
+    override suspend fun setRotationSmoothing(smoothing: RotationSmoothing) {
+        rotationSmoothingState.value = smoothing
+    }
+
     val reverseMagneticZState = MutableStateFlow(false)
 
     override val reverseMagneticZ: Flow<Boolean> = reverseMagneticZState

--- a/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/settings/FakeSettings.kt
+++ b/stardroid-v2/app/src/test/kotlin/com/google/android/stardroid/settings/FakeSettings.kt
@@ -166,12 +166,20 @@ class FakeSettings : Settings {
         sensorDampingState.value = damping
     }
 
-    val rotationSmoothingState = MutableStateFlow(RotationSmoothing.OFF)
+    val rotationLowPassState = MutableStateFlow(RotationSmoothingLevel.OFF)
 
-    override val rotationSmoothing: Flow<RotationSmoothing> = rotationSmoothingState
+    override val rotationLowPass: Flow<RotationSmoothingLevel> = rotationLowPassState
 
-    override suspend fun setRotationSmoothing(smoothing: RotationSmoothing) {
-        rotationSmoothingState.value = smoothing
+    override suspend fun setRotationLowPass(level: RotationSmoothingLevel) {
+        rotationLowPassState.value = level
+    }
+
+    val rotationDeadbandState = MutableStateFlow(RotationSmoothingLevel.OFF)
+
+    override val rotationDeadband: Flow<RotationSmoothingLevel> = rotationDeadbandState
+
+    override suspend fun setRotationDeadband(level: RotationSmoothingLevel) {
+        rotationDeadbandState.value = level
     }
 
     val reverseMagneticZState = MutableStateFlow(false)


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Description

Fixes the jitter reported in #963 and #1001: on some phones, `TYPE_ROTATION_VECTOR`'s on-device sensor fusion is noisy enough to make labels hard to read even holding the phone still. v2 previously ran that fused sensor completely raw/unsmoothed on the assumption that Android's fusion is always clean — true on Pixels, not universally true (confirmed reporter device: Honor Magic V2 / Android 16).

The existing Sensor Speed/Damping settings don't help here — they only apply to the legacy accelerometer+magnetometer fallback path and are inert whenever the fused sensor is active.

Adds a new **Sensor Smoothing** setting (Off/Low/Medium/High, default **Off**) that:
- SLERPs the raw fused quaternion (not the derived rotation matrix — SLERP is the geometrically correct way to interpolate along the rotation manifold) toward each new sample by a per-level alpha.
- Applies a small angular deadband per level so micro-movements are ignored outright, per #963's "maybe even ignore small movements entirely" suggestion.
- Handles quaternion double-cover (`q` and `-q` are the same rotation) so a sign flip between samples doesn't cause a visible spin.
- Is a no-op when Off (default): no smoother is allocated and the existing pass-through code path is untouched, so devices that already fuse cleanly see zero behavior change.

The setting only shows in Settings while the fused/gyro path is active — the mirror image of how Speed/Damping/Reverse-Z only show for the legacy path.

Translations for the new strings are intentionally not included in this PR — planned as a follow-up.

## Type of Change

- [ ] Bug fix
- [x] New feature (Sky Map team only)
- [ ] Translation (new or updated)
- [ ] Documentation
- [ ] Refactoring / code cleanup
- [ ] Dependency upgrade
- [ ] Other

## Checklist

- [x] I've read the [contributing guidelines](../../CONTRIBUTING.md)
- [ ] For major changes, I've emailed skymapdevs@gmail.com first
- [x] I've run the unit tests (`./gradlew check` from `stardroid-v2/`, or `./gradlew :app:test` from `stardroid-v1/`, matching whichever module this PR touches)
- [ ] I've tested on a device/emulator if applicable
- [x] If I have multiple commits, I've squashed them into one

No need to update CHANGELOG.md - we'll get Claude to do that when we cut a release.

## Notes for Reviewers

- New quaternion SLERP smoother lives beside the sensor code (`app/.../sensors/QuaternionSlerpSmoother.kt`), not in `core/math` — no `Quaternion` type exists in the repo yet, and this need is local to one sensor path.
- Since the new setting is visible precisely when the fused/gyro path is active, `SensorOrientationSource`'s `distinctUntilChanged` had to be updated too — it previously assumed no visible setting could change on that path.
- Real acceptance test is external: we can't reproduce the reporters' hardware (Honor Magic V2) locally. Plan is to ask the #963/#1001 reporters to try this once it's in a beta build, before closing those issues.
- Tuning values (alpha/deadband per level) are a starting point, not final — easy to adjust in `QuaternionSlerpSmoother.alphaAndDeadbandRadiansFor` based on reporter feedback.
- Translations deliberately deferred per this session's instructions — `tm translate --all-primary --include-stale` still needs to run before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YF48nBSjKm8ab6Cd3ceJz


___

### **PR Type**
Enhancement


___

### **Description**
- Add SLERP quaternion smoother with deadband filtering.

- Introduce configurable rotation smoothing settings.

- Update sensor pipeline to filter noisy rotations.

- Add UI controls and string resources.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    Sensor["Rotation Vector Sensor"] -- "Raw Quaternion" --> Smoother["QuaternionSlerpSmoother"]
    Settings["RotationSmoothing Settings"] -- "Alpha & Deadband" --> Smoother
    Smoother -- "Filtered Quaternion" --> Orientation["SensorOrientationSource"]
    Orientation -- "Orientation Matrix" --> View["Map Display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>AppModule.kt</strong><dd><code>Inject rotation smoothing setting into sensor configuration</code></dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-2be088f514312fc19578e9d84a5451993537c6a4899ad7ad3ae1fe58db3b19b3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuaternionSlerpSmoother.kt</strong><dd><code>Implement SLERP quaternion smoother with deadband support</code></dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-a7c9bbaa9259a346a28e28c6556f605d4027eee1cea23a4db0bb2cbf019d1ce2">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SensorConfig.kt</strong><dd><code>Add rotation smoothing field to sensor config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-21d2dc8cb18c5540d448ba464e2d7f3b978ef6b5e39264076a21c25141105cb3">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SensorOrientationSource.kt</strong><dd><code>Apply quaternion smoother to rotation vector orientations</code></dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-2f39f16ceb2ea99d433a7b200dd1fd7ee50783d3bdee680aeef6c5a3f8da4e62">+43/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataStoreSettings.kt</strong><dd><code>Persist rotation smoothing preference in DataStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-3685eb5306c8a63a997f6455bf465ee5dbc25de9b7ae6bd0780e46742feb5ab0">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Settings.kt</strong><dd><code>Define RotationSmoothing enum and settings interface methods</code></dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-07d51840c3a24c20da727a3b3f04bec9182b436294b448bf644e8bc457c39274">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SettingsUi.kt</strong><dd><code>Add rotation smoothing selector to settings UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-d3d757dc110e354eecd8ded5712144a410050cee7661c91bd30c7d0e1a2fa086">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SettingsViewModel.kt</strong><dd><code>Expose rotation smoothing state and update actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-3254fcae4c73eeceb5b17a9f831b963b5afd52ee8c6d367a345c7393e841a6f4">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>strings.xml</strong><dd><code>Add string resources for rotation smoothing settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-47ca36ffdf2cb8ecdfa60f7be7d0fd8eb0af8143da77ba0c206d52b401243934">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>QuaternionSlerpSmootherTest.kt</strong><dd><code>Add unit tests for quaternion SLERP smoother</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-11eb3c000b347daf7b1305bbf9d8c6737c3b3bfe593577b50cac8378828eddfa">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>FakeSettings.kt</strong><dd><code>Support rotation smoothing in test fake settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1006/files#diff-bc7a44b6b12904fcedfbd3d1db054ac6144a2171829c51d892adb9e34af0e81c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

