### PR TITLE
v2: fix illegible cardinal-direction labels on the horizon glow

### DIFF
--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/layers/SkyColors.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/layers/SkyColors.kt
@@ -34,10 +34,13 @@ object SkyColors {
     val HORIZON_LINE = Rgba(0x59 / 255f, 0x7c / 255f, 0x4a / 255f, 0x78 / 255f)
 
     /**
-     * Cardinal/zenith/nadir labels share the horizon line's green so the horizon reads as one
-     * element (upstream `horizon_label`).
+     * Cardinal/zenith/nadir labels: a lighter, higher-luminance tint of the horizon line's green
+     * (issue #1014 — the original opaque `#597C4A`, identical to [HORIZON_LINE], read as green
+     * text on the green glow band and was reported illegible). Keeping the same hue keeps the
+     * horizon reading as one element while the higher luminance gives real contrast against the
+     * darker glow.
      */
-    val HORIZON_LABEL = Rgba(0x59 / 255f, 0x7c / 255f, 0x4a / 255f, 1f)
+    val HORIZON_LABEL = Rgba(0xb8 / 255f, 0xde / 255f, 0x8e / 255f, 1f)
 
     /** RA/Dec graticule lines (upstream `grid_line` `#14BCEFF8`). */
     val GRID_LINE = Rgba(0xbc / 255f, 0xef / 255f, 0xf8 / 255f, 0x14 / 255f)

--- a/stardroid-v2/docs/design/render-gles3.md
+++ b/stardroid-v2/docs/design/render-gles3.md
@@ -497,6 +497,14 @@ commitment.
 14. **Night mode as a post-process** — noted in §3 as a parity simplification, but worth calling
     out as a *quality* win too: it finally reddens photographs and DSO imagery correctly, which
     the current per-primitive colour bake handles only by shipping a second copy of every texture.
+15. **Label halos/outlines.** Motivated by issue #1014 (`horizon_label` green rendering
+    illegible against `HORIZON_LINE`'s own green glow). Under GLES1's fixed-function pipeline a
+    halo means rasterizing and drawing a second, wider glyph per label (a stroked outline quad
+    behind the fill quad) — real cost against the `LabelDrawer` TODO on batching for catalog-scale
+    label counts. In a fragment shader it is nearly free: sample the `R8` coverage mask twice at a
+    fixed pixel offset (or once against a signed-distance-field atlas) and composite outline colour
+    under fill colour in one draw call, no extra geometry. Worth revisiting once `sprite.vert/frag`
+    exists (§3, shader inventory) rather than building the GLES1 two-glyph version now.
 
 ---
 


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary
- Fixes #1014 — `HORIZON_LABEL` was set to the exact same opaque green (`#597C4A`) as `HORIZON_LINE`/the horizon glow, so the N/S/E/W/zenith/nadir labels blended into the glow band and were reported illegible.
- Changes `HORIZON_LABEL` to a lighter sage tint of the same hue (`#B8DE8E`) — real luminance contrast against the darker glow while still reading as "horizon green."
- Notes in `docs/design/render-gles3.md` (§8) that label halos would be a cheap fragment-shader win for this class of problem once the GLES3 sprite shader exists, versus the costly double-geometry hack GLES1 would need — recorded so it isn't lost, not implemented here.

## Test plan
- [x] `./gradlew check` (unit tests, ktlint, Konsist) passes
- [x] Verified visually on an emulator (`RendererTestActivity`) — the label reads clearly against the horizon glow where the old color did not

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Lighten horizon label color for readability

- Document future GLES3 label halo shaders


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HL["HORIZON_LINE glow (#597C4A)"]
  OldLabel["Old HORIZON_LABEL (#597C4A)"] -- "Low contrast" --> HL
  NewLabel["New HORIZON_LABEL (#B8DE8E)"] -- "High luminance contrast" --> HL
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SkyColors.kt</strong><dd><code>Increase luminance of horizon label color</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/layers/SkyColors.kt

<ul><li>Lighten <code>HORIZON_LABEL</code> from <code>#597C4A</code> to a sage green tint <code>#B8DE8E</code> for <br>contrast against the horizon glow.<br> <li> Update KDoc explaining the luminance change and referencing issue <br>#1014.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1018/files#diff-a6c3f7dec92b6676e959f821366d607ca78ebca676c6cee50f0c3f770d9cabb9">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>render-gles3.md</strong><dd><code>Document future GLES3 label halo outlines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stardroid-v2/docs/design/render-gles3.md

<ul><li>Add note 15 covering label halos and outlines as a fragment shader <br>optimization in GLES3.<br> <li> Contrast the fragment shader approach with GLES1 multi-pass glyph <br>rendering.</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1018/files#diff-d6d3d378fa4630cae6c14678a6b7cfa4555a9bfb958aaa049341ddbd05e12b2a">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

