### PR TITLE
Fix FocusRequester crash in SearchDialog

### DIFF
--- a/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchUi.kt
+++ b/stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchUi.kt
@@ -32,9 +32,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -45,6 +46,7 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -240,6 +242,11 @@ fun SearchDialog(
     val suggestions by viewModel.suggestions.collectAsStateWithLifecycle()
     val noResults by viewModel.noResults.collectAsStateWithLifecycle()
     val focusRequester = remember { FocusRequester() }
+    // Requesting focus from a LaunchedEffect keyed on SearchDialog itself can fire before the
+    // AlertDialog's own subcomposition (it composes text into a separate Popup) has attached
+    // this field's focus node, throwing IllegalStateException. Request focus only once the
+    // field has actually been placed, when the node is guaranteed to be attached.
+    var hasRequestedFocus by remember { mutableStateOf(false) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -260,7 +267,13 @@ fun SearchDialog(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .focusRequester(focusRequester),
+                            .focusRequester(focusRequester)
+                            .onGloballyPositioned {
+                                if (!hasRequestedFocus) {
+                                    hasRequestedFocus = true
+                                    focusRequester.requestFocus()
+                                }
+                            },
                 )
                 if (noResults) {
                     Text(
@@ -287,8 +300,6 @@ fun SearchDialog(
             }
         },
     )
-
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
 }
 
 @Composable


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Fixes #1019

## Summary
Moves the search text field's `focusRequester.requestFocus()` call out of a sibling `LaunchedEffect(Unit)` and into an `onGloballyPositioned` callback on the field itself, so it can no longer run before the `AlertDialog`'s subcomposition attaches the focus node. This fixes the `IllegalStateException: FocusRequester is not initialized` crash reported from the Play Store in version 2.0.5.

## Test plan
- [ ] `./gradlew ktlintCheck`
- [ ] `./gradlew check`
- [ ] Manually open the search dialog repeatedly on a device/emulator to confirm no crash and that the keyboard still autofocuses

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix `FocusRequester is not initialized` crash

- Move `requestFocus()` to `onGloballyPositioned` callback

- Ensure focus node is attached before requesting


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph SearchDialog ["SearchDialog"]
        field["OutlinedTextField"]
        layout["onGloballyPositioned"]
        focus["focusRequester.requestFocus()"]
    end
    field -- "layout completed" --> layout
    layout -- "first pass" --> focus
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SearchUi.kt</strong><dd><code>Defer search field focus request to onGloballyPositioned</code>&nbsp; </dd></summary>
<hr>

stardroid-v2/app/src/main/kotlin/com/google/android/stardroid/ui/search/SearchUi.kt

<ul><li>Removed <code>LaunchedEffect(Unit)</code> that called <code>focusRequester.requestFocus()</code> <br>during dialog composition<br> <li> Added single-shot <code>onGloballyPositioned</code> callback on the search <br><code>OutlinedTextField</code> to request focus once attached<br> <li> Prevented <code>IllegalStateException: FocusRequester is not initialized</code> <br>race condition with <code>AlertDialog</code> subcomposition</ul>


</details>


  </td>
  <td><a href="https://github.com/sky-map-team/stardroid/pull/1020/files#diff-c042f160eacff28fe8b71e9ebe9c5d008727b77aa24095b9a3dfbb235f02c698">+15/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

